### PR TITLE
Add API for task-bound dynamic memory allocation

### DIFF
--- a/src/coroutine.h
+++ b/src/coroutine.h
@@ -106,6 +106,7 @@ CoStatus cotask_status(CoTask *task);
 CoTask *cotask_active(void);
 EntityInterface *cotask_bind_to_entity(CoTask *task, EntityInterface *ent) attr_returns_nonnull;
 CoTaskEvents *cotask_get_events(CoTask *task);
+void *cotask_malloc(CoTask *task, size_t size) attr_returns_allocated attr_malloc attr_alloc_size(2);
 
 BoxedTask cotask_box(CoTask *task);
 CoTask *cotask_unbox(BoxedTask box);
@@ -390,6 +391,7 @@ DECLARE_EXTERN_TASK(_cancel_task_helper, { BoxedTask task; });
 
 #define THIS_TASK     cotask_box(cotask_active())
 #define TASK_EVENTS(task) cotask_get_events(cotask_unbox(task))
+#define TASK_MALLOC(size) cotask_malloc(cotask_active(), size)
 
 #define YIELD         cotask_yield(NULL)
 #define WAIT(delay)   cotask_wait(delay)

--- a/src/progress.c
+++ b/src/progress.c
@@ -469,7 +469,7 @@ static void progress_prepare_cmd_stage_playinfo(size_t *bufsize, void **arg) {
 				e->num_played = p->num_played;      data->size += sizeof(uint32_t);
 				e->num_cleared = p->num_cleared;    data->size += sizeof(uint32_t);
 
-				list_push(&data->elems, e);
+				(void)list_push(&data->elems, e);
 			}
 		}
 	});

--- a/src/util/compat.h
+++ b/src/util/compat.h
@@ -270,6 +270,15 @@ typedef cmplx64 cmplx;
 	#define attr_designated_init
 #endif
 
+// Function returns a pointer that can't alias any other pointer when the function returns.
+// Storage pointed at doesn't contain pointers to any valid objects.
+#define attr_malloc \
+	__attribute__ ((malloc))
+
+// Function returns a pointer to object whose size is specified by the 'size_arg_index'th function argument.
+#define attr_alloc_size(size_arg_index) \
+	__attribute__ ((alloc_size(size_arg_index)))
+
 #define INLINE static inline attr_must_inline __attribute__((gnu_inline))
 
 #ifdef USE_GNU_EXTENSIONS

--- a/src/util/pixmap_conversion.inc.h
+++ b/src/util/pixmap_conversion.inc.h
@@ -1,6 +1,6 @@
 
-#define _CONV_IN_IS_FLOAT (_CONV_IN_MAX == 1.0f)
-#define _CONV_OUT_IS_FLOAT (_CONV_OUT_MAX == 1.0f)
+#define _CONV_IN_IS_FLOAT ((float)_CONV_IN_MAX == 1.0f)
+#define _CONV_OUT_IS_FLOAT ((float)_CONV_OUT_MAX == 1.0f)
 
 static void _CONV_FUNCNAME(
 	size_t in_elements,
@@ -26,11 +26,12 @@ static void _CONV_FUNCNAME(
 						fill = (_CONV_OUT_TYPE)round(clamp(*buf_in++, 0, 1) * _CONV_OUT_MAX);
 					}
 				} else if(_CONV_OUT_IS_FLOAT) {
-					fill = *buf_in++ * (1.0f / _CONV_IN_MAX);
+					fill = *buf_in++ * (1.0f / (float)_CONV_IN_MAX);
 				} else if(_CONV_OUT_MAX >= _CONV_IN_MAX) {
 					fill = *buf_in++ * (_CONV_OUT_MAX / _CONV_IN_MAX);
 				} else {
-					fill = (_CONV_OUT_TYPE)round(*buf_in++ * ((float)_CONV_OUT_MAX / _CONV_IN_MAX));
+					// TODO use fixed point math
+					fill = (_CONV_OUT_TYPE)round(*buf_in++ * ((float)_CONV_OUT_MAX / (float)_CONV_IN_MAX));
 				}
 			} else {
 				fill = default_pixel[element];


### PR DESCRIPTION
`TASK_MALLOC(size)` allocates a memory region with a lifetime bound to the active task. It can't be `free`'d manually.

Allocation requests are served from a dedicated region on the task's stack whenever possible, which is fast and essentially free. If there is not enough free space to serve the request, then the memory is allocated on the heap. Such heap allocations are automatically `free`'d when the task expires.

The allocated memory is zero-initialized and aligned as strictly as `max_align_t`.

I'm not yet sure if we'll end up using this, so I'll just let it sit here for now and merge when/if needed.