### PR TITLE
renderer,gl33: expose new magic uniforms; see render_context.glslh

### DIFF
--- a/resources/00-taisei.pkgdir/shader/lib/render_context.glslh
+++ b/resources/00-taisei.pkgdir/shader/lib/render_context.glslh
@@ -9,4 +9,19 @@ UNIFORM(513) mat4 r_projectionMatrix;
 UNIFORM(514) mat4 r_textureMatrix;
 UNIFORM(515) vec4 r_color;
 
+// Active viewport, i.e. the region we're rendering into.
+// xy = offset, zw = width and height.
+// Units are real pixels.
+UNIFORM(516) vec4 r_viewport;
+
+// Size(s) of output buffer(s) we're rendering into, in real pixels.
+// A size of 0,0 means the buffer is not attached.
+//
+// Note that r_colorOutputSizes is not a direct mapping to framebuffer attachments;
+// it is affected by the output -> attachment mapping (see r_framebuffer_set_output_attachments).
+// This means that r_colorOutputSizes[N] always corresponds to fragment shader output #N, which
+// is probably what you'd expect.
+UNIFORM(517) vec2 r_colorOutputSizes[4];  // NOTE: should match FRAMEBUFFER_MAX_OUTPUTS in renderer/api.h
+UNIFORM(521) vec2 r_depthOutputSize;
+
 #endif

--- a/src/renderer/api.h
+++ b/src/renderer/api.h
@@ -547,7 +547,7 @@ void _r_uniform_ptr_float_array(Uniform *uniform, uint offset, uint count, float
 void _r_uniform_float_array(const char *uniform, uint offset, uint count, float elements[count]) attr_nonnull(1, 4);
 #define r_uniform_float_array(uniform, ...) _R_UNIFORM_GENERIC(float_array, uniform, __VA_ARGS__)
 
-void _r_uniform_ptr_vec2(Uniform *uniform, float x, float y) attr_nonnull(1);
+void _r_uniform_ptr_vec2(Uniform *uniform, float x, float y);
 void _r_uniform_vec2(const char *uniform, float x, float y) attr_nonnull(1);
 #define r_uniform_vec2(uniform, ...) _R_UNIFORM_GENERIC(vec2, uniform, __VA_ARGS__)
 

--- a/src/renderer/gl33/shader_program.h
+++ b/src/renderer/gl33/shader_program.h
@@ -17,9 +17,24 @@
 #include "opengl.h"
 #include "resource/shader_program.h"
 
+typedef enum MagicUniformIndex {
+	UMAGIC_INVALID = -1,
+
+	UMAGIC_MATRIX_MV,
+	UMAGIC_MATRIX_PROJ,
+	UMAGIC_MATRIX_TEX,
+	UMAGIC_COLOR,
+	UMAGIC_VIEWPORT,
+	UMAGIC_COLOR_OUT_SIZES,
+	UMAGIC_DEPTH_OUT_SIZE,
+
+	NUM_MAGIC_UNIFORMS,
+} MagicUniformIndex;
+
 struct ShaderProgram {
 	GLuint gl_handle;
 	ht_str2ptr_t uniforms;
+	Uniform *magic_uniforms[NUM_MAGIC_UNIFORMS];
 	char debug_label[R_DEBUG_LABEL_SIZE];
 };
 


### PR DESCRIPTION
Also optimize access to all magic uniforms slightly.