### PR TITLE
Various fixes & improvements for concurrent loading

### DIFF
--- a/src/eventloop/eventloop.c
+++ b/src/eventloop/eventloop.c
@@ -52,6 +52,10 @@ void eventloop_leave(void) {
 	}
 }
 
+FrameTimes eventloop_get_frame_times(void) {
+	return evloop.frame_times;
+}
+
 LogicFrameAction run_logic_frame(LoopFrame *frame) {
 	assert(frame == evloop.stack_ptr);
 

--- a/src/eventloop/eventloop.h
+++ b/src/eventloop/eventloop.h
@@ -11,6 +11,8 @@
 
 #include "taisei.h"
 
+#include "hirestime.h"
+
 typedef enum RenderFrameAction {
 	RFRAME_SWAP,
 	RFRAME_DROP,
@@ -25,6 +27,12 @@ typedef enum LogicFrameAction {
 typedef LogicFrameAction (*LogicFrameFunc)(void *context);
 typedef RenderFrameAction (*RenderFrameFunc)(void *context);
 typedef void (*PostLoopFunc)(void *context);
+
+typedef struct FrameTimes {
+	hrtime_t target;
+	hrtime_t start;
+	hrtime_t next;
+} FrameTimes;
 
 #ifdef DEBUG_CALLCHAIN
 	#include "util/debug.h"
@@ -63,6 +71,8 @@ void eventloop_enter(
 ) attr_nonnull(1, 2, 3);
 
 void eventloop_run(void);
+
+FrameTimes eventloop_get_frame_times(void);
 
 #ifdef DEBUG_CALLCHAIN
 INLINE attr_nonnull(1) void run_call_chain(CallChain *cc, void *result, DebugInfo caller_dbg) {

--- a/src/eventloop/eventloop_private.h
+++ b/src/eventloop/eventloop_private.h
@@ -30,13 +30,8 @@ struct LoopFrame {
 extern struct evloop_s {
 	LoopFrame stack[EVLOOP_STACK_SIZE];
 	LoopFrame *stack_ptr;
+	FrameTimes frame_times;
 } evloop;
-
-typedef struct FrameTimes {
-	hrtime_t target;
-	hrtime_t start;
-	hrtime_t next;
-} FrameTimes;
 
 void eventloop_leave(void);
 

--- a/src/eventloop/executor_emscripten.c
+++ b/src/eventloop/executor_emscripten.c
@@ -14,7 +14,6 @@
 
 #include <emscripten.h>
 
-static FrameTimes frame_times;
 static uint frame_num;
 
 static bool em_handle_resize_event(SDL_Event *event, void *arg);
@@ -28,23 +27,23 @@ static void em_loop_callback(void) {
 		return;
 	}
 
-	if(time_get() < frame_times.next) {
+	if(time_get() < evloop.frame_times.next) {
 		return;
 	}
 
-	frame_times.start = time_get();
-	frame_times.target = frame->frametime;
+	evloop.frame_times.start = time_get();
+	evloop.frame_times.target = frame->frametime;
 
-	frame_times.next += frame_times.target;
-	hrtime_t min_next_time = frame_times.start - 2 * frame_times.target;
+	evloop.frame_times.next += evloop.frame_times.target;
+	hrtime_t min_next_time = evloop.frame_times.start - 2 * evloop.frame_times.target;
 
-	if(min_next_time > frame_times.next) {
-		frame_times.next = min_next_time;
+	if(min_next_time > evloop.frame_times.next) {
+		evloop.frame_times.next = min_next_time;
 	}
 
-	global.fps.busy.last_update_time = frame_times.start;
+	global.fps.busy.last_update_time = evloop.frame_times.start;
 
-	LogicFrameAction lframe_action = handle_logic(&frame, &frame_times);
+	LogicFrameAction lframe_action = handle_logic(&frame, &evloop.frame_times);
 
 	if(!frame || lframe_action == LFRAME_STOP) {
 		return;
@@ -72,7 +71,7 @@ static bool em_handle_resize_event(SDL_Event *event, void *arg) {
 }
 
 void eventloop_run(void) {
-	frame_times.next = time_get();
+	evloop.frame_times.next = time_get();
 	emscripten_set_main_loop(em_loop_callback, 0, false);
 	update_vsync();
 

--- a/src/events.h
+++ b/src/events.h
@@ -111,5 +111,6 @@ void events_register_handler(EventHandler *handler);
 void events_unregister_handler(EventHandlerProc proc);
 void events_poll(EventHandler *handlers, EventFlags flags);
 void events_emit(TaiseiEvent type, int32_t code, void *data1, void *data2);
+void events_defer(SDL_Event *evt);
 
 #endif // IGUARD_events_h

--- a/src/hashtable.inc.h
+++ b/src/hashtable.inc.h
@@ -720,7 +720,7 @@ HT_DECLARE_PRIV_FUNC(void, end_read, (HT_BASETYPE *ht)) {
 	SDL_LockMutex(ht->sync.mutex);
 
 	if(!--ht->sync.readers) {
-		SDL_CondSignal(ht->sync.cond);
+		SDL_CondBroadcast(ht->sync.cond);
 	}
 
 	SDL_UnlockMutex(ht->sync.mutex);

--- a/src/log.h
+++ b/src/log.h
@@ -119,7 +119,7 @@ void log_set_gui_error_appendix(const char *message);
 #if defined(DEBUG) && !defined(__EMSCRIPTEN__)
 	#define log_debug(...) log_custom(LOG_DEBUG, __VA_ARGS__)
 	#undef UNREACHABLE
-	#define UNREACHABLE log_fatal("This code should never be reached")
+	#define UNREACHABLE log_fatal("This code should never be reached  (%s:%i)", __FILE__, __LINE__)
 #else
 	#define log_debug(...)
 	#define LOG_NO_FILENAMES

--- a/src/main.c
+++ b/src/main.c
@@ -31,8 +31,6 @@ attr_unused
 static void taisei_shutdown(void) {
 	log_info("Shutting down");
 
-	taskmgr_global_shutdown();
-
 	if(!global.is_replay_verification) {
 		config_save();
 		progress_save();
@@ -42,6 +40,7 @@ static void taisei_shutdown(void) {
 
 	free_all_refs();
 	free_resources(true);
+	taskmgr_global_shutdown();
 	audio_shutdown();
 	video_shutdown();
 	gamepad_shutdown();

--- a/src/menu/charselect.c
+++ b/src/menu/charselect.c
@@ -381,6 +381,7 @@ void preload_char_menu(void) {
 	for(int i = 0; i < NUM_CHARACTERS; ++i) {
 		PlayerCharacter *pchar = plrchar_get(i);
 		portrait_preload_base_sprite(pchar->lower_name, NULL, RESF_PERMANENT);
+		preload_resource(RES_TEXTURE, pchar->menu_texture_name, RESF_PERMANENT);
 	}
 
 	char *p = (char*)facedefs;

--- a/src/renderer/api.c
+++ b/src/renderer/api.c
@@ -450,6 +450,10 @@ void r_texture_destroy(Texture *tex) {
 	B.texture_destroy(tex);
 }
 
+PixmapFormat r_texture_optimal_pixmap_format_for_type(TextureType type, PixmapFormat src_format) {
+	return B.texture_optimal_pixmap_format_for_type(type, src_format);
+}
+
 Framebuffer* r_framebuffer_create(void) {
 	return B.framebuffer_create();
 }

--- a/src/renderer/api.h
+++ b/src/renderer/api.h
@@ -665,6 +665,7 @@ void r_texture_fill_region(Texture *tex, uint mipmap, uint x, uint y, const Pixm
 void r_texture_invalidate(Texture *tex) attr_nonnull(1);
 void r_texture_clear(Texture *tex, const Color *clr) attr_nonnull(1, 2);
 void r_texture_destroy(Texture *tex) attr_nonnull(1);
+PixmapFormat r_texture_optimal_pixmap_format_for_type(TextureType type, PixmapFormat src_format);
 
 Framebuffer* r_framebuffer_create(void);
 const char* r_framebuffer_get_debug_label(Framebuffer *fb) attr_nonnull(1);
@@ -811,17 +812,17 @@ void r_disable(RendererCapability cap) {
 
 INLINE
 ShaderProgram* r_shader_get(const char *name) {
-	return get_resource_data(RES_SHADER_PROGRAM, name, RESF_DEFAULT | RESF_UNSAFE);
+	return get_resource_data(RES_SHADER_PROGRAM, name, RESF_DEFAULT);
 }
 
 INLINE
 ShaderProgram* r_shader_get_optional(const char *name) {
-	return get_resource_data(RES_SHADER_PROGRAM, name, RESF_OPTIONAL | RESF_UNSAFE);
+	return get_resource_data(RES_SHADER_PROGRAM, name, RESF_OPTIONAL);
 }
 
 INLINE
 Texture* r_texture_get(const char *name) {
-	return get_resource_data(RES_TEXTURE, name, RESF_DEFAULT | RESF_UNSAFE);
+	return get_resource_data(RES_TEXTURE, name, RESF_DEFAULT);
 }
 
 #pragma GCC diagnostic push
@@ -873,12 +874,12 @@ void r_clear(ClearBufferFlags flags, const Color *colorval, float depthval) {
 
 INLINE attr_nonnull(1)
 void r_draw_model(const char *model) {
-	r_draw_model_ptr(get_resource_data(RES_MODEL, model, RESF_UNSAFE), 0, 0);
+	r_draw_model_ptr(get_resource_data(RES_MODEL, model, RESF_DEFAULT), 0, 0);
 }
 
 INLINE attr_nonnull(1)
 void r_draw_model_instanced(const char *model, uint instances, uint base_instance) {
-	r_draw_model_ptr(get_resource_data(RES_MODEL, model, RESF_UNSAFE), instances, base_instance);
+	r_draw_model_ptr(get_resource_data(RES_MODEL, model, RESF_DEFAULT), instances, base_instance);
 }
 
 INLINE

--- a/src/renderer/common/backend.h
+++ b/src/renderer/common/backend.h
@@ -71,6 +71,7 @@ typedef struct RendererFuncs {
 	void (*texture_fill)(Texture *tex, uint mipmap, const Pixmap *image_data);
 	void (*texture_fill_region)(Texture *tex, uint mipmap, uint x, uint y, const Pixmap *image_data);
 	void (*texture_clear)(Texture *tex, const Color *clr);
+	PixmapFormat (*texture_optimal_pixmap_format_for_type)(TextureType type, PixmapFormat src_format);
 
 	Framebuffer* (*framebuffer_create)(void);
 	const char* (*framebuffer_get_debug_label)(Framebuffer *framebuffer);

--- a/src/renderer/gl33/gl33.c
+++ b/src/renderer/gl33/gl33.c
@@ -1201,6 +1201,7 @@ RendererBackend _r_backend_gl33 = {
 		.texture_fill = gl33_texture_fill,
 		.texture_fill_region = gl33_texture_fill_region,
 		.texture_clear = gl33_texture_clear,
+		.texture_optimal_pixmap_format_for_type = gl33_texture_optimal_pixmap_format_for_type,
 		.framebuffer_create = gl33_framebuffer_create,
 		.framebuffer_destroy = gl33_framebuffer_destroy,
 		.framebuffer_attach = gl33_framebuffer_attach,

--- a/src/renderer/gl33/texture.h
+++ b/src/renderer/gl33/texture.h
@@ -30,7 +30,7 @@ typedef struct Texture {
 Texture* gl33_texture_create(const TextureParams *params);
 void gl33_texture_get_size(Texture *tex, uint mipmap, uint *width, uint *height);
 void gl33_texture_get_params(Texture *tex, TextureParams *params);
-const char* gl33_texture_get_debug_label(Texture *tex);
+const char *gl33_texture_get_debug_label(Texture *tex);
 void gl33_texture_set_debug_label(Texture *tex, const char *label);
 void gl33_texture_set_filter(Texture *tex, TextureFilterMode fmin, TextureFilterMode fmag);
 void gl33_texture_set_wrap(Texture *tex, TextureWrapMode ws, TextureWrapMode wt);
@@ -42,8 +42,9 @@ void gl33_texture_taint(Texture *tex);
 void gl44_texture_clear(Texture *tex, const Color *clr);
 void gl33_texture_clear(Texture *tex, const Color *clr);
 void gl33_texture_destroy(Texture *tex);
+PixmapFormat gl33_texture_optimal_pixmap_format_for_type(TextureType type, PixmapFormat src_format);
 
-GLTextureTypeInfo* gl33_texture_type_info(TextureType type);
+GLTextureTypeInfo *gl33_texture_type_info(TextureType type);
 GLTexFormatCapabilities gl33_texture_format_caps(GLenum internal_fmt);
 
 #endif // IGUARD_renderer_gl33_texture_h

--- a/src/renderer/null/null.c
+++ b/src/renderer/null/null.c
@@ -90,6 +90,7 @@ static void null_texture_fill_region(Texture *tex, uint mipmap, uint x, uint y, 
 static void null_texture_invalidate(Texture *tex) { }
 static void null_texture_destroy(Texture *tex) { }
 static void null_texture_clear(Texture *tex, const Color *color) { }
+static PixmapFormat null_texture_optimal_pixmap_format_for_type(TextureType type, PixmapFormat src_format) { return src_format; }
 
 static FloatRect default_fb_viewport;
 
@@ -207,6 +208,7 @@ RendererBackend _r_backend_null = {
 		.texture_fill = null_texture_fill,
 		.texture_fill_region = null_texture_fill_region,
 		.texture_clear = null_texture_clear,
+		.texture_optimal_pixmap_format_for_type = null_texture_optimal_pixmap_format_for_type,
 		.framebuffer_create = null_framebuffer_create,
 		.framebuffer_get_debug_label = null_framebuffer_get_debug_label,
 		.framebuffer_set_debug_label = null_framebuffer_set_debug_label,

--- a/src/resource/animation.h
+++ b/src/resource/animation.h
@@ -26,12 +26,6 @@ typedef struct Animation {
 	int sprite_count;
 } Animation;
 
-char *animation_path(const char *name);
-bool check_animation_path(const char *path);
-void *load_animation_begin(const char *filename, uint flags);
-void *load_animation_end(void *opaque, const char *filename, uint flags);
-void unload_animation(void *vani);
-
 INLINE Animation *get_ani(const char *name) {
 	return get_resource(RES_ANIM, name, RESF_DEFAULT)->data;
 }

--- a/src/resource/postprocess.h
+++ b/src/resource/postprocess.h
@@ -48,25 +48,10 @@ struct PostprocessShaderUniform {
 typedef void (*PostprocessDrawFuncPtr)(Framebuffer *fb, double w, double h);
 typedef void (*PostprocessPrepareFuncPtr)(Framebuffer *fb, ShaderProgram *prog, void *arg);
 
-char* postprocess_path(const char *path);
-
 PostprocessShader* postprocess_load(const char *path, uint flags);
 void postprocess_unload(PostprocessShader **list);
 void postprocess(PostprocessShader *ppshaders, FBPair *fbos, PostprocessPrepareFuncPtr prepare, PostprocessDrawFuncPtr draw, double width, double height, void *arg);
 
-/*
- *  Glue for resources api
- */
-
-char* postprocess_path(const char *name);
-bool check_postprocess_path(const char *path);
-void* load_postprocess_begin(const char *path, uint flags);
-void* load_postprocess_end(void *opaque, const char *path, uint flags);
-void unload_postprocess(void*);
-
 extern ResourceHandler postprocess_res_handler;
-
-#define PP_PATH_PREFIX SHPROG_PATH_PREFIX
-#define PP_EXTENSION ".pp"
 
 #endif // IGUARD_resource_postprocess_h

--- a/src/resource/resource.c
+++ b/src/resource/resource.c
@@ -49,27 +49,93 @@ typedef enum ResourceStatus {
 	RES_STATUS_FAILED,
 } ResourceStatus;
 
-typedef struct InternalResource {
+typedef enum LoadStatus {
+	LOAD_NONE,
+	LOAD_OK,
+	LOAD_FAILED,
+	LOAD_CONT_ON_MAIN,
+	LOAD_CONT,
+} LoadStatus;
+
+typedef struct InternalResource InternalResource;
+typedef struct InternalResLoadState InternalResLoadState;
+
+struct InternalResource {
 	Resource res;
-	ResourceStatus status;
 	SDL_mutex *mutex;
 	SDL_cond *cond;
-	Task *async_task;
-} InternalResource;
+	InternalResLoadState *load;
+	ResourceStatus status;
+};
 
-typedef struct ResourceAsyncLoadData {
+struct InternalResLoadState {
+	ResourceLoadState st;
 	InternalResource *ires;
-	char *path;
-	char *name;
-	ResourceFlags flags;
-	void *opaque;
-} ResourceAsyncLoadData;
+	Task *async_task;
+	char *allocated_name;
+	char *allocated_path;
+	ResourceLoadProc continuation;
+	DYNAMIC_ARRAY(InternalResource*) dependencies;
+	LoadStatus status;
+	bool ready_to_finalize;
+};
 
-static inline ResourceHandler* get_handler(ResourceType type) {
+static struct {
+	hrtime_t frame_threshold;
+	uchar loaded_this_frame : 1;
+	struct {
+		uchar no_async_load : 1;
+		uchar no_preload : 1;
+		uchar no_unload : 1;
+		uchar preload_required : 1;
+	} env;
+} res_gstate;
+
+static inline InternalResLoadState *loadstate_internal(ResourceLoadState *st) {
+	return UNION_CAST(ResourceLoadState*, InternalResLoadState*, st);
+}
+
+static InternalResource *preload_resource_internal(ResourceType type, const char *name, ResourceFlags flags);
+
+void res_load_failed(ResourceLoadState *st) {
+	InternalResLoadState *ist = loadstate_internal(st);
+	ist->status = LOAD_FAILED;
+}
+
+void res_load_finished(ResourceLoadState *st, void *res) {
+	InternalResLoadState *ist = loadstate_internal(st);
+	ist->status = LOAD_OK;
+	ist->st.opaque = res;
+}
+
+void res_load_continue_on_main(ResourceLoadState *st, ResourceLoadProc callback, void *opaque) {
+	InternalResLoadState *ist = loadstate_internal(st);
+	ist->status = LOAD_CONT_ON_MAIN;
+	ist->st.opaque = opaque;
+	ist->continuation = callback;
+}
+
+void res_load_continue_after_dependencies(ResourceLoadState *st, ResourceLoadProc callback, void *opaque) {
+	InternalResLoadState *ist = loadstate_internal(st);
+	ist->status = LOAD_CONT;
+	ist->st.opaque = opaque;
+	ist->continuation = callback;
+}
+
+void res_load_dependency(ResourceLoadState *st, ResourceType type, const char *name) {
+	InternalResLoadState *ist = loadstate_internal(st);
+	InternalResource *dep = preload_resource_internal(type, name, st->flags);
+	InternalResource *ires = ist->ires;
+	SDL_LockMutex(ires->mutex);
+	*dynarray_append(&ist->dependencies) = dep;
+	SDL_UnlockMutex(ires->mutex);
+}
+
+static inline ResourceHandler *get_handler(ResourceType type) {
 	return *(_handlers + type);
 }
 
-static inline ResourceHandler* get_ires_handler(InternalResource *ires) {
+static inline ResourceHandler *get_ires_handler(InternalResource *ires) {
 	return get_handler(ires->res.type);
 }
 
@@ -78,7 +144,7 @@ static void alloc_handler(ResourceHandler *h) {
 	ht_create(&h->private.mapping);
 }
 
-static const char* type_name(ResourceType type) {
+static const char *type_name(ResourceType type) {
 	return get_handler(type)->typename;
 }
 
@@ -86,7 +152,7 @@ struct valfunc_arg {
 	ResourceType type;
 };
 
-static void* valfunc_begin_load_resource(void* arg) {
+static void *valfunc_begin_load_resource(void* arg) {
 	ResourceType type = ((struct valfunc_arg*)arg)->type;
 
 	InternalResource *ires = calloc(1, sizeof(InternalResource));
@@ -104,41 +170,67 @@ static bool try_begin_load_resource(ResourceType type, const char *name, hash_t 
 	return ht_try_set_prehashed(&handler->private.mapping, name, hash, &arg, valfunc_begin_load_resource, (void**)out_ires);
 }
 
-static void load_resource_finish(InternalResource *ires, void *opaque, const char *path, const char *name, char *allocated_path, char *allocated_name, ResourceFlags flags);
+static void load_resource_finish(InternalResLoadState *st);
 
-static void finish_async_load(InternalResource *ires, ResourceAsyncLoadData *data) {
-	assert(ires == data->ires);
-	assert(ires->status == RES_STATUS_LOADING);
-	load_resource_finish(ires, data->opaque, data->path, data->name, data->path, data->name, data->flags);
-	SDL_CondBroadcast(data->ires->cond);
-	assert(ires->status != RES_STATUS_LOADING);
-	free(data);
+static ResourceStatus pump_or_wait_for_dependencies(InternalResLoadState *st, bool pump_only);
+
+static ResourceStatus pump_dependencies(InternalResLoadState *st) {
+	return pump_or_wait_for_dependencies(st, true);
 }
 
-static ResourceStatus wait_for_resource_load(InternalResource *ires, uint32_t want_flags) {
+static ResourceStatus wait_for_dependencies(InternalResLoadState *st) {
+	return pump_or_wait_for_dependencies(st, false);
+}
+
+static ResourceStatus pump_or_wait_for_resource_load(InternalResource *ires, uint32_t want_flags, bool pump_only) {
 	SDL_LockMutex(ires->mutex);
 
-	if(ires->async_task != NULL && is_main_thread()) {
+	InternalResLoadState *load_state = ires->load;
+
+	if(load_state) {
 		assert(ires->status == RES_STATUS_LOADING);
 
-		ResourceAsyncLoadData *data;
-		Task *task = ires->async_task;
-		ires->async_task = NULL;
+		Task *task = load_state->async_task;
 
-		SDL_UnlockMutex(ires->mutex);
+		if(task) {
+			// If there's an async load task for this resource, wait for it for complete.
+			// If it's not yet running, it will be offloaded to this thread instead.
 
-		if(!task_finish(task, (void**)&data)) {
-			log_fatal("Internal error: ires->async_task failed");
+			load_state->async_task = NULL;
+			SDL_UnlockMutex(ires->mutex);
+
+			if(!task_finish(task, NULL)) {
+				log_fatal("Internal error: async task failed");
+			}
+
+			SDL_LockMutex(ires->mutex);
+
+			// It's important to refresh load_state here, because the task may have finalized the load.
+			// This may happen if the resource doesn't need to be finalized on the main thread, or if we *are* the main thread.
+			load_state = ires->load;
 		}
 
-		SDL_LockMutex(ires->mutex);
+		if(load_state) {
+			ResourceStatus dep_status = pump_dependencies(load_state);
 
-		if(ires->status == RES_STATUS_LOADING) {
-			finish_async_load(ires, data);
+			if(load_state->ready_to_finalize && is_main_thread()) {
+				// Resource has finished async load, but needs to be finalized on the main thread.
+				// Since we are the main thread, we can do it here.
+
+				if(dep_status == RES_STATUS_LOADING) {
+					dep_status = wait_for_dependencies(load_state);
+				}
+
+				load_resource_finish(load_state);
+				assert(ires->status != RES_STATUS_LOADING);
+			}
 		}
 	}
 
-	while(ires->status == RES_STATUS_LOADING) {
+	while(ires->status == RES_STATUS_LOADING && !pump_only) {
+		// If we get to this point, then we're waiting for a resource that's awaiting finalization on the main thread.
+		// If we *are* the main thread, there's no excuse for us to wait; we should've finalized the resource ourselves.
+		assert(!is_main_thread());
 		SDL_CondWait(ires->cond, ires->mutex);
 	}
 
@@ -159,6 +251,106 @@ static ResourceStatus wait_for_resource_load(InternalResource *ires, uint32_t wa
 	return status;
 }
 
+static ResourceStatus wait_for_resource_load(InternalResource *ires, uint32_t want_flags) {
+	return pump_or_wait_for_resource_load(ires, want_flags, false);
+}
+
+static ResourceStatus pump_or_wait_for_dependencies(InternalResLoadState *st, bool pump_only) {
+	ResourceStatus dep_status = RES_STATUS_LOADED;
+
+	dynarray_foreach_elem(&st->dependencies, InternalResource **dep, {
+		ResourceStatus s = pump_or_wait_for_resource_load(*dep, st->st.flags, pump_only);
+
+		switch(s) {
+			case RES_STATUS_FAILED:
+				return RES_STATUS_FAILED;
+
+			case RES_STATUS_LOADING:
+				dep_status = RES_STATUS_LOADING;
+				break;
+
+			case RES_STATUS_LOADED:
+				break;
+
+			default:
+				UNREACHABLE;
+		}
+	});
+
+	if(!pump_only) {
+		assert(dep_status != RES_STATUS_LOADING);
+	}
+
+	return dep_status;
+}
+
+static void *load_resource_async_task(void *vdata) {
+	InternalResLoadState *st = vdata;
+	InternalResource *ires = st->ires;
+	assume(st == ires->load);
+
+	SDL_LockMutex(ires->mutex);
+	ResourceHandler *h = get_ires_handler(ires);
+
+	st->status = LOAD_NONE;
+	h->procs.load(&st->st);
+
+retry:
+	switch(st->status) {
+		case LOAD_CONT: {
+			ResourceStatus dep_status;
+
+			if(is_main_thread()) {
+				dep_status = pump_dependencies(st);
+
+				if(dep_status == RES_STATUS_LOADING) {
+					dep_status = wait_for_dependencies(st);
+				}
+
+				st->status = LOAD_NONE;
+				st->continuation(&st->st);
+				goto retry;
+			} else {
+				dep_status = pump_dependencies(st);
+
+				if(dep_status == RES_STATUS_LOADING) {
+					st->status = LOAD_CONT_ON_MAIN;
+					st->ready_to_finalize = true;
+					events_emit(TE_RESOURCE_ASYNC_LOADED, 0, ires, NULL);
+					break;
+				} else {
+					st->status = LOAD_NONE;
+					st->continuation(&st->st);
+					goto retry;
+				}
+			}
+
+			UNREACHABLE;
+		}
+
+		case LOAD_CONT_ON_MAIN:
+			if(pump_dependencies(st) == RES_STATUS_LOADING || !is_main_thread()) {
+				st->ready_to_finalize = true;
+				events_emit(TE_RESOURCE_ASYNC_LOADED, 0, ires, NULL);
+				break;
+			}
+		// fallthrough
+		case LOAD_OK:
+		case LOAD_FAILED:
+			st->ready_to_finalize = true;
+			load_resource_finish(st);
+			st = NULL;
+			break;
+
+		default:
+			UNREACHABLE;
+	}
+
+	assume(ires->load == st);
+	SDL_UnlockMutex(ires->mutex);
+	return st;
+}
+
 static void unload_resource(InternalResource *ires) {
 	if(wait_for_resource_load(ires, 0) == RES_STATUS_LOADED) {
 		get_handler(ires->res.type)->procs.unload(ires->res.data);
@@ -169,78 +361,120 @@ static void unload_resource(InternalResource *ires) {
 	free(ires);
 }
 
-static char* get_name(ResourceHandler *handler, const char *path) {
-	if(handler->procs.name) {
-		return handler->procs.name(path);
+static char *get_name_from_path(ResourceHandler *handler, const char *path) {
+	if(!strstartswith(path, handler->subdir)) {
+		return NULL;
 	}
 
 	return resource_util_basename(handler->subdir, path);
 }
 
-static void* load_resource_async_task(void *vdata) {
-	ResourceAsyncLoadData *data = vdata;
+static bool should_defer_load(void) {
+	FrameTimes ft = eventloop_get_frame_times();
 
-	SDL_LockMutex(data->ires->mutex);
-	data->opaque = get_ires_handler(data->ires)->procs.begin_load(data->path, data->flags);
-	events_emit(TE_RESOURCE_ASYNC_LOADED, 0, data->ires, data);
-	SDL_UnlockMutex(data->ires->mutex);
+	if(ft.next != res_gstate.frame_threshold) {
+		res_gstate.frame_threshold = ft.next;
+		res_gstate.loaded_this_frame = false;
+	}
 
-	return data;
+	if(!res_gstate.loaded_this_frame) {
+		return false;
+	}
+
+	hrtime_t t = time_get();
+
+	if(ft.next < t || ft.next - t < ft.target / 2) {
+		return true;
+	}
+
+	return false;
 }
 
 static bool resource_asyncload_handler(SDL_Event *evt, void *arg) {
 	assert(is_main_thread());
 
 	InternalResource *ires = evt->user.data1;
+	InternalResLoadState *st = ires->load;
 
-	SDL_LockMutex(ires->mutex);
-	Task *task = ires->async_task;
-	assert(!task || ires->status == RES_STATUS_LOADING);
-	ires->async_task = NULL;
-	SDL_UnlockMutex(ires->mutex);
-
-	if(task == NULL) {
+	if(st == NULL) {
 		return true;
 	}
 
-	ResourceAsyncLoadData *data, *verify_data;
-
-	if(!task_finish(task, (void**)&verify_data)) {
-		log_fatal("Internal error: data->ires->async_task failed");
+#if 1
+	if(should_defer_load()) {
+		events_defer(evt);
+		return true;
 	}
+#endif
 
 	SDL_LockMutex(ires->mutex);
 
-	if(ires->status == RES_STATUS_LOADING) {
-		data = evt->user.data2;
-		assert(data == verify_data);
-		finish_async_load(ires, data);
+	ResourceStatus dep_status = pump_dependencies(st);
+
+	if(dep_status == RES_STATUS_LOADING) {
+		log_debug("Deferring %s '%s' because some dependencies are not satisfied", type_name(ires->res.type), st->st.name);
+		SDL_UnlockMutex(ires->mutex);
+		events_defer(evt);
+		return true;
+	}
+
+	Task *task = st->async_task;
+	assert(!task || ires->status == RES_STATUS_LOADING);
+	st->async_task = NULL;
+
+	if(task) {
+		SDL_UnlockMutex(ires->mutex);
+
+		if(!task_finish(task, NULL)) {
+			log_fatal("Internal error: async task failed");
+		}
+
+		SDL_LockMutex(ires->mutex);
+		st = ires->load;
+	}
+
+	if(st) {
+		load_resource_finish(ires->load);
+		res_gstate.loaded_this_frame = true;
 	}
 
 	SDL_UnlockMutex(ires->mutex);
-
 	return true;
 }
 
-static void load_resource_async(InternalResource *ires, char *path, char *name, ResourceFlags flags) {
-	ResourceAsyncLoadData *data = malloc(sizeof(ResourceAsyncLoadData));
+static InternalResLoadState *make_persistent_loadstate(InternalResLoadState *st_transient) {
+	if(st_transient->ires->load != NULL) {
+		assert(st_transient->ires->load == st_transient);
+		return st_transient;
+	}
 
-	log_debug("Loading %s '%s' asynchronously", type_name(ires->res.type), name);
+	InternalResLoadState *st = memdup(st_transient, sizeof(*st));
 
-	data->ires = ires;
-	data->path = path;
-	data->name = name;
-	data->flags = flags;
-	ires->async_task = taskmgr_global_submit((TaskParams) { load_resource_async_task, data });
+	assume(st->st.name != NULL);
+	assume(st->st.path != NULL);
+
+	if(!st->allocated_name) {
+		st->st.name = st->allocated_name = strdup(st->st.name);
+	}
+
+	if(!st->allocated_path) {
+		st->st.path = st->allocated_path = strdup(st->st.path);
+	}
+
+	st->ires->load = st;
+	return st;
 }
 
-static void load_resource(InternalResource *ires, const char *path, const char *name, ResourceFlags flags, bool async) {
+static void load_resource_async(InternalResLoadState *st_transient) {
+	InternalResLoadState *st = make_persistent_loadstate(st_transient);
+	st->async_task = taskmgr_global_submit((TaskParams) { load_resource_async_task, st });
+}
+
+attr_nonnull_all
+static void load_resource(InternalResource *ires, const char *name, ResourceFlags flags, bool async) {
 	ResourceHandler *handler = get_ires_handler(ires);
 	const char *typename = type_name(handler->type);
-	char *allocated_path = NULL;
-	char *allocated_name = NULL;
-
-	assert(path || name);
+	char *path = NULL;
 
 	if(handler->type == RES_SFX || handler->type == RES_BGM) {
 		// audio stuff is always optional.
@@ -249,96 +483,134 @@ static void load_resource(InternalResource *ires, const char *path, const char *
 		flags |= RESF_OPTIONAL;
 	}
 
-	if(!path) {
-		path = allocated_path = handler->procs.find(name);
-
-		if(!path) {
-			if(!(flags & RESF_OPTIONAL)) {
-				log_fatal("Required %s '%s' couldn't be located", typename, name);
-			} else {
-				log_error("Failed to locate %s '%s'", typename, name);
-			}
-
-			ires->status = RES_STATUS_FAILED;
-		}
-	} else if(!name) {
-		name = allocated_name = get_name(handler, path);
-	}
+	path = handler->procs.find(name);
 
 	if(path) {
 		assert(handler->procs.check(path));
+	} else {
+		if(!(flags & RESF_OPTIONAL)) {
+			log_fatal("Required %s '%s' couldn't be located", typename, name);
+		} else {
+			log_error("Failed to locate %s '%s'", typename, name);
+		}
+
+		ires->status = RES_STATUS_FAILED;
 	}
+
+	InternalResLoadState st = {
+		.ires = ires,
+		.allocated_path = path,
+		.st = {
+			.name = name,
+			.path = path,
+			.flags = flags,
+		},
+	};
 
 	if(ires->status == RES_STATUS_FAILED) {
-		load_resource_finish(ires, NULL, path, name, allocated_path, allocated_name, flags);
-		return;
-	}
-
-	if(async) {
-		// these will be freed when loading is done
-		path = allocated_path ? allocated_path : strdup(path);
-		name = allocated_name ? allocated_name : strdup(name);
-		load_resource_async(ires, (char*)path, (char*)name, flags);
+		st.ready_to_finalize = true;
+		load_resource_finish(&st);
+	} else if(async) {
+		load_resource_async(&st);
 	} else {
-		load_resource_finish(ires, handler->procs.begin_load(path, flags), path, name, allocated_path, allocated_name, flags);
+		st.status = LOAD_NONE;
+		handler->procs.load(&st.st);
+
+		retry: switch(st.status) {
+			case LOAD_OK:
+			case LOAD_FAILED:
+				st.ready_to_finalize = true;
+				load_resource_finish(&st);
+				break;
+			case LOAD_CONT:
+			case LOAD_CONT_ON_MAIN:
+				wait_for_dependencies(&st);
+				st.status = LOAD_NONE;
+				st.continuation(&st.st);
+				goto retry;
+			default: UNREACHABLE;
+		}
 	}
 }
 
-static void finalize_resource(InternalResource *ires, const char *name, void *data, ResourceFlags flags, const char *source) {
-	assert(name != NULL);
-	assert(source != NULL);
+static void load_resource_finish(InternalResLoadState *st) {
+	void *raw = NULL;
+	InternalResource *ires = st->ires;
 
-	if(data == NULL) {
-		const char *typename = type_name(ires->res.type);
-		if(!(flags & RESF_OPTIONAL)) {
-			log_fatal("Required %s '%s' couldn't be loaded", typename, name);
-		} else {
-			log_error("Failed to load %s '%s'", typename, name);
+	assert(ires->status == RES_STATUS_LOADING || ires->status == RES_STATUS_FAILED);
+	assert(st->ready_to_finalize);
+
+	if(ires->status != RES_STATUS_FAILED) {
+		retry: switch(st->status) {
+			case LOAD_CONT:
+			case LOAD_CONT_ON_MAIN:
+				st->status = LOAD_NONE;
+				st->continuation(&st->st);
+				goto retry;
+
+			case LOAD_OK:
+				raw = NOT_NULL(st->st.opaque);
+				break;
+
+			case LOAD_FAILED:
+				break;
+
+			default:
+				UNREACHABLE;
 		}
 	}
 
-	if(ires->res.type == RES_MODEL || env_get("TAISEI_NOUNLOAD", false)) {
-		// FIXME: models can't be safely unloaded at runtime
-		flags |= RESF_PERMANENT;
+	dynarray_free_data(&st->dependencies);
+
+	const char *name = NOT_NULL(st->st.name);
+	const char *path = st->st.path ? st->st.path : "<path unknown>";
+	char *allocated_source = vfs_repr(path, true);
+	const char *source = allocated_source ? allocated_source : path;
+	const char *typename = type_name(ires->res.type);
+
+	ires->res.flags = st->st.flags;
+	ires->res.data = raw;
+
+	if(ires->res.type == RES_MODEL || res_gstate.env.no_unload) {
+		// FIXME: models can't be safely unloaded at runtime yet
+		ires->res.flags |= RESF_PERMANENT;
 	}
 
-	ires->res.flags = flags;
-	ires->res.data = data;
+	if(raw) {
+		ires->status = RES_STATUS_LOADED;
+		log_info("Loaded %s '%s' from '%s' (%s)", typename, name, source, (ires->res.flags & RESF_PERMANENT) ? "permanent" : "transient");
+	} else {
+		ires->status = RES_STATUS_FAILED;
 
-	if(data) {
-		log_info("Loaded %s '%s' from '%s' (%s)", type_name(ires->res.type), name, source, (flags & RESF_PERMANENT) ? "permanent" : "transient");
+		if(ires->res.flags & RESF_OPTIONAL) {
+			log_error("Failed to load %s '%s' from '%s'", typename, name, source);
+		} else {
+			log_fatal("Required %s '%s' couldn't be loaded from '%s'", typename, name, source);
+		}
 	}
 
-	ires->status = data ? RES_STATUS_LOADED : RES_STATUS_FAILED;
-}
+	free(allocated_source);
+	free(st->allocated_path);
+	free(st->allocated_name);
 
-static void load_resource_finish(InternalResource *ires, void *opaque, const char *path, const char *name, char *allocated_path, char *allocated_name, ResourceFlags flags) {
-	void *raw = (ires->status == RES_STATUS_FAILED) ? NULL : get_ires_handler(ires)->procs.end_load(opaque, path, flags);
+	assume(!ires->load || ires->load == st);
 
-	name = name ? name : "<name unknown>";
-	path = path ? path : "<path unknown>";
+	Task *async_task = st->async_task;
+	if(async_task) {
+		st->async_task = NULL;
+		task_detach(async_task);
+	}
 
-	char *sp = vfs_repr(path, true);
-	finalize_resource(ires, name, raw, flags, sp ? sp : path);
-	free(sp);
+	free(ires->load);
+	ires->load = NULL;
 
-	free(allocated_path);
-	free(allocated_name);
+	SDL_CondBroadcast(ires->cond);
+	assert(ires->status != RES_STATUS_LOADING);
 }
 
 Resource *_get_resource(ResourceType type, const char *name, hash_t hash, ResourceFlags flags) {
 	InternalResource *ires;
 	Resource *res;
-
-	if(flags & RESF_UNSAFE) {
-		// FIXME: I'm not sure we actually need this functionality.
-
-		ires = ht_get_unsafe_prehashed(&get_handler(type)->private.mapping, name, hash, NULL);
-
-		if(ires != NULL && ires->status == RES_STATUS_LOADED) {
-			return &ires->res;
-		}
-	}
 
 	if(try_begin_load_resource(type, name, hash, &ires)) {
 		SDL_LockMutex(ires->mutex);
@@ -346,12 +618,12 @@ Resource *_get_resource(ResourceType type, const char *name, hash_t hash, Resour
 		if(!(flags & RESF_PRELOAD)) {
 			log_warn("%s '%s' was not preloaded", type_name(type), name);
 
-			if(env_get("TAISEI_PRELOAD_REQUIRED", false)) {
+			if(res_gstate.env.preload_required) {
 				log_fatal("Aborting due to TAISEI_PRELOAD_REQUIRED");
 			}
 		}
 
-		load_resource(ires, NULL, name, flags, false);
+		load_resource(ires, name, flags, false);
 		SDL_CondBroadcast(ires->cond);
 
 		if(ires->status == RES_STATUS_FAILED) {
@@ -389,16 +661,21 @@ void *_get_resource_data(ResourceType type, const char *name, hash_t hash, Resou
 	return NULL;
 }
 
-void preload_resource(ResourceType type, const char *name, ResourceFlags flags) {
-	if(env_get("TAISEI_NOPRELOAD", false))
-		return;
-
+static InternalResource *preload_resource_internal(ResourceType type, const char *name, ResourceFlags flags) {
 	InternalResource *ires;
 
 	if(try_begin_load_resource(type, name, ht_str2ptr_hash(name), &ires)) {
 		SDL_LockMutex(ires->mutex);
-		load_resource(ires, NULL, name, flags | RESF_PRELOAD, !env_get("TAISEI_NOASYNC", false));
+		load_resource(ires, name, flags, !res_gstate.env.no_async_load);
 		SDL_UnlockMutex(ires->mutex);
+	}
+
+	return ires;
+}
+
+void preload_resource(ResourceType type, const char *name, ResourceFlags flags) {
+	if(!res_gstate.env.no_preload) {
+		preload_resource_internal(type, name, flags | RESF_PRELOAD);
 	}
 }
 
@@ -414,6 +691,11 @@ void preload_resources(ResourceType type, ResourceFlags flags, const char *first
 }
 
 void init_resources(void) {
+	res_gstate.env.no_async_load = env_get("TAISEI_NOASYNC", false);
+	res_gstate.env.no_preload = env_get("TAISEI_NOPRELOAD", false);
+	res_gstate.env.no_unload = env_get("TAISEI_NOUNLOAD", false);
+	res_gstate.env.preload_required = env_get("TAISEI_PRELOAD_REQUIRED", false);
+
 	for(int i = 0; i < RES_NUMTYPES; ++i) {
 		ResourceHandler *h = get_handler(i);
 		alloc_handler(h);
@@ -423,7 +705,7 @@ void init_resources(void) {
 		}
 	}
 
-	if(!env_get("TAISEI_NOASYNC", 0)) {
+	if(!res_gstate.env.no_async_load) {
 		EventHandler h = {
 			.proc = resource_asyncload_handler,
 			.priority = EPRIO_SYSTEM,
@@ -436,11 +718,14 @@ void init_resources(void) {
 
 void resource_util_strip_ext(char *path) {
 	char *dot = strrchr(path, '.');
-	if(dot > strrchr(path, '/'))
+	char *psep = strrchr(path, '/');
+
+	if(dot && (!psep || dot > psep)) {
 		*dot = 0;
+	}
 }
 
-char* resource_util_basename(const char *prefix, const char *path) {
+char *resource_util_basename(const char *prefix, const char *path) {
 	assert(strstartswith(path, prefix));
 
 	char *out = strdup(path + strlen(prefix));
@@ -449,7 +734,7 @@ char* resource_util_basename(const char *prefix, const char *path) {
 	return out;
 }
 
-const char* resource_util_filename(const char *path) {
+const char *resource_util_filename(const char *path) {
 	char *sep = strrchr(path, '/');
 
 	if(sep) {
@@ -459,19 +744,30 @@ const char* resource_util_filename(const char *path) {
 	return path;
 }
 
-static void* preload_shaders(const char *path, void *arg) {
-	if(!_handlers[RES_SHADER_PROGRAM]->procs.check(path)) {
-		return NULL;
+static void preload_path(const char *path, ResourceType type, ResourceFlags flags) {
+	if(_handlers[type]->procs.check(path)) {
+		char *name = get_name_from_path(_handlers[type], path);
+		if(name) {
+			preload_resource(type, name, flags);
+			free(name);
+		}
 	}
+}
 
-	char *name = resource_util_basename(SHPROG_PATH_PREFIX, path);
-	preload_resource(RES_SHADER_PROGRAM, name, RESF_PERMANENT);
-	free(name);
+static void *preload_shaders(const char *path, void *arg) {
+	preload_path(path, RES_SHADER_PROGRAM, RESF_PERMANENT);
+	return NULL;
+}
+
+static void *preload_all(const char *path, void *arg) {
+	for(ResourceType t = 0; t < RES_NUMTYPES; ++t) {
+		preload_path(path, t, RESF_PERMANENT | RESF_OPTIONAL);
+	}
 
 	return NULL;
 }
 
-void* resource_for_each(ResourceType type, void* (*callback)(const char *name, Resource *res, void *arg), void *arg) {
+void *resource_for_each(ResourceType type, void* (*callback)(const char *name, Resource *res, void *arg), void *arg) {
 	ht_str2ptr_ts_iter_t iter;
 	ht_iter_begin(&get_handler(type)->private.mapping, &iter);
 	void *result = NULL;
@@ -508,13 +804,30 @@ void load_resources(void) {
 	menu_preload();
 
 	if(env_get("TAISEI_PRELOAD_SHADERS", 0)) {
-		log_warn("Loading all shaders now due to TAISEI_PRELOAD_SHADERS");
+		log_info("Loading all shaders now due to TAISEI_PRELOAD_SHADERS");
 		vfs_dir_walk(SHPROG_PATH_PREFIX, preload_shaders, NULL);
+	}
+
+	if(env_get("TAISEI_AGGRESSIVE_PRELOAD", 0)) {
+		log_info("Attempting to load all resources now due to TAISEI_AGGRESSIVE_PRELOAD");
+		vfs_dir_walk("res/", preload_all, NULL);
 	}
 }
 
 void free_resources(bool all) {
 	ht_str2ptr_ts_iter_t iter;
+
+	for(ResourceType type = 0; type < RES_NUMTYPES; ++type) {
+		ResourceHandler *handler = get_handler(type);
+
+		ht_iter_begin(&handler->private.mapping, &iter);
+
+		for(; iter.has_data; ht_iter_next(&iter)) {
+			wait_for_resource_load(iter.value, 0);
+		}
+
+		ht_iter_end(&iter);
+	}
 
 	for(ResourceType type = 0; type < RES_NUMTYPES; ++type) {
 		ResourceHandler *handler = get_handler(type);
@@ -575,7 +888,7 @@ void free_resources(bool all) {
 		return;
 	}
 
-	if(!env_get("TAISEI_NOASYNC", 0)) {
+	if(!res_gstate.env.no_async_load) {
 		events_unregister_handler(resource_asyncload_handler);
 	}
 }

--- a/src/resource/sprite.h
+++ b/src/resource/sprite.h
@@ -62,16 +62,11 @@ FloatRect sprite_denormalized_tex_coords(const Sprite *restrict spr);
 IntRect sprite_denormalized_int_tex_coords(const Sprite *restrict spr);
 void sprite_set_denormalized_tex_coords(Sprite *restrict spr, FloatRect tc);
 
-char *sprite_path(const char *name);
-void *load_sprite_begin(const char *path, uint flags);
-void *load_sprite_end(void *opaque, const char *path, uint flags);
-bool check_sprite_path(const char *path);
-
 void draw_sprite(float x, float y, const char *name);
 void draw_sprite_p(float x, float y, Sprite *spr);
 
 INLINE Sprite *get_sprite(const char *name) {
-	return get_resource_data(RES_SPRITE, name, RESF_DEFAULT | RESF_UNSAFE);
+	return get_resource_data(RES_SPRITE, name, RESF_DEFAULT);
 }
 
 Sprite *prefix_get_sprite(const char *name, const char *prefix);

--- a/src/taskmanager.h
+++ b/src/taskmanager.h
@@ -24,7 +24,7 @@ typedef enum TaskStatus {
 	TASK_FINISHED,   /** Task has finished executing and has been removed from the queue */
 } TaskStatus;
 
-typedef void* (*task_func_t)(void *userdata);
+typedef void *(*task_func_t)(void *userdata);
 typedef void (*task_free_func_t)(void *userdata);
 
 /**
@@ -76,7 +76,7 @@ typedef struct TaskParams {
  * On success, returns a pointer to the created TaskManager.
  * On failure, returns NULL.
  */
-TaskManager* taskmgr_create(uint numthreads, SDL_ThreadPriority prio, const char *name)
+TaskManager *taskmgr_create(uint numthreads, SDL_ThreadPriority prio, const char *name)
 	attr_nodiscard attr_returns_max_aligned attr_nonnull(3);
 
 /**
@@ -93,7 +93,7 @@ TaskManager* taskmgr_create(uint numthreads, SDL_ThreadPriority prio, const char
  *
  * On failure, returns NULL.
  */
-Task* taskmgr_submit(TaskManager *mgr, TaskParams params)
+Task *taskmgr_submit(TaskManager *mgr, TaskParams params)
 	attr_nonnull(1) attr_nodiscard attr_returns_max_aligned;
 
 /**
@@ -124,7 +124,8 @@ void taskmgr_abort(TaskManager *mgr)
 TaskStatus task_status(Task *task);
 
 /**
- * Wait for [task] to complete.
+ * Wait for [task] to complete. If the task is not running yet, it will be removed from the queue and
+ * executed on the current thread instead.
  *
  * On success, returns true and stores the task's return value in [result] (unless [result] is NULL).
  * On failure, returns false; [result] is left untouched.
@@ -176,6 +177,6 @@ void taskmgr_global_shutdown(void);
 /**
  * Submit a task to the global task manager. See `taskmgr_submit`.
  */
-Task* taskmgr_global_submit(TaskParams params);
+Task *taskmgr_global_submit(TaskParams params);
 
 #endif // IGUARD_taskmanager_h


### PR DESCRIPTION
* RESF_UNSAFE is removed.
* Resources that don't have to be finalized on the main thread can load completely asynchronously.
* A thread waiting for a concurrent task to complete can start executing that task itself if it hasn't started yet.
* Refactor the resource loading interface, add support for load-time dependencies.
* Main-thread finalization of asynchronously loaded resources is now spread out across multiple frames to mitigate frametime spikes.
* Remove some archaisms from the resource management code.
* Fix potential hashtable synchronization issue.
* Fix some deadlock edge cases.
* Don't spawn more worker threads than there are CPU cores (degrades performance).
* Add `TAISEI_AGGRESSIVE_PRELOAD` env variable to attempt to aggressively discover and preload every possible resource.
* Make `r_texture_fill{,_region}` expect optimal pixmaps, so that it's never forced to convert them on the main thread. The optimal format may be queried with the new `r_texture_optimal_pixmap_format_for_type` API. These functions will also no longer needlessly copy the entire image into a staging buffer - previously they did this even if no conversion was needed.
* Other random changes to facilitate the stuff above.

The overall effect is somewhat faster load times.

Of course it's still all terrible and full of lock contention because I suck at concurrent programming, but it's not worse than it was. Probably.