### PR TITLE
always update gamepad device list at least once

### DIFF
--- a/src/gamepad.c
+++ b/src/gamepad.c
@@ -309,6 +309,7 @@ void gamepad_init(void) {
 	});
 
 	SDL_GameControllerEventState(SDL_ENABLE);
+	gamepad_update_device_list();
 }
 
 void gamepad_shutdown(void) {


### PR DESCRIPTION
I had this issue with the Nintendo GameCube adapter on Linux, that it would show "No devices available" and controller input wouldn't work.

@Akaricchi pointed me to this quick fix. There may be better solution, or further understanding why SDL events don't work on my system for this particular controller (SDL 2.0.9 Linux openSUSE 15.0 x64)