### PR TITLE
docs: fix simple typo, pendatic -> pedantic

### DIFF
--- a/src/renderer/gl33/shader_program.c
+++ b/src/renderer/gl33/shader_program.c
@@ -351,7 +351,7 @@ static bool cache_uniforms(ShaderProgram *prog) {
 		uni.cache.update_first_idx = uni.array_size;
 
 		if(glext.version.is_webgl) {
-			// Some browsers are pendatic about getting a null in GLctx.getUniform(),
+			// Some browsers are pedantic about getting a null in GLctx.getUniform(),
 			// so we'd have to be very careful and query each array index with
 			// glGetUniformLocation in order to avoid an exception. Which is too much
 			// hassle, so instead here's a hack that fills initial cache state with


### PR DESCRIPTION
There is a small typo in src/renderer/gl33/shader_program.c.

Should read `pedantic` rather than `pendatic`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md