### PR TITLE
Switch SDL video modes detection

### DIFF
--- a/src/video.c
+++ b/src/video.c
@@ -687,8 +687,10 @@ void video_init(void) {
 		{0, 0},
 	};
 
-	for(int i = 0; common_modes[i].width; ++i) {
-		video_add_mode(common_modes[i].width, common_modes[i].height);
+	if(video_query_capability(VIDEO_CAP_FULLSCREEN) != VIDEO_ALWAYS_ENABLED) {
+		for(int i = 0; common_modes[i].width; ++i) {
+			video_add_mode(common_modes[i].width, common_modes[i].height);
+		}
 	}
 
 	// sort it, mainly for the options menu

--- a/src/video.c
+++ b/src/video.c
@@ -69,7 +69,6 @@ static VideoCapabilityState video_query_capability_alwaysfullscreen(VideoCapabil
 	UNREACHABLE;
 }
 
-#ifndef __SWITCH__
 static VideoCapabilityState video_query_capability_webcanvas(VideoCapability cap) {
 	switch(cap) {
 		case VIDEO_CAP_EXTERNAL_RESIZE:
@@ -82,7 +81,6 @@ static VideoCapabilityState video_query_capability_webcanvas(VideoCapability cap
 			return video_query_capability_generic(cap);
 	}
 }
-#endif
 
 static void video_add_mode(int width, int height) {
 	if(video.modes) {
@@ -627,10 +625,6 @@ void video_init(void) {
 	const char *driver = SDL_GetCurrentVideoDriver();
 	log_info("Using driver '%s'", driver);
 
-#ifdef __SWITCH__
-	video.backend = VIDEO_BACKEND_SWITCH;
-	video_query_capability = video_query_capability_alwaysfullscreen;
-#else
 	video_query_capability = video_query_capability_generic;
 
 	if(!strcmp(driver, "x11")) {
@@ -648,15 +642,16 @@ void video_init(void) {
 	} else if(!strcmp(driver, "RPI")) {
 		video.backend = VIDEO_BACKEND_RPI;
 		video_query_capability = video_query_capability_alwaysfullscreen;
+	} else if(!strcmp(driver, "Switch")) {
+		video.backend = VIDEO_BACKEND_SWITCH;
+		video_query_capability = video_query_capability_alwaysfullscreen;
 	} else {
 		video.backend = VIDEO_BACKEND_OTHER;
 	}
-#endif
 
 	r_init();
 
 	// Register all resolutions that are available in fullscreen
-#ifndef __SWITCH__
 	for(int s = 0; s < video_num_displays(); ++s) {
 		log_info("Found display #%i: %s", s, video_display_name(s));
 		for(int i = 0; i < SDL_GetNumDisplayModes(s); ++i) {
@@ -670,7 +665,6 @@ void video_init(void) {
 			}
 		}
 	}
-#endif
 
 	if(!fullscreen_available) {
 		log_warn("No available fullscreen modes");
@@ -680,11 +674,6 @@ void video_init(void) {
 	// Then, add some common 4:3 modes for the windowed mode if they are not there yet.
 	// This is required for some multihead setups.
 	VideoMode common_modes[] = {
-#ifdef __SWITCH__
-		{640, 480},
-		{1280, 720},
-		{1920, 1080},
-#else
 		{RESX, RESY},
 		{SCREEN_W, SCREEN_H},
 
@@ -695,7 +684,6 @@ void video_init(void) {
 		{1152, 864},
 		{1400, 1050},
 		{1440, 1080},
-#endif
 		{0, 0},
 	};
 


### PR DESCRIPTION
* Use SDL driver and video modes detection on Switch
* Don't add windowed modes if always fullscreen