### PR TITLE
macOS/Linux building notes, +*.swp for .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ __pycache__
 *.kdev4
 .kdev4/
 *.kate-swp
+*.swp

--- a/README.rst
+++ b/README.rst
@@ -48,7 +48,7 @@ The build system will try to pull in as many missing dependencies as it can into
 
 On **Linux**, you should use the libraries provided by your distribution's package manager (i.e: apt, yum, etc.). In particular, installing packages like ``libsdl2-dev`` is necessary, especially if your system uses Wayland, since it will pull in the necessary libraries to build for your system. Ensure that you've correctly installed the dependency packages if you run into errors like ``SDL_Error: No available video device``.
 
-On **macOS**, it's a bit different. Using ``brew`` (from Mac Homebrew), you can safely install: ``libzip``, ``libpng``, ``webp``, ``sdl2``, ``freetype``. What you should **avoid** is installing ``sdl2_mixer`` and ``opusfile``, as they versions they ship don't currently seem compatible with Taisei. The build system will pull those in for you so you can safely ignore them.
+On **macOS**, it's a bit different. Using ``brew`` (from Mac Homebrew), you can safely install: ``libzip``, ``libpng``, ``webp``, ``sdl2``, ``freetype``. What you should **avoid** is installing ``sdl2_mixer`` and ``opusfile``, as the versions they ship don't currently seem compatible with Taisei. The build system will pull those in for you so you can safely ignore them.
 
 Obtaining the source code
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,6 @@ Optional:
 -  SPIRV-Cross >= 2019-03-22 (for OpenGL ES backends)
 -  libshaderc (for OpenGL ES backends)
 
-
 Build-only dependencies
 ^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/README.rst
+++ b/README.rst
@@ -31,6 +31,7 @@ Optional:
 -  SPIRV-Cross >= 2019-03-22 (for OpenGL ES backends)
 -  libshaderc (for OpenGL ES backends)
 
+
 Build-only dependencies
 ^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -40,6 +41,15 @@ Build-only dependencies
 Optional:
 
 -  docutils (for documentation)
+
+Platform-Specific Instructions
+""""""""""""""""""""""""""""""
+
+The build system will try to pull in as many missing dependencies as it can into the build environment. However, this has a few caveats.
+
+On **Linux**, you should use the libraries provided by your distribution's package manager (i.e: apt, yum, etc.). In particular, installing packages like ``libsdl2-dev`` is necessary, especially if your system uses Wayland, since it will pull in the necessary libraries to build for your system. Ensure that you've correctly installed the dependency packages if you run into errors like ``SDL_Error: No available video device``.
+
+On **macOS**, it's a bit different. Using ``brew`` (from Mac Homebrew), you can safely install: ``libzip``, ``libpng``, ``webp``, ``sdl2``, ``freetype``. What you should **avoid** is installing ``sdl2_mixer`` and ``opusfile``, as they versions they ship don't currently seem compatible with Taisei. The build system will pull those in for you so you can safely ignore them.
 
 Obtaining the source code
 ^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Some things I noticed building on macOS and Linux. A section for Windows will be included when I get around to trying to build on Windows too. 

Also adds *.swp for .gitignore, which helps elitist vim users (such as myself).