### PR TITLE
Some compatibility fixes for Elbrus compiler (and others based on EDG front end)

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -48,7 +48,7 @@ taisei_c_args = cc.get_supported_arguments(
     '-Winit-self',
     '-Wlogical-op',
     '-Wmissing-prototypes',
-    '-Wno-typedef-redefinition'
+    '-Wno-typedef-redefinition',
     '-Wno-long-long',
     '-Wnull-dereference',
     '-Wparentheses',

--- a/meson.build
+++ b/meson.build
@@ -48,6 +48,7 @@ taisei_c_args = cc.get_supported_arguments(
     '-Winit-self',
     '-Wlogical-op',
     '-Wmissing-prototypes',
+    '-Wno-typedef-redefinition'
     '-Wno-long-long',
     '-Wnull-dereference',
     '-Wparentheses',

--- a/meson.build
+++ b/meson.build
@@ -56,20 +56,10 @@ taisei_c_args = cc.get_supported_arguments(
     '-Wsometimes-uninitialized',
     '-Wstrict-prototypes',
     '-Wtype-limits',
+    '-Wunreachable-code',
     '-Wunneeded-internal-declaration',
     '-Wunreachable-code-loop-increment',
 )
-
-if cc.compiles('''
-int main() {
-    return 0;
-    __builtin_unreachable();
-}
-''', name : 'unreachable __builtin_unreachable() with -Werror', args : [ '-Wunreachable-code', '-Werror' ] )
-    taisei_c_args += cc.get_supported_arguments('-Wunreachable-code')
-else
-    warning('-Wunreachable-code will not be used due to incorrect handling of __builtin_unreachable')
-endif
 
 static = get_option('static')
 

--- a/meson.build
+++ b/meson.build
@@ -57,9 +57,19 @@ taisei_c_args = cc.get_supported_arguments(
     '-Wstrict-prototypes',
     '-Wtype-limits',
     '-Wunneeded-internal-declaration',
-    '-Wunreachable-code',
     '-Wunreachable-code-loop-increment',
 )
+
+if cc.compiles('''
+int main() {
+    return 0;
+    __builtin_unreachable();
+}
+''', name : 'unreachable __builtin_unreachable() with -Werror', args : [ '-Wunreachable-code', '-Werror' ] )
+    taisei_c_args += cc.get_supported_arguments('-Wunreachable-code')
+else
+    warning('-Wunreachable-code will not be used due to incorrect handling of __builtin_unreachable')
+endif
 
 static = get_option('static')
 

--- a/src/entity.h
+++ b/src/entity.h
@@ -108,8 +108,6 @@ static inline attr_must_inline const char* ent_type_name(EntityType type) {
 		#undef ENT_TYPE
 		default: return "ENT_INVALID";
 	}
-
-	UNREACHABLE;
 }
 
 #define ENT_TYPE_ID(typename) (_ENT_TYPEID_##typename)

--- a/src/renderer/common/sprite_batch.c
+++ b/src/renderer/common/sprite_batch.c
@@ -183,7 +183,7 @@ void r_flush_sprites(void) {
 }
 
 static void _r_sprite_batch_add(Sprite *spr, const SpriteParams *params, SDL_RWops *stream) {
-	SpriteAttribs alignas(16) attribs;
+	SpriteAttribs attribs;
 	r_mat_current(MM_MODELVIEW, attribs.transform);
 	r_mat_current(MM_TEXTURE, attribs.tex_transform);
 

--- a/src/renderer/common/sprite_batch.c
+++ b/src/renderer/common/sprite_batch.c
@@ -183,7 +183,7 @@ void r_flush_sprites(void) {
 }
 
 static void _r_sprite_batch_add(Sprite *spr, const SpriteParams *params, SDL_RWops *stream) {
-	SpriteAttribs alignas(32) attribs;
+	SpriteAttribs alignas(16) attribs;
 	r_mat_current(MM_MODELVIEW, attribs.transform);
 	r_mat_current(MM_TEXTURE, attribs.tex_transform);
 

--- a/src/util/compat.h
+++ b/src/util/compat.h
@@ -71,7 +71,11 @@
 #else
 	#define PRAGMA(p) _Pragma(#p)
 	#define USE_GNU_EXTENSIONS
+#ifdef TAISEI_BUILDCONF_USE_BUILTIN_UNREACHABLE
 	#define UNREACHABLE __builtin_unreachable()
+#else
+	#define UNREACHABLE
+#endif
 #endif
 
 #ifndef __has_attribute

--- a/src/util/compat.h
+++ b/src/util/compat.h
@@ -71,11 +71,7 @@
 #else
 	#define PRAGMA(p) _Pragma(#p)
 	#define USE_GNU_EXTENSIONS
-#ifdef TAISEI_BUILDCONF_USE_BUILTIN_UNREACHABLE
 	#define UNREACHABLE __builtin_unreachable()
-#else
-	#define UNREACHABLE
-#endif
 #endif
 
 #ifndef __has_attribute

--- a/src/util/compat.h
+++ b/src/util/compat.h
@@ -201,7 +201,7 @@ typedef signed char schar;
 	__attribute__ ((always_inline))
 
 // Structure must not be initialized with an implicit (non-designated) initializer.
-#if __has_attribute(designated_init)
+#if __has_attribute(designated_init) && defined(TAISEI_BUILDCONF_USE_DESIGNATED_INIT)
 	#define attr_designated_init \
 		__attribute__ ((designated_init))
 #else

--- a/src/util/meson.build
+++ b/src/util/meson.build
@@ -23,22 +23,9 @@ if is_developer_build
     util_src += files('debug.c')
 endif
 
-use_builtin_unreachable = cc.compiles('''
-int main() {
-    return 0;
-    __builtin_unreachable();
-}
-''', name : '__builtin_unreachable() with -Werror', args : [ '-Wunreachable-code', '-Werror' ] )
-
 use_designated_init = cc.compiles('''
 struct { ; } __attribute__((designated_init)) x;
 ''', name : '__attribute__((designated_init)) with -Werror', args : [ '-Wattributes', '-Werror' ] )
-
-if use_builtin_unreachable
-    config.set('TAISEI_BUILDCONF_USE_BUILTIN_UNREACHABLE', true)
-else
-    config.set('TAISEI_BUILDCONF_USE_BUILTIN_UNREACHABLE', false)
-endif
 
 if use_designated_init
     config.set('TAISEI_BUILDCONF_USE_DESIGNATED_INIT', true)

--- a/src/util/meson.build
+++ b/src/util/meson.build
@@ -24,7 +24,7 @@ if is_developer_build
 endif
 
 use_designated_init = cc.compiles('''
-struct { ; } __attribute__((designated_init)) x;
+struct { int dummy; } __attribute__((designated_init)) x;
 ''', name : '__attribute__((designated_init)) with -Werror', args : [ '-Wattributes', '-Werror' ] )
 
 if use_designated_init

--- a/src/util/meson.build
+++ b/src/util/meson.build
@@ -23,7 +23,6 @@ if is_developer_build
     util_src += files('debug.c')
 endif
 
-
 use_builtin_unreachable = cc.compiles('''
 int main() {
     return 0;
@@ -31,10 +30,20 @@ int main() {
 }
 ''', name : '__builtin_unreachable() with -Werror', args : [ '-Wunreachable-code', '-Werror' ] )
 
+use_designated_init = cc.compiles('''
+struct { ; } __attribute__((designated_init)) x;
+''', name : '__attribute__((designated_init)) with -Werror', args : [ '-Wattributes', '-Werror' ] )
+
 if use_builtin_unreachable
     config.set('TAISEI_BUILDCONF_USE_BUILTIN_UNREACHABLE', true)
-elif get_option('intel_intrin')
+else
     config.set('TAISEI_BUILDCONF_USE_BUILTIN_UNREACHABLE', false)
+endif
+
+if use_designated_init
+    config.set('TAISEI_BUILDCONF_USE_DESIGNATED_INIT', true)
+else
+    config.set('TAISEI_BUILDCONF_USE_DESIGNATED_INIT', false)
 endif
 
 if host_machine.system() == 'windows'

--- a/src/util/meson.build
+++ b/src/util/meson.build
@@ -23,6 +23,20 @@ if is_developer_build
     util_src += files('debug.c')
 endif
 
+
+use_builtin_unreachable = cc.compiles('''
+int main() {
+    return 0;
+    __builtin_unreachable();
+}
+''', name : '__builtin_unreachable() with -Werror', args : [ '-Wunreachable-code', '-Werror' ] )
+
+if use_builtin_unreachable
+    config.set('TAISEI_BUILDCONF_USE_BUILTIN_UNREACHABLE', true)
+elif get_option('intel_intrin')
+    config.set('TAISEI_BUILDCONF_USE_BUILTIN_UNREACHABLE', false)
+endif
+
 if host_machine.system() == 'windows'
     # NOTE: Even if we ever build this with something like Midipix, we'd
     # probably still want to use the winapi implementation of this here.

--- a/src/version.h
+++ b/src/version.h
@@ -44,7 +44,11 @@ typedef struct TaiseiVersion {
 )
 
 typedef enum {
-	VCMP_MAJOR,
+	// Start filling this enum from nonzero value.
+	// This would help avoid a warning on some compilers like
+	// those with EDG frontend. Actual values of VCMP_...
+	// don't matter, the thing which does matter is its order.
+	VCMP_MAJOR = 1,
 	VCMP_MINOR,
 	VCMP_PATCH,
 	VCMP_TWEAK,


### PR DESCRIPTION
There were 5 issues that produced warnings: stack variable alignment, typedef redefinition, warning on unreachable __builtin_unreachable(), unsigned enums and __attribute__((designated_init)). Fixes were done to achieve warningless release build (though debug still have some -Wtype-limits on asserts due to this unsigned enums stuff).

Tested on following setups:
x86_64, meson 0.45.1, gcc (Ubuntu 7.3.0-27ubuntu1~18.04) 7.3.0
x86_64, meson 0.45.1, clang version 6.0.0-1ubuntu2 (tags/RELEASE_600/final) Target: x86_64-pc-linux-gnu
Elbrus-8C, meson 0.48.999, lcc:1.23.10:Jun-11-2018:e2k-v4-linux gcc (GCC) 5.5.0 compatible