### PR TITLE
Turn on SDL_WINDOW_ALLOW_HIGHDPI

### DIFF
--- a/src/video.c
+++ b/src/video.c
@@ -257,6 +257,8 @@ static void video_new_window_internal(uint display, uint w, uint h, uint32_t fla
 static void video_new_window(uint display, uint w, uint h, bool fs, bool resizable) {
 	uint32_t flags = 0;
 
+	flags |= SDL_WINDOW_ALLOW_HIGHDPI;
+
 	if(fs) {
 		flags |= get_fullscreen_flag();
 	} else if(resizable && video.backend != VIDEO_BACKEND_EMSCRIPTEN) {


### PR DESCRIPTION
Hi, I needed this flag to remove the blurriness on my setup (Wayland, 3840x2160 monitor with scale factor 2). 

I'm not sure if you want this flag on conditionally or somewhere else or as a build parameter or something, so I can move this assignment or change the logic - just let me know.

In the screenshot below, the left build is with the patch, and the right one is master.

![20200412_01h19m03s_grim](https://user-images.githubusercontent.com/43256343/79061292-b8f32780-7c5c-11ea-800f-2d624e8cc6fe.png)
