### PR TITLE
Asynchronous logging

### DIFF
--- a/doc/ENVIRON.rst
+++ b/doc/ENVIRON.rst
@@ -246,17 +246,45 @@ The levels
 The variables
 ^^^^^^^^^^^^^
 
--  **TAISEI_LOGLVLS_CONSOLE**: controls what goes to the console, both
-   ``stdout`` and ``stderr``. Defaults to *All* (``+a``). This is a
-   master switch for the two variables below:
+**TAISEI_LOGLVLS_CONSOLE**
+   | Default: ``+a`` *(All)*
 
-   -  **TAISEI_LOGLVLS_STDOUT**: controls what goes to standard output.
-      Defaults to *Debug and Info* (``+di``).
-   -  **TAISEI_LOGLVLS_STDERR**: controls what goes to standard error.
-      Defaults to *Warning, Error, and Fatal* (``+wef``).
+   Controls what log levels may go to the console. This acts as a master
+   switch for **TAISEI_LOGLVLS_STDOUT** and **TAISEI_LOGLVLS_STDERR**.
 
--  **TAISEI_LOGLVLS_FILE**: controls what goes into the log file
-   (``{storage directory}/log.txt``). Defaults to *All* (``+a``).
+**TAISEI_LOGLVLS_STDOUT**
+   | Default: ``+di`` *(Debug, Info)*
+
+   Controls what log levels go to standard output. Log levels that are
+   disabled by **TAISEI_LOGLVLS_CONSOLE** are ignored.
+
+**TAISEI_LOGLVLS_STDERR**
+   | Default: ``+wef`` *(Warning, Error, Fatal)*
+
+   Controls what log levels go to standard error. Log levels that are
+   disabled by **TAISEI_LOGLVLS_CONSOLE** are ignored.
+
+**TAISEI_LOGLVLS_FILE**
+   | Default: ``+a`` *(All)*
+
+   Controls what log levels go to the log file
+   (``{storage directory}/log.txt``).
+
+**TAISEI_LOG_ASYNC**
+   | Default: ``1``
+
+   If ``1``, log messages are written asynchronously from a background
+   thread. This mostly benefits platforms where writing to the console
+   or files is very slow (such as Windows). You may want to disable this
+   when debugging.
+
+**TAISEI_LOG_ASYNC_FAST_SHUTDOWN**
+   | Default: ``0``
+
+   If ``1``, don't wait for the whole log queue to be written when
+   shutting down. This will make the game quit faster if log writing is
+   slow, at the expense of log integrity. Ignored if ``TAISEI_LOG_ASYNC``
+   is disabled.
 
 Examples
 ^^^^^^^^

--- a/src/log.c
+++ b/src/log.c
@@ -144,7 +144,7 @@ static void log_dispatch(LogEntry *entry) {
 		if(l->levels & entry->level) {
 			strbuf_clear(fmt_buf);
 			size_t slen = l->formatter.format(&l->formatter, fmt_buf, entry);
-			assert(fmt_buf->buf_size >= slen);
+			assert_nolog(fmt_buf->buf_size >= slen);
 			SDL_RWwrite(l->out, fmt_buf->start, 1, slen);
 		}
 	}

--- a/src/log.c
+++ b/src/log.c
@@ -14,6 +14,7 @@
 #include "log.h"
 #include "util.h"
 #include "list.h"
