### PR TITLE
Stop vendoring cglm

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,7 @@ jobs:
       run: sudo apt update && sudo apt install build-essential libsdl2-dev libogg-dev libopusfile-dev libpng-dev libzip-dev libx11-dev libwayland-dev python3-docutils libwebp-dev libfreetype6-dev libzstd-dev
 
     - name: Configure - Step 1 (Meson)
-      run: meson setup --prefix=$(pwd)/build-test --wrap-mode=nofallback build/ -Db_lto=false -Dstrip=false -Ddeprecation_warnings=no-error -Dwerror=true -Db_pch=false
+      run: meson setup --prefix=$(pwd)/build-test --wrap-mode=nofallback --force-fallback-for=cglm build/ -Db_lto=false -Dstrip=false -Ddeprecation_warnings=no-error -Dwerror=true -Db_pch=false
 
     - name: Build - Step 2 (Ninja)
       run: meson compile -C build/
@@ -86,7 +86,7 @@ jobs:
       run: pip install zstandard
 
     - name: Configure - Step 1 (Meson)
-      run: meson setup --prefix=$(pwd)/build-test --wrap-mode=nofallback build/ -Db_lto=false -Dstrip=false -Ddeprecation_warnings=no-error -Dwerror=true -Db_pch=false
+      run: meson setup --prefix=$(pwd)/build-test --wrap-mode=nofallback --force-fallback-for=cglm build/ -Db_lto=false -Dstrip=false -Ddeprecation_warnings=no-error -Dwerror=true -Db_pch=false
 
     - name: Build - Step 2 (Ninja)
       run: meson compile -C build/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,3 @@
-[submodule "cglm"]
-	path = external/cglm
-	url = https://github.com/taisei-project/cglm.git
-	branch = taisei
 [submodule "gamecontrollerdb"]
 	path = external/gamecontrollerdb
 	url = https://github.com/taisei-project/SDL_GameControllerDB.git

--- a/README.rst
+++ b/README.rst
@@ -16,6 +16,7 @@ Dependencies
 ^^^^^^^^^^^^
 
 -  OpenGL >= 3.3 or OpenGL ES >= 3.0 or OpenGL ES >= 2.0 (with some extensions)
+-  `cglm <https://github.com/recp/cglm>`__ >= 0.7.8
 -  SDL2 >= 2.0.6
 -  freetype2
 -  libpng >= 1.5.0

--- a/meson.build
+++ b/meson.build
@@ -10,6 +10,9 @@ project('taisei', 'c',
 
         'koishi:threadsafe=false',
 
+        'cglm:install=false',
+        'cglm:build_tests=false',
+
         'libzip:bzip2=disabled',
         'libzip:lzma=disabled',
         'libzip:zstd=enabled',
@@ -154,13 +157,13 @@ dep_webpdecoder = dependency('libwebpdecoder', version : '>=0.5',   required : f
 dep_zlib        = dependency('zlib',                                required : true,  static : static, fallback : ['zlib', 'zlib_dep'])
 dep_zstd        = dependency('libzstd',        version : '>=1.3.0', required : true,  static : static, fallback : ['libzstd', 'libzstd_dep'])
 dep_zip         = dependency('libzip',         version : '>=1.7',   required : false, static : static, fallback : ['libzip', 'libzip_dep'])
+dep_cglm        = dependency('cglm',           version : '>=0.7.8', required : true,  static : static, fallback : ['cglm', 'cglm_dep'])
 dep_crypto      = dependency('libcrypto',                           required : false, static : static)
 dep_gamemode    = dependency('gamemode',                            required : false, static : static)
 
 dep_m           = cc.find_library('m', required : false)
 
 dep_basisu_transcoder = subproject('basis_universal').get_variable('basisu_transcoder_dep')
-dep_cglm        = subproject('cglm').get_variable('cglm_dep')
 dep_glad        = subproject('glad').get_variable('glad_dep')
 dep_koishi      = subproject('koishi').get_variable('koishi_dep')
 

--- a/src/util/glm.h
+++ b/src/util/glm.h
@@ -17,17 +17,10 @@
 
 #include "util.h"
 
-#define TAISEI_USE_GLM_CALLS
-
-#ifdef TAISEI_USE_GLM_CALLS
-    #include <cglm/call.h>
-    #include <cglm/glm2call.h>
-#else
-    PRAGMA(GCC diagnostic push)
-    PRAGMA(GCC diagnostic ignored "-Wdeprecated-declarations")
-    #include <cglm/cglm.h>
-    PRAGMA(GCC diagnostic pop)
-#endif
+DIAGNOSTIC(push)
+DIAGNOSTIC(ignored "-Wdeprecated-declarations")
+#include <cglm/cglm.h>
+DIAGNOSTIC(pop)
 
 typedef float (*glm_ease_t)(float);
 

--- a/subprojects/.gitignore
+++ b/subprojects/.gitignore
@@ -1,6 +1,7 @@
 SPIRV-Cross
 SPIRV-Headers
 SPIRV-Tools
+cglm
 crossc
 freetype
 glslang

--- a/subprojects/cglm
+++ b/subprojects/cglm
@@ -1,1 +1,0 @@
-../external/cglm

--- a/subprojects/cglm.wrap
+++ b/subprojects/cglm.wrap
@@ -1,0 +1,5 @@
+[wrap-git]
+directory=cglm
+url=https://github.com/taisei-project/cglm.git
+push-url=git@github.com:taisei-project/cglm.git
+revision=taisei-0.8.0


### PR DESCRIPTION
* Remove cglm from submodules
* Add cglm to list of dependencies
* Prefer system version of cglm, with a wrap fallback (as with other dependencies)