### PR TITLE
Improve high-DPI handling

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -89,7 +89,6 @@
 	\
 	CONFIGDEF_STRING    (PLAYERNAME,                "playername",                           "Player") \
 	CONFIGDEF_INT       (FULLSCREEN,                "fullscreen",                           0) \
-	CONFIGDEF_INT       (FULLSCREEN_DESKTOP,        "fullscreen_desktop_mode",              1) \
 	CONFIGDEF_INT       (VID_WIDTH,                 "vid_width",                            RESX) \
 	CONFIGDEF_INT       (VID_HEIGHT,                "vid_height",                           RESY) \
 	CONFIGDEF_INT       (VID_DISPLAY,               "vid_display",                          0) \

--- a/src/taisei.manifest
+++ b/src/taisei.manifest
@@ -29,8 +29,8 @@
   </dependency>
   <application xmlns="urn:schemas-microsoft-com:asm.v3">
     <windowsSettings>
-      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
-      <dpiAware>true</dpiAware>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2,PerMonitor</dpiAwareness>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">True/PM</dpiAware>
     </windowsSettings>
   </application>
 </assembly>

--- a/src/video.h
+++ b/src/video.h
@@ -11,16 +11,10 @@
 
 #include "taisei.h"
 
-// FIXME: This is just for IntRect, which probably should be placed elsewhere.
 #include "util/geometry.h"
-
 #include "renderer/api.h"
 
 #include <SDL.h>
-
-#define WINFLAGS_IS_FULLSCREEN(f)       ((f) & SDL_WINDOW_FULLSCREEN_DESKTOP)
-#define WINFLAGS_IS_FAKE_FULLSCREEN(f)  (WINFLAGS_IS_FULLSCREEN(f) == SDL_WINDOW_FULLSCREEN_DESKTOP)
-#define WINFLAGS_IS_REAL_FULLSCREEN(f)  (WINFLAGS_IS_FULLSCREEN(f) == SDL_WINDOW_FULLSCREEN)
 
 #define WINDOW_TITLE "Taisei Project"
 #define VIDEO_ASPECT_RATIO ((double)SCREEN_W/SCREEN_H)
@@ -33,9 +27,18 @@ enum {
 
 #define SCREEN_SIZE { SCREEN_W, SCREEN_H }
 
-typedef struct VideoMode {
-	int width;
-	int height;
+typedef union VideoMode {
+	// NOTE: These really should be floats, since this represents abstract screen coordinates, not pixels.
+	// However, SDL's API expects integers everywhere, so it does not really make sense.
+
+	struct {
+		// TODO: get rid of this and just typedef to IntExtent?
+
+		int width;
+		int height;
+	};
+
+	IntExtent as_int_extent;
 } VideoMode;
 
 typedef enum VideoBackend {
@@ -82,5 +85,6 @@ VideoBackend video_get_backend(void);
 VideoMode video_get_mode(uint idx, bool fullscreen);
 uint video_get_num_modes(bool fullscreen);
 VideoMode video_get_current_mode(void);
+double video_get_scaling_factor(void);
 
 #endif // IGUARD_video_h


### PR DESCRIPTION
`SDL_WINDOW_ALLOW_HIGHDPI` is now used. On platforms where SDL supports this flag, the window size units are interpreted as abstract scaled points rather than raw pixels, and may not match the underlying framebuffer resolution if the display scaling factor is not 1. The scaling factor and the effective framebuffer resolution are now displayed in the options menu to reflect this fact.

In addition, the hidden `fullscreen_desktop_mode` setting has been removed and the behavior is now always as if the value was `1` (the default). Exclusive fullscreen with modesetting is not very useful, and does not work well on some platforms (X11 in particular). That code is not worth maintaining together with the frankly ridiculous complexity of dancing around with the DPI scaling shenanigans of various operating systems.

On platforms that do not support `SDL_WINDOW_ALLOW_HIGHDPI`, the window size is assumed to correspond to raw pixels, and an effort is made to disable the operating system's DPI upscaling mechanism, when possible.

This commit also fixes the Windows manifest, broken by dc57f78d89f654344ab2314a05f459fde0b76bda thanks to microshaft's amazing documentation.

Closes #211