### PR TITLE
macos-install-dylibs: ensure dylibs are user-writeable

### DIFF
--- a/scripts/macos-install-dylibs.py
+++ b/scripts/macos-install-dylibs.py
@@ -9,7 +9,7 @@ import sys
 import subprocess
 import itertools
 import shutil
-from os import environ, pathsep
+from os import chmod, environ, pathsep
 from pathlib import Path
 
 build_root = Path(environ['MESON_BUILD_ROOT'])
@@ -51,6 +51,7 @@ def fix_libs(opath):
         dst = str(dst)
         print('Installing {0} as {1}'.format(src, dst))
         shutil.copy(str(src), str(dst))
+        chmod(str(dst), 0o755)
 
     def fix(path):
         for lib in regex.findall(otool('-L', path)):


### PR DESCRIPTION
This fixes a bug @Akaricchi and I were discussing in this Homebrew issue: https://github.com/Homebrew/homebrew-core/pull/23341

When the dylibs are copied by `macos-install-dylibs`, it's important to make sure that the copied files are user-writeable; the original files might not be `+x`, and those permissions are carried through when they're copied into the app bundle. If the copied dylibs aren't writeable by the process installing taisei, then `install_name_tool` will fail.