### PR TITLE
Reduce compile-time noise with `libzip` and `clang`

### DIFF
--- a/src/vfs/zipfile_impl.h
+++ b/src/vfs/zipfile_impl.h
@@ -11,7 +11,11 @@
 
 #include "taisei.h"
 
+// libzip on clang creates useless noise
+DIAGNOSTIC_CLANG(push)
+DIAGNOSTIC_CLANG(ignored "-Wnullability-extension")
 #include <zip.h>
+DIAGNOSTIC_CLANG(pop)
 
 #include "private.h"
 #include "hashtable.h"


### PR DESCRIPTION
Simple enough fix to make `libzip` stop throwing so many useless notices/warnings on compile, with some distributions of `libzip`.