### PR TITLE
Switch port fixes

### DIFF
--- a/resources/meson.build
+++ b/resources/meson.build
@@ -112,6 +112,7 @@ if host_machine.system() == 'nx'
                 '--exclude', '**/meson.build',
             ],
             output : shader_pkg_zip,
+            depends : essl_targets,
             depfile : '@0@.d'.format(shader_pkg_zip),
             install : true,
             install_dir : data_path,

--- a/src/arch_switch.c
+++ b/src/arch_switch.c
@@ -78,11 +78,6 @@ void userAppInit(void) {
 
 attr_used
 void userAppExit(void) {
-	if(g_nxAtExitFn != NULL) {
-		NX_LOG("calling exit callback");
-		g_nxAtExitFn();
-		g_nxAtExitFn = NULL;
-	}
 	socketExit();
 	appletUnlockExit();
 }
@@ -99,6 +94,12 @@ int nxAtExit(nxAtExitFn fn) {
 void __attribute__((weak)) noreturn __libnx_exit(int rc);
 
 void noreturn nxExit(int rc) {
+	if(g_nxAtExitFn != NULL) {
+		NX_LOG("calling exit callback");
+		g_nxAtExitFn();
+		g_nxAtExitFn = NULL;
+	}
+
 	__libnx_exit(rc);
 }
 

--- a/src/arch_switch.c
+++ b/src/arch_switch.c
@@ -9,14 +9,17 @@
 
 #include "arch_switch.h"
 
-#include <switch/runtime/devices/socket.h>
-#include <switch/runtime/nxlink.h>
 #include <switch/services/applet.h>
 #include <switch/services/fs.h>
+#include <switch/services/ssl.h>
+#include <switch/runtime/devices/socket.h>
+#include <switch/runtime/nxlink.h>
 
 #define NX_LOG_FMT(fmt, ...) tsfprintf(stdout, "[NX] " fmt "\n", ##__VA_ARGS__)
 #define NX_LOG(str) NX_LOG_FMT("%s", str)
 #define NX_SETENV(name, val) NX_LOG_FMT("Setting env var %s to %s", name, val);env_set_string(name, val, true)
+
+uint32_t __nx_fs_num_sessions = 1;
 
 static nxAtExitFn g_nxAtExitFn = NULL;
 static char g_programDir[FS_MAX_PATH] = {0};
@@ -58,7 +61,10 @@ void userAppInit(void) {
 	NX_SETENV("EGL_LOG_LEVEL", "debug");
 	NX_SETENV("MESA_VERBOSE", "all");
 	NX_SETENV("MESA_DEBUG", "1");
+	NX_SETENV("MESA_INFO", "1");
+	NX_SETENV("MESA_GLSL", "errors");
 	NX_SETENV("NOUVEAU_MESA_DEBUG", "1");
+	NX_SETENV("LIBGL_DEBUG", "verbose");
 
 	// enable shader debugging in Nouveau:
 	NX_SETENV("NV50_PROG_OPTIMIZE", "0");


### PR DESCRIPTION
*  Corrected header includes and fs session count to match new libnx (we still don't include the whole <switch.h> to avoid name clashes)
* More env configuration added on debug builds (that helped fix the other issues)
* Game shutdown is now done before __libc_fini_array is called, which avoids
freeing the gl context resources twice (in __libc_fini_array, and in SDL_GL_DeleteContext)
* Linking with libstdc++ is required since the mesa switch portlib was updated