### PR TITLE
OpenGL ES 3.0/ANGLE support on macOS

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -358,14 +358,9 @@ else
 endif
 
 if angle_enabled
-    install_data(
-      get_option('angle_libgles'),
-      get_option('angle_libegl'),
-      install_dir : join_paths(bindir, 'ANGLE'),
-    )
-
+    angle_dir = 'ANGLE' 
     if host_machine.system() == 'windows'
-        angle_path = 'ANGLE\\'
+        angle_path = angle_dir + '\\'
         gles_filename = angle_path + 'libGLESv2.dll'
         egl_filename = angle_path + 'libEGL.dll'
 	# activate the Windows-Intel-ANGLE workaround
@@ -373,18 +368,27 @@ if angle_enabled
     elif host_machine.system() == 'darwin'
         # this is relative to SDL_GetBasePath()
         # easiest way to traverse is to go up one dir
-        angle_path = '../MacOS/ANGLE/'
-        gles_filename = angle_path + 'libGLESv2.dylib'
-        egl_filename = angle_path + 'libEGL.dylib'
+        angle_path = 'MacOS/' + angle_dir + '/'
+	if not macos_app_bundle
+            # if the user decides not to use the app bundle on macOS
+            angle_path = 'lib/' + angle_dir + '/'
+	endif
+        gles_filename = '../' + angle_path + 'libGLESv2.dylib'
+        egl_filename = '../' + angle_path + 'libEGL.dylib'
     else
         # FIXME: for Linux
-        angle_path = './'
-        gles_filename = angle_path + 'libGLESv2.so'
-        egl_filename = angle_path + 'libEGL.so'
+        angle_path = 'lib/' + angle_dir + '/'
+        gles_filename = '../' + angle_path + 'libGLESv2.so'
+        egl_filename = '../' + angle_path + 'libEGL.so'
     endif 
 
     config.set_quoted('TAISEI_BUILDCONF_ANGLE_GLES_PATH', gles_filename )
     config.set_quoted('TAISEI_BUILDCONF_ANGLE_EGL_PATH', egl_filename )
+    install_data(
+      get_option('angle_libgles'),
+      get_option('angle_libegl'),
+      install_dir : angle_path,
+    )
 endif
 
 systype = (have_posix ? 'POSIX (@0@)' : '@0@').format(host_machine.system())

--- a/meson.build
+++ b/meson.build
@@ -359,10 +359,32 @@ endif
 
 if angle_enabled
     install_data(
-	get_option('angle_libgles'),
-	get_option('angle_libegl'),
-	install_dir : join_paths(bindir, 'ANGLE'),
+      get_option('angle_libgles'),
+      get_option('angle_libegl'),
+      install_dir : join_paths(bindir, 'ANGLE'),
     )
+
+    if host_machine.system() == 'windows'
+        angle_path = 'ANGLE\\'
+        gles_filename = angle_path + 'libGLESv2.dll'
+        egl_filename = angle_path + 'libEGL.dll'
+	# activate the Windows-Intel-ANGLE workaround
+	config.set('TAISEI_BUILDCONF_WINDOWS_ANGLE_INTEL', 1)
+    elif host_machine.system() == 'darwin'
+        # this is relative to SDL_GetBasePath()
+        # easiest way to traverse is to go up one dir
+        angle_path = '../MacOS/ANGLE/'
+        gles_filename = angle_path + 'libGLESv2.dylib'
+        egl_filename = angle_path + 'libEGL.dylib'
+    else
+        # FIXME: for Linux
+        angle_path = './'
+        gles_filename = angle_path + 'libGLESv2.so'
+        egl_filename = angle_path + 'libEGL.so'
+    endif 
+
+    config.set_quoted('TAISEI_BUILDCONF_ANGLE_GLES_PATH', gles_filename )
+    config.set_quoted('TAISEI_BUILDCONF_ANGLE_EGL_PATH', egl_filename )
 endif
 
 systype = (have_posix ? 'POSIX (@0@)' : '@0@').format(host_machine.system())

--- a/meson.build
+++ b/meson.build
@@ -350,21 +350,19 @@ if host_machine.system() == 'windows'
         )
     endif
 
-    if angle_enabled
-        install_data(
-            get_option('angle_libgles'),
-            get_option('angle_libegl'),
-            install_dir : join_paths(bindir, 'ANGLE'),
-        )
-    endif
 else
     if install_docs
         install_data('COPYING', install_dir : doc_path)
     endif
 
