### PR TITLE
Fix build warnings for `clang`

### DIFF
--- a/src/audio/stream/stream_opus.c
+++ b/src/audio/stream/stream_opus.c
@@ -93,7 +93,7 @@ static const char *astream_opus_meta(AudioStream *s, AudioStreamMetaTag tag) {
 		[STREAM_META_COMMENT] = "DESCRIPTION=",
 	};
 
-	uint idx = tag;
+	attr_unused uint idx = tag;
 	assert(idx < ARRAY_SIZE(tag_map));
 
 	return get_opus_tag(of, tag_map[tag]);

--- a/src/log.c
+++ b/src/log.c
@@ -188,7 +188,7 @@ static void log_internal(LogLevel lvl, const char *funcname, const char *filenam
 
 	va_list args_copy;
 	va_copy(args_copy, args);
-	int slen = strbuf_vprintf(buf, fmt, args_copy);
+	attr_unused int slen = strbuf_vprintf(buf, fmt, args_copy);
 	va_end(args_copy);
 	assert_nolog(slen >= 0);
 

--- a/src/pixmap/loaders/loader_png.c
+++ b/src/pixmap/loaders/loader_png.c
@@ -88,7 +88,7 @@ static bool px_png_load(SDL_RWops *stream, Pixmap *pixmap, PixmapFormat preferre
 	int num_passes = png_set_interlace_handling(png);
 	png_read_update_info(png, png_info);
 
-	png_byte channels = png_get_channels(png, png_info);
+	attr_unused png_byte channels = png_get_channels(png, png_info);
 	color_type = png_get_color_type(png, png_info);
 	bit_depth = png_get_bit_depth(png, png_info);
 


### PR DESCRIPTION
Small fixes to help get `clang` compiling warning-free, so `-Dwerror` can be enabled on the GitHub Actions pipeline. (#266)