### PR TITLE
Experimental enemy/boss grazing

### DIFF
--- a/src/boss.c
+++ b/src/boss.c
@@ -33,7 +33,7 @@ typedef struct SpellBonus {
 
 static void calc_spell_bonus(Attack *a, SpellBonus *bonus);
 
-Boss* create_boss(char *name, char *ani, cmplx pos) {
+Boss *create_boss(char *name, char *ani, cmplx pos) {
 	Boss *boss = calloc(1, sizeof(Boss));
 
 	boss->name = strdup(name);
@@ -44,6 +44,7 @@ Boss* create_boss(char *name, char *ani, cmplx pos) {
 	aniplayer_create(&boss->ani, res_anim(strbuf), "main");
 
 	boss->birthtime = global.frames;
+	boss->next_graze = global.frames;
 	boss->zoomcolor = *RGBA(0.1, 0.2, 0.3, 1.0);
 
 	boss->ent.draw_layer = LAYER_BOSS;
@@ -1167,6 +1168,15 @@ void process_boss(Boss **pboss) {
 		}
 
 		play_sfx_ex("bossdeath", BOSS_DEATH_DELAY * 2, false);
+	}
+
+	if(boss_is_player_collision_active(boss)) {
+		player_try_enemy_collision(
+			&global.plr,
+			(Circle) { boss->pos, BOSS_HURT_RADIUS },
+			&boss->next_graze,
+			&boss->glowcolor
+		);
 	}
 
 	if(boss_is_player_collision_active(boss) && cabs(boss->pos - global.plr.pos) < BOSS_HURT_RADIUS) {

--- a/src/boss.h
+++ b/src/boss.h
@@ -144,6 +144,7 @@ DEFINE_ENTITY_TYPE(Boss, {
 	int failed_spells;
 	int lastdamageframe; // used to make the boss blink on damage taken
 	int birthtime;
+	int next_graze;
 
 	BossRule global_rule;
 

--- a/src/enemy.c
+++ b/src/enemy.c
@@ -87,6 +87,7 @@ Enemy *create_enemy_p(EnemyList *enemies, cmplx pos, float hp, EnemyVisualRule v
 	e->dir = 0;
 
 	e->birthtime = global.frames;
+	e->next_graze = global.frames;
 	e->pos = pos;
 	e->pos0 = pos;
 	e->pos0_visual = pos;
@@ -162,7 +163,7 @@ static void enemy_death_effect(cmplx pos) {
 	);
 }
 
-static void* _delete_enemy(ListAnchor *enemies, List* enemy, void *arg) {
+static void *_delete_enemy(ListAnchor *enemies, List* enemy, void *arg) {
 	Enemy *e = (Enemy*)enemy;
 
 	if(e->hp <= 0 && !(e->flags & EFLAG_NO_DEATH_EXPLOSION)) {
@@ -431,10 +432,14 @@ void process_enemies(EnemyList *enemies) {
 
 		int action = enemy_call_logic_rule(enemy, global.frames - enemy->birthtime);
 
-		float hurt_radius = enemy_get_hurt_radius(enemy);
-
-		if(hurt_radius > 0 && cabs(enemy->pos - global.plr.pos) < hurt_radius) {
-			ent_damage(&global.plr.ent, &(DamageInfo) { .type = DMG_ENEMY_COLLISION });
+		real hurt_radius = enemy_get_hurt_radius(enemy);
+		if(hurt_radius > 0) {
+			player_try_enemy_collision(
+				&global.plr,
+				(Circle) { enemy->pos, hurt_radius },
+				&enemy->next_graze,
+				RGBA(1, 0.3 * rng_real(), 0, 0)
+			);
 		}
 
 		enemy->alpha = approach(enemy->alpha, 1.0, 1.0/60.0);

--- a/src/enemy.h
+++ b/src/enemy.h
@@ -79,6 +79,7 @@ DEFINE_ENTITY_TYPE(Enemy, {
 
 	int birthtime;
 	int dir;
+	int next_graze;
 
 	float spawn_hp;
 	float hp;

--- a/src/player.h
+++ b/src/player.h
@@ -203,6 +203,7 @@ void player_move(Player*, cmplx delta);
 void player_realdeath(Player*);
 void player_death(Player*);
 void player_graze(Player *plr, cmplx pos, int pts, int effect_intensity, const Color *color);
+void player_try_enemy_collision(Player *plr, Circle enemy, int *graze_timer, const Color *graze_color);
 
 void player_event(Player *plr, uint8_t type, uint16_t value, bool *out_useful, bool *out_cheat);
 bool player_event_with_replay(Player *plr, uint8_t type, uint16_t value);


### PR DESCRIPTION
Works similarly to laser grazing, i.e. it's continuous while the player is near an enemy. Intended mostly as a way to gain power and maintain surge during downtime or low density patterns, especially on the lower difficulties.