-    if angle_enabled
-        error('install_angle is only available for Windows targets at the moment')
-    endif
+endif
+
+if angle_enabled
+    install_data(
+	get_option('angle_libgles'),
+	get_option('angle_libegl'),
+	install_dir : join_paths(bindir, 'ANGLE'),
+    )
 endif
 
 systype = (have_posix ? 'POSIX (@0@)' : '@0@').format(host_machine.system())

--- a/meson.build
+++ b/meson.build
@@ -358,21 +358,22 @@ else
 endif
 
 if angle_enabled
-    angle_dir = 'ANGLE' 
+    angle_dir = 'ANGLE'
+
     if host_machine.system() == 'windows'
         angle_path = angle_dir + '\\'
         gles_filename = angle_path + 'libGLESv2.dll'
         egl_filename = angle_path + 'libEGL.dll'
-	# activate the Windows-Intel-ANGLE workaround
-	config.set('TAISEI_BUILDCONF_WINDOWS_ANGLE_INTEL', 1)
+        # activate the Windows-Intel-ANGLE workaround
+        config.set('TAISEI_BUILDCONF_WINDOWS_ANGLE_INTEL', 1)
     elif host_machine.system() == 'darwin'
         # this is relative to SDL_GetBasePath()
         # easiest way to traverse is to go up one dir
         angle_path = 'MacOS/' + angle_dir + '/'
-	if not macos_app_bundle
+        if not macos_app_bundle
             # if the user decides not to use the app bundle on macOS
             angle_path = 'lib/' + angle_dir + '/'
-	endif
+        endif
         gles_filename = '../' + angle_path + 'libGLESv2.dylib'
         egl_filename = '../' + angle_path + 'libEGL.dylib'
     else
@@ -380,7 +381,7 @@ if angle_enabled
         angle_path = 'lib/' + angle_dir + '/'
         gles_filename = '../' + angle_path + 'libGLESv2.so'
         egl_filename = '../' + angle_path + 'libEGL.so'
-    endif 
+    endif
 
     # used in gles.c for determining what libraries to use
     config.set_quoted('TAISEI_BUILDCONF_ANGLE_GLES_PATH', gles_filename )

--- a/meson.build
+++ b/meson.build
@@ -382,12 +382,15 @@ if angle_enabled
         egl_filename = '../' + angle_path + 'libEGL.so'
     endif 
 
+    # used in gles.c for determining what libraries to use
     config.set_quoted('TAISEI_BUILDCONF_ANGLE_GLES_PATH', gles_filename )
     config.set_quoted('TAISEI_BUILDCONF_ANGLE_EGL_PATH', egl_filename )