+#include "util/strbuf.h"
 
 typedef struct Logger {
 	LIST_INTERFACE(struct Logger);
@@ -26,16 +27,20 @@ typedef struct Logger {
 typedef struct QueuedLogEntry {
 	LIST_INTERFACE(struct QueuedLogEntry);
 	LogEntry e;
+	char message[];
 } QueuedLogEntry;
 
 static struct {
 	Logger *outputs;
 	size_t num_outputs;
-	char *fmt_buf1;
-	char *fmt_buf2;
 	size_t fmt_buf_size;
 	SDL_mutex *mutex;
 	uint enabled_log_levels;
+
+	struct {
+		StringBuffer pre_format;
+		StringBuffer format;
+	} buffers;
 
 	struct {
 		SDL_Thread *thread;
@@ -116,69 +121,31 @@ void log_set_gui_error_appendix(const char *message) {
 #endif
 }
 
-static void realloc_buffers(size_t min_size) {
-	min_size = topow2_u64(min_size);
-
-	if(min_size > MAX_BUF_SIZE) {
-		min_size = MAX_BUF_SIZE;
-	}
-
-	if(logging.fmt_buf_size >= min_size) {
-		return;
-	}
-
-	logging.fmt_buf1 = realloc(logging.fmt_buf1, min_size);
-	logging.fmt_buf2 = realloc(logging.fmt_buf2, min_size);
-	logging.fmt_buf_size = min_size;
-}
-
-static void add_debug_info(char **buf) {
+static void add_debug_info(StringBuffer *buf) {
 	IF_DEBUG({
 		DebugInfo *debug_info = get_debug_info();
 		DebugInfo *debug_meta = get_debug_meta();
 
-		char *dbg = strfmt(
-			"%s\n\n\n"
+		strbuf_printf(buf,
+			"\n\n\n"
 			"Debug info: %s:%i:%s\n"
 			"Debug info set at: %s:%i:%s\n"
 			"Note: debug info may not be relevant to this issue\n",
-			*buf,
 			debug_info->file, debug_info->line, debug_info->func,
 			debug_meta->file, debug_meta->line, debug_meta->func
 		);
-
-		free(*buf);
-		*buf = dbg;
 	});
 }
 
 static void log_dispatch(LogEntry *entry) {
+	StringBuffer *fmt_buf = &logging.buffers.format;
+
 	for(Logger *l = logging.outputs; l; l = l->next) {
 		if(l->levels & entry->level) {
-			size_t slen = l->formatter.format(&l->formatter, logging.fmt_buf2, logging.fmt_buf_size, entry);
-
-			if(slen >= logging.fmt_buf_size) {
-				{
-					char tmp[strlen(logging.fmt_buf1) + 1];
-					strcpy(tmp, logging.fmt_buf1);
-					realloc_buffers(slen + 1);
-					strcpy(logging.fmt_buf1, tmp);
-				}
-
-				entry->message = logging.fmt_buf1;
-
-				attr_unused int old_slen = slen;
-				slen = l->formatter.format(&l->formatter, logging.fmt_buf2, logging.fmt_buf_size, entry);
-				assert_nolog(old_slen == slen);
-			}
-
-			assert_nolog(slen >= 0);
-
-			if(logging.fmt_buf_size < slen) {
-				slen = logging.fmt_buf_size;
-			}
-
-			SDL_RWwrite(l->out, logging.fmt_buf2, 1, slen);
+			strbuf_clear(fmt_buf);
+			size_t slen = l->formatter.format(&l->formatter, fmt_buf, entry);
+			assert(fmt_buf->buf_size >= slen);
+			SDL_RWwrite(l->out, fmt_buf->start, 1, slen);
 		}
 	}
 }
@@ -186,8 +153,11 @@ static void log_dispatch(LogEntry *entry) {
 static void log_dispatch_async(LogEntry *entry) {
 	for(Logger *l = logging.outputs; l; l = l->next) {
 		if(l->levels & entry->level) {
-			QueuedLogEntry *qle = calloc(1, sizeof( *qle));
+			size_t msg_len = strlen(entry->message);
+			QueuedLogEntry *qle = calloc(1, sizeof(*qle) + msg_len + 1);
 			memcpy(&qle->e, entry, sizeof(*entry));
+			memcpy(qle->message, entry->message, msg_len);
+			qle->e.message = qle->message;
 			SDL_LockMutex(logging.queue.mutex);
 			alist_append(&logging.queue.queue, qle);
 			SDL_CondSignal(logging.queue.cond);
@@ -195,7 +165,6 @@ static void log_dispatch_async(LogEntry *entry) {
 			break;
 		}
 	}
-
 }
 
 static void log_internal(LogLevel lvl, const char *funcname, const char *filename, uint line, const char *fmt, va_list args) {
@@ -210,26 +179,21 @@ static void log_internal(LogLevel lvl, const char *funcname, const char *filenam
 
 	SDL_LockMutex(logging.mutex);
 
+	StringBuffer *buf = &logging.buffers.pre_format;
+	strbuf_clear(buf);
+
 	va_list args_copy;
 	va_copy(args_copy, args);
-	int slen = vsnprintf(logging.fmt_buf1, logging.fmt_buf_size, fmt, args_copy);
+	int slen = strbuf_vprintf(buf, fmt, args_copy);
 	va_end(args_copy);
-
-	if(slen >= logging.fmt_buf_size) {
-		realloc_buffers(slen + 1);
-		va_copy(args_copy, args);
-		slen = vsnprintf(logging.fmt_buf1, logging.fmt_buf_size, fmt, args_copy);
-		va_end(args_copy);
-	}
-
 	assert_nolog(slen >= 0);
 
 	if(lvl & LOG_FATAL) {
-		add_debug_info(&logging.fmt_buf1);
+		add_debug_info(buf);
 	}
 
 	LogEntry entry = {
-		.message = logging.fmt_buf1,
+		.message = buf->start,
 		.file = filename,
 		.func = funcname,
 		.line = line,
@@ -349,7 +313,6 @@ static void log_queue_shutdown(void) {
 void log_init(LogLevel lvls) {
 	logging.enabled_log_levels = lvls;
 	logging.mutex = SDL_CreateMutex();
-	realloc_buffers(INIT_BUF_SIZE);
 	log_queue_init();
 }
 
@@ -357,8 +320,8 @@ void log_shutdown(void) {
 	log_queue_shutdown();
 	list_foreach(&logging.outputs, delete_logger, NULL);
 	SDL_DestroyMutex(logging.mutex);
-	free(logging.fmt_buf1);
-	free(logging.fmt_buf2);
+	strbuf_free(&logging.buffers.pre_format);
+	strbuf_free(&logging.buffers.format);
 
 #ifdef LOG_FATAL_MSGBOX
 	free(logging.err_appendix);
@@ -427,16 +390,9 @@ LogLevel log_parse_levels(LogLevel lvls, const char *lvlmod) {
 	return lvls;
 }
 
-static void ensure_newline(char *buf, size_t buf_size, size_t output_size) {
-	if(output_size >= buf_size) {
-		*(strrchr(buf, '\0') - 1) = '\n';
-	}
-}
-
-static int log_fmtconsole_format_ansi(FormatterObj *obj, char *buf, size_t buf_size, LogEntry *entry) {
-	int r = snprintf(
+static int log_fmtconsole_format_ansi(FormatterObj *obj, StringBuffer *buf, LogEntry *entry) {
+	return strbuf_printf(
 		buf,
-		buf_size,
 		"\x1b[1;30m%-9d %s%s\x1b[1;30m: \x1b[1;34m%s\x1b[1;30m: \x1b[0m%s\n",
 		entry->time,
 		level_ansi_style_code(entry->level),
@@ -444,22 +400,17 @@ static int log_fmtconsole_format_ansi(FormatterObj *obj, char *buf, size_t buf_s
 		entry->func,
 		entry->message
 	);
-	ensure_newline(buf, buf_size, r);
-	return r;
 }
 
-static int log_fmtconsole_format_plain(FormatterObj *obj, char *buf, size_t buf_size, LogEntry *entry) {
-	int r = snprintf(
+static int log_fmtconsole_format_plain(FormatterObj *obj, StringBuffer *buf, LogEntry *entry) {
+	return strbuf_printf(
 		buf,
-		buf_size,
 		"%-9d %s: %s: %s\n",
 		entry->time,
 		level_prefix(entry->level),
 		entry->func,
 		entry->message
 	);
-	ensure_newline(buf, buf_size, r);
-	return r;
 }
 
 #ifdef TAISEI_BUILDCONF_HAVE_POSIX
@@ -491,18 +442,15 @@ void log_formatter_console(FormatterObj *obj, const SDL_RWops *output) {
 	}
 }
 
-static int log_fmtfile_format(FormatterObj *obj, char *buf, size_t buf_size, LogEntry *entry) {
-	int r = snprintf(
+static int log_fmtfile_format(FormatterObj *obj, StringBuffer *buf, LogEntry *entry) {
+	return strbuf_printf(
 		buf,
-		buf_size,
 		"%d  %s  %s: %s\n",
 		entry->time,
 		level_name(entry->level),
 		entry->func,
 		entry->message
 	);
-	ensure_newline(buf, buf_size, r);
-	return r;
 }
 
 void log_formatter_file(FormatterObj *obj, const SDL_RWops *output) {

--- a/src/log.h
+++ b/src/log.h
@@ -117,6 +117,7 @@ void log_backtrace(LogLevel lvl);
 LogLevel log_parse_levels(LogLevel lvls, const char *lvlmod) attr_nodiscard;
 bool log_initialized(void) attr_nodiscard;
 void log_set_gui_error_appendix(const char *message);
+void log_sync(void);
 
 #if defined(DEBUG) && !defined(__EMSCRIPTEN__)
 	#define log_debug(...) log_custom(LOG_DEBUG, __VA_ARGS__)

--- a/src/log.h
+++ b/src/log.h
@@ -13,6 +13,8 @@
 
 #include <SDL.h>
 
+#include "util/strbuf.h"
+
 enum {
 	_LOG_DEBUG_ID,
 	_LOG_INFO_ID,
@@ -97,7 +99,7 @@ typedef struct LogEntry {
 typedef struct FormatterObj FormatterObj;
 
 struct FormatterObj {
-	int (*format)(FormatterObj *self, char *buf, size_t buf_size, LogEntry *entry);
+	int (*format)(FormatterObj *self, StringBuffer *buffer, LogEntry *entry);
 	void (*free)(FormatterObj *self);
 	void *data;
 };

--- a/src/util/assert.c
+++ b/src/util/assert.c
@@ -17,6 +17,7 @@ void _ts_assert_fail(const char *cond, const char *func, const char *file, int l
 
 	if(use_log) {
 		_taisei_log(LOG_FAKEFATAL, func, file, line, "%s:%i: assertion `%s` failed", file, line, cond);
+		log_sync();
 	} else {
 		tsfprintf(stderr, "%s:%i: %s(): assertion `%s` failed\n", file, line, func, cond);
 	}

--- a/src/util/strbuf.c
+++ b/src/util/strbuf.c
@@ -56,7 +56,10 @@ int strbuf_vprintf(StringBuffer *strbuf, const char *format, va_list args) {
 
 void strbuf_clear(StringBuffer *strbuf) {
 	strbuf->pos = strbuf->start;
-	*strbuf->pos = 0;
+
+	if(strbuf->start) {
+		*strbuf->pos = 0;
+	}
 }
 
 void strbuf_free(StringBuffer *strbuf) {

--- a/src/util/strbuf.c
+++ b/src/util/strbuf.c
@@ -23,10 +23,10 @@ int strbuf_printf(StringBuffer *strbuf, const char *format, ...) {
 
 int strbuf_vprintf(StringBuffer *strbuf, const char *format, va_list args) {
 	ptrdiff_t offset = strbuf->pos - strbuf->start;
-	assume(offset >= 0);
+	assume_nolog(offset >= 0);
 
 	ptrdiff_t size_available = strbuf->buf_size - offset;
-	assume(size_available >= 0);
+	assume_nolog(size_available >= 0);
 
 	va_list args_copy;
 	va_copy(args_copy, args);
@@ -34,7 +34,7 @@ int strbuf_vprintf(StringBuffer *strbuf, const char *format, va_list args) {
 	va_end(args_copy);
 
 	if(size_required >= size_available) {
-		size_t new_size = topow2_u64(strbuf->buf_size + (size_required - size_available));
+		size_t new_size = topow2_u64(strbuf->buf_size + (size_required - size_available + 1));
 		strbuf->start = realloc(strbuf->start, new_size);
 		strbuf->pos = strbuf->start + offset;
 		strbuf->buf_size = new_size;
@@ -45,11 +45,11 @@ int strbuf_vprintf(StringBuffer *strbuf, const char *format, va_list args) {
 		size_required = vsnprintf(strbuf->pos, size_available, format, args_copy);
 		va_end(args_copy);
 
-		assume(size_required < size_available);
+		assume_nolog(size_required < size_available);
 	}
 
 	strbuf->pos += size_required;
-	assume(*strbuf->pos == 0);
+	assume_nolog(*strbuf->pos == 0);
 
 	return size_required;
 }


### PR DESCRIPTION
Put all log messages into a queue. A background thread will format and dispatch the messages to loggers in a first-in-first-out fashion. This is mostly useful for windows/wine, or in cases of *very* spammy logging. This adds some malloc overhead, however.

Can be disabled with `TAISEI_LOG_ASYNC=0`.

This also updates the logging module to use the new `StringBuffer` facility, and fixes some dumb bugs in it.