+
+    # installs ANGLE to the paths specified
     install_data(
-      get_option('angle_libgles'),
-      get_option('angle_libegl'),
-      install_dir : angle_path,
+        get_option('angle_libgles'),
+        get_option('angle_libegl'),
+        install_dir : angle_path,
     )
 endif
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -43,7 +43,7 @@ option(
     'install_angle',
     type : 'boolean',
     value : 'false',
-    description : 'Install pre-built ANGLE libraries. Necessary for OpenGL ES 2.0/3.0 support.'
+    description : 'Install pre-built ANGLE libraries. Required for Windows/macOS OpenGL ES 2.0/3.0'
 )
 
 option(

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -43,7 +43,7 @@ option(
     'install_angle',
     type : 'boolean',
     value : 'false',
-    description : 'Install pre-built ANGLE libraries. Only makes sense with a GLES backend. Currently only supported on Windows'
+    description : 'Install pre-built ANGLE libraries. Necessary for OpenGL ES 2.0/3.0 support.'
 )
 
 option(

--- a/misc/Info.plist.in
+++ b/misc/Info.plist.in
@@ -22,6 +22,8 @@
     <string>????</string>
     <key>CFBundleVersion</key>
     <string>${VERSION({major}.{minor}.{patch}.{tweak})}</string>
+    <key>LSApplicationCategoryType</key>
+    <string>public.app-category.arcade-games</string>
     <key>NSHumanReadableCopyright</key>
     <string>© 2011-2019, Taisei Project</string>
 </dict>

--- a/misc/meson.build
+++ b/misc/meson.build
@@ -4,7 +4,8 @@ if macos_app_bundle
 
     plist = custom_target('macOS property list',
         command : [preprocess_command, '@INPUT@', '@OUTPUT@'],
-        build_always : true,
+        build_by_default : true,
+        build_always_stale : true,
         input : 'Info.plist.in',
         output : 'Info.plist',
         install : true,

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,7 +1,8 @@
 
 version_deps += custom_target('version information',
     command : [preprocess_command, '@INPUT@', '@OUTPUT@'],
-    build_always : true,
+    build_by_default : true,
+    build_always_stale : true,
     input : 'version_auto.c.in',
     output : 'version_auto.c',
 )
@@ -30,7 +31,8 @@ if host_machine.system() == 'windows'
     # https://github.com/mesonbuild/meson/issues/4301
     rc_target = custom_target('windows-resource',
         command : [preprocess_command, rcdefs, '@INPUT@', '@OUTPUT@'],
-        build_always : true,
+        build_always_stale : true,
+        build_by_default : true,
         input : 'taisei.rc.in',
         output : 'taisei.rc',
     )

--- a/src/renderer/glcommon/opengl.c
+++ b/src/renderer/glcommon/opengl.c
@@ -651,7 +651,7 @@ static const char *get_unmasked_property(GLenum prop, bool fallback) {
 }
 
 static void detect_broken_intel_driver(void) {
-#if (defined TAISEI_BUILDCONF_HAVE_ANGLE && defined _WIN32)
+#ifdef TAISEI_BUILDCONF_WINDOWS_ANGLE_INTEL
 	extern DECLSPEC int SDLCALL SDL_ShowMessageBox(const SDL_MessageBoxData *messageboxdata, int *buttonid);
 
 	bool is_broken_intel_driver = (

--- a/src/renderer/glcommon/opengl.c
+++ b/src/renderer/glcommon/opengl.c
@@ -651,7 +651,7 @@ static const char *get_unmasked_property(GLenum prop, bool fallback) {
 }
 
 static void detect_broken_intel_driver(void) {
-#ifdef TAISEI_BUILDCONF_HAVE_WINDOWS_ANGLE_FALLBACK
+#if (defined TAISEI_BUILDCONF_HAVE_ANGLE && defined _WIN32)
 	extern DECLSPEC int SDLCALL SDL_ShowMessageBox(const SDL_MessageBoxData *messageboxdata, int *buttonid);
 
 	bool is_broken_intel_driver = (
@@ -719,6 +719,7 @@ static void detect_broken_intel_driver(void) {
 	);
 
 	exit(0);
+
 #endif
 }
 

--- a/src/renderer/glescommon/gles.c
+++ b/src/renderer/glescommon/gles.c
@@ -17,31 +17,16 @@ void gles_init(RendererBackend *gles_backend, int major, int minor) {
 #ifdef TAISEI_BUILDCONF_HAVE_ANGLE
 	// for loading ANGLE libraries
 	char *basepath = SDL_GetBasePath();
-	size_t basepath_len = strlen(basepath);
-	char buf[basepath_len + 256];
-
-#ifdef __APPLE__
-	const char *libgles = "libGLESv2.dylib";
-	const char *libegl = "libEGL.dylib";
-	// SDL_GetBasePath() returns Contents/Resources
-	// but we need Contents/MacOS, so go up one dir 
-	snprintf(buf, sizeof(buf), "%s../MacOS/ANGLE/", basepath);
-	basepath_len += sizeof("../MacOS/ANGLE");
-#else
-	// for Windows
-	const char *libgles = "libGLESv2.dll";
-	const char *libegl = "libEGL.dll";
-	snprintf(buf, sizeof(buf), "%sANGLE\\", basepath);
-	basepath_len += sizeof("ANGLE");
-#endif
-
-	SDL_free(basepath);
-
-	strlcpy(buf + basepath_len, libgles, sizeof(buf) - basepath_len);
+	char buf[128];
+	
+	// SDL_*_DRIVER are SDL-specific env vars
+	snprintf(buf, sizeof(buf), "%s%s", basepath, TAISEI_BUILDCONF_ANGLE_GLES_PATH);
 	env_set("SDL_VIDEO_GL_DRIVER", buf, false);
 
-	strlcpy(buf + basepath_len, libegl, sizeof(buf) - basepath_len);
+	snprintf(buf, sizeof(buf), "%s%s", basepath, TAISEI_BUILDCONF_ANGLE_EGL_PATH);
 	env_set("SDL_VIDEO_EGL_DRIVER", buf, false);
+
+	SDL_free(basepath);
 
 	env_set("SDL_OPENGL_ES_DRIVER", 1, false);
 

--- a/src/renderer/glescommon/gles.c
+++ b/src/renderer/glescommon/gles.c
@@ -14,18 +14,37 @@
 #include "../gl33/gl33.h"
 
 void gles_init(RendererBackend *gles_backend, int major, int minor) {
-#ifdef TAISEI_BUILDCONF_HAVE_WINDOWS_ANGLE_FALLBACK
+#ifdef TAISEI_BUILDCONF_HAVE_ANGLE
+	// for loading ANGLE libraries
 	char *basepath = SDL_GetBasePath();
 	size_t basepath_len = strlen(basepath);
-	char buf[basepath_len + 32];
+	char buf[basepath_len + 256];
+
+#ifdef __APPLE__
+	const char *libgles = "libGLESv2.dylib";
+	const char *libegl = "libEGL.dylib";
+	// SDL_GetBasePath() returns Contents/Resources
+	// but we need Contents/MacOS, so go up one dir 
+	snprintf(buf, sizeof(buf), "%s../MacOS/ANGLE/", basepath);
+	basepath_len += sizeof("../MacOS/ANGLE");
+#else
+	// for Windows
+	const char *libgles = "libGLESv2.dll";
+	const char *libegl = "libEGL.dll";
 	snprintf(buf, sizeof(buf), "%sANGLE\\", basepath);
-	SDL_free(basepath);
 	basepath_len += sizeof("ANGLE");
-	strlcpy(buf + basepath_len, "libGLESv2.dll", sizeof(buf) - basepath_len);
+#endif
+
+	SDL_free(basepath);
+
+	strlcpy(buf + basepath_len, libgles, sizeof(buf) - basepath_len);
 	env_set("SDL_VIDEO_GL_DRIVER", buf, false);
-	strlcpy(buf + basepath_len, "libEGL.dll", sizeof(buf) - basepath_len);
+
+	strlcpy(buf + basepath_len, libegl, sizeof(buf) - basepath_len);
 	env_set("SDL_VIDEO_EGL_DRIVER", buf, false);
+
 	env_set("SDL_OPENGL_ES_DRIVER", 1, false);
+
 #endif
 
 	_r_backend_inherit(gles_backend, &_r_backend_gl33);

--- a/src/renderer/meson.build
+++ b/src/renderer/meson.build
@@ -61,7 +61,11 @@ endforeach
 r_macro = ' '.join(r_macro)
 config.set('TAISEI_BUILDCONF_RENDERER_BACKENDS', r_macro)
 config.set_quoted('TAISEI_BUILDCONF_RENDERER_DEFAULT', default_renderer)
-config.set('TAISEI_BUILDCONF_HAVE_ANGLE',
-    enabled_renderers.contains('gles30') and
-    get_option('install_angle')
-)
+
+if angle_enabled
+    if enabled_renderers.contains('gles30') or enabled_renderers.contains('gles20')
+        config.set('TAISEI_BUILDCONF_HAVE_ANGLE', 1)
+    else
+        error('you should enable gles30 and/or gles20 with ANGLE')
+    endif
+endif

--- a/src/renderer/meson.build
+++ b/src/renderer/meson.build
@@ -61,8 +61,7 @@ endforeach
 r_macro = ' '.join(r_macro)
 config.set('TAISEI_BUILDCONF_RENDERER_BACKENDS', r_macro)
 config.set_quoted('TAISEI_BUILDCONF_RENDERER_DEFAULT', default_renderer)
-config.set('TAISEI_BUILDCONF_HAVE_WINDOWS_ANGLE_FALLBACK',
-    host_machine.system() == 'windows' and
+config.set('TAISEI_BUILDCONF_HAVE_ANGLE',
     enabled_renderers.contains('gles30') and
     get_option('install_angle')
 )


### PR DESCRIPTION
This fixes (mostly) everything needed to compile GL ES 3.0 on macOS.

You still need to have `libGLESv2.dylib` and `libEGL.dylib` handy and specified with configuring the environment with Meson, but it should pull those files in and put them in a predictable place within `Taisei.app`. 

I also got rid of some deprecation warnings in `meson.build` files for `build_always`. The replacement functions have been around since before the minimum version to build Taisei (>=0.48) so it should be safe.

Even if it's mostly just a wrapper around OpenGL 4.1 through ANGLE, it's nice to keep our options open. It also runs pretty well. (Who knows - maybe an iOS or Android port for v1.5? (more like v2.0))