### PR TITLE
Zstandard compression

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,8 +36,8 @@ jobs:
       with:
         python-version: '3.x'
 
-    - name: Install Meson/Ninja (Pip)
-      run: pip install meson ninja
+    - name: Install Build Tools (pip)
+      run: pip install meson ninja zstandard
 
     - name: Install Build Tools (apt)
       run: sudo apt update && sudo apt install build-essential libsdl2-dev libogg-dev libopusfile-dev libpng-dev libzip-dev libx11-dev libwayland-dev python3-docutils libwebp-dev libfreetype6-dev libzstd-dev
@@ -81,6 +81,9 @@ jobs:
 
     - name: Install Build Tools (brew)
       run: brew install gcc meson pkg-config docutils pygments freetype2 libzip opusfile libvorbis webp sdl2 ninja
+
+    - name: Install Build Tools (pip)
+      run: pip install zstandard
 
     - name: Configure - Step 1 (Meson)
       run: meson setup --prefix=$(pwd)/build-test --wrap-mode=nofallback build/ -Db_lto=false -Dstrip=false -Ddeprecation_warnings=no-error -Dwerror=true -Db_pch=false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,7 @@ jobs:
       run: pip install meson ninja
 
     - name: Install Build Tools (apt)
-      run: sudo apt update && sudo apt install build-essential libsdl2-dev libogg-dev libopusfile-dev libpng-dev libzip-dev libx11-dev libwayland-dev python3-docutils libwebp-dev libfreetype6-dev
+      run: sudo apt update && sudo apt install build-essential libsdl2-dev libogg-dev libopusfile-dev libpng-dev libzip-dev libx11-dev libwayland-dev python3-docutils libwebp-dev libfreetype6-dev libzstd-dev
 
     - name: Configure - Step 1 (Meson)
       run: meson setup --prefix=$(pwd)/build-test --wrap-mode=nofallback build/ -Db_lto=false -Dstrip=false -Ddeprecation_warnings=no-error -Dwerror=true -Db_pch=false

--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 	path = external/basis_universal
 	url = https://github.com/taisei-project/basis_universal.git
 	branch = taisei
+[submodule "external/python-zipfile-zstd"]
+	path = external/python-zipfile-zstd
+	url = https://github.com/taisei-project/python-zipfile-zstd

--- a/README.rst
+++ b/README.rst
@@ -38,6 +38,7 @@ Build-only dependencies
 
 -  Python >= 3.5
 -  meson >= 0.53.0
+-  [python-zstandard](https://github.com/indygreg/python-zstandard)
 
 Optional:
 

--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ Optional:
 Build-only dependencies
 ^^^^^^^^^^^^^^^^^^^^^^^
 
--  Python >= 3.5
+-  Python >= 3.7
 -  meson >= 0.53.0
 -  [python-zstandard](https://github.com/indygreg/python-zstandard)
 

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ Dependencies
 -  freetype2
 -  libpng >= 1.5.0
 -  libwebpdecoder >= 0.5 or libwebp >= 0.5
--  libzip >= 1.2
+-  libzip >= 1.7
 -  libzstd >= 1.3.0
 -  opusfile
 -  zlib

--- a/README.rst
+++ b/README.rst
@@ -21,6 +21,7 @@ Dependencies
 -  libpng >= 1.5.0
 -  libwebpdecoder >= 0.5 or libwebp >= 0.5
 -  libzip >= 1.2
+-  libzstd >= 1.3.0
 -  opusfile
 -  zlib
 

--- a/meson.build
+++ b/meson.build
@@ -14,6 +14,19 @@ project('taisei', 'c',
         'libzip:enable_crypto=false',
         'libzip:enable_lzma=false',
 
+        'libzstd:install_headers=false',
+        'libzstd:install_libraries=false',
+        'libzstd:install_pkgconfig=false',
+        'libzstd:legacy_level=0',
+        'libzstd:debug_level=0',
+        'libzstd:bin_programs=false',
+        'libzstd:bin_tests=false',
+        'libzstd:bin_contrib=false',
+        'libzstd:zlib=disabled',
+        'libzstd:lzma=disabled',
+        'libzstd:lz4=disabled',
+        'libzstd:multi_thread=disabled',
+
         'sdl2:use_haptic=disabled',
         'sdl2:use_power=disabled',
         'sdl2:use_render=disabled',
@@ -141,7 +154,7 @@ dep_zip         = dependency('libzip',         version : '>=1.2',   required : f
 dep_zlib        = dependency('zlib',                                required : true,  static : static, fallback : ['zlib', 'zlib_dep'])
 dep_crypto      = dependency('libcrypto',                           required : false, static : static)
 dep_gamemode    = dependency('gamemode',                            required : false, static : static)
-dep_zstd        = dependency('libzstd',        version : '>=1.3.0', required : true,  static : static)
+dep_zstd        = dependency('libzstd',        version : '>=1.3.0', required : true,  static : static, fallback : ['libzstd', 'libzstd_dep'])
 
 dep_m           = cc.find_library('m', required : false)
 

--- a/meson.build
+++ b/meson.build
@@ -141,6 +141,7 @@ dep_zip         = dependency('libzip',         version : '>=1.2',   required : f
 dep_zlib        = dependency('zlib',                                required : true,  static : static, fallback : ['zlib', 'zlib_dep'])
 dep_crypto      = dependency('libcrypto',                           required : false, static : static)
 dep_gamemode    = dependency('gamemode',                            required : false, static : static)
+dep_zstd        = dependency('libzstd',        version : '>=1.3.0', required : true,  static : static)
 
 dep_m           = cc.find_library('m', required : false)
 
@@ -159,6 +160,7 @@ taisei_deps = [
     dep_png,
     dep_sdl2,
     dep_zlib,
+    dep_zstd,
     # don't add glad here
 ]
 

--- a/meson.build
+++ b/meson.build
@@ -150,7 +150,7 @@ dep_png         = dependency('libpng',         version : '>=1.5',   required : t
 dep_sdl2        = dependency('sdl2',           version : '>=2.0.6', required : true,  static : static, fallback : ['sdl2', 'sdl2_dep'])
 dep_webp        = dependency('libwebp',        version : '>=0.5',   required : true,  static : static, fallback : ['libwebp', 'webpdecoder_dep'])
 dep_webpdecoder = dependency('libwebpdecoder', version : '>=0.5',   required : false, static : static)
-dep_zip         = dependency('libzip',         version : '>=1.2',   required : false, static : static, fallback : ['libzip', 'libzip_dep'])
+dep_zip         = dependency('libzip',         version : '>=1.7',   required : false, static : static, fallback : ['libzip', 'libzip_dep'])
 dep_zlib        = dependency('zlib',                                required : true,  static : static, fallback : ['zlib', 'zlib_dep'])
 dep_crypto      = dependency('libcrypto',                           required : false, static : static)
 dep_gamemode    = dependency('gamemode',                            required : false, static : static)

--- a/resources/00-taisei.pkgdir/.nocompress
+++ b/resources/00-taisei.pkgdir/.nocompress
@@ -1,1 +1,1 @@
-^.*\.(ttf|png|webp|ogg|opus|prog)$
+^.*\.(ttf|png|webp|ogg|opus|prog|basis|tex|font|num_slices)$

--- a/resources/meson.build
+++ b/resources/meson.build
@@ -90,6 +90,7 @@ foreach pkg : packages
             depfile : '@0@.d'.format(pkg_zip),
             install : true,
             install_dir : data_path,
+            console : true,
         )
     else
         glob_result = run_command(glob_command, pkg_path, '**/meson.build')
@@ -116,6 +117,7 @@ if host_machine.system() == 'nx'
             depfile : '@0@.d'.format(shader_pkg_zip),
             install : true,
             install_dir : data_path,
+            console : true,
         )
     else
         glob_result = run_command(glob_command, shaders_build_dir, '**/*.spv', '**/meson.build')

--- a/resources/meson.build
+++ b/resources/meson.build
@@ -17,6 +17,7 @@ if host_machine.system() == 'emscripten'
         'gfx/*.png',
         'gfx/*.webp',
         'gfx/*.basis',
+        'gfx/*.basis.zst',
         'fonts/*.ttf',
         'fonts/*.otf',
     ]

--- a/scripts/mkbasis.py
+++ b/scripts/mkbasis.py
@@ -170,8 +170,10 @@ def process(args):
         if args.uastc:
             cmd += [
                 '-uastc',
-                '-uastc_rdo_l', '1',
             ]
+
+            if args.uastc_rdo > 0:
+                cmd += ['-uastc_rdo_l', str(args.uastc_rdo)]
 
             profiles = {
                 'slow': [
@@ -416,6 +418,14 @@ def main(args):
         dest='uastc',
         help='encode to UASTC: large size, high quality; will output to .basis.zst by default',
         action='store_true',
+    )
+
+    parser.add_argument('--uastc-rdo',
+        dest='uastc_rdo',
+        help='enable Rate Distortion Optimization to improve LZ compression; larger value = worse quality/better compression; try 0.25 - 5.0 (default: 1.0)',
+        default=1.0,
+        metavar='LEVEL',
+        type=float
     )
 
     parser.add_argument('--dry-run',

--- a/scripts/mkbasis.py
+++ b/scripts/mkbasis.py
@@ -168,7 +168,10 @@ def process(args):
         ]
 
         if args.uastc:
-            cmd += ['-uastc']
+            cmd += [
+                '-uastc',
+                '-uastc_rdo_l', '1',
+            ]
 
             profiles = {
                 'slow': [
@@ -182,6 +185,7 @@ def process(args):
                 'incredibly_slow': [
                     '-mip_slow',
                     '-uastc_level', '4',
+                    '-uastc_rdo_d', '8192',
                 ],
             }
         else:

--- a/scripts/mkbasis.py
+++ b/scripts/mkbasis.py
@@ -219,6 +219,7 @@ def process(args):
             cmd = [
                 'zstd',
                 '-v',
+                '-f',
                 '-19',
                 basis_output,
                 '-o', zst_output,

--- a/scripts/mkbasis.py
+++ b/scripts/mkbasis.py
@@ -224,7 +224,8 @@ def process(args):
                 'zstd',
                 '-v',
                 '-f',
-                '-19',
+                '--ultra',
+                '-22',
                 basis_output,
                 '-o', zst_output,
             ]

--- a/scripts/pack.py
+++ b/scripts/pack.py
@@ -3,16 +3,24 @@
 import os
 import sys
 import re
+import zstandard
+import zlib
+import shutil
 
 from datetime import (
     datetime,
 )
 
+import zipfile_zstd
+
 from zipfile import (
-    ZipFile,
-    ZipInfo,
     ZIP_DEFLATED,
     ZIP_STORED,
+    ZIP_ZSTANDARD,
+    ZSTANDARD_VERSION,
+    ZipFile,
+    ZipInfo,
+    compressor_names,
 )
 
 from pathlib import Path
@@ -24,8 +32,84 @@ from taiseilib.common import (
     write_depfile,
 )
 
+
+zstd_decompressor = zstandard.ZstdDecompressor()
+
+
+def write_zst_file(zf, zst_path, arcname):
+    '''
+    Add a file pre-compressed with zstd to the archive
+    Of course zipfile doesn't support this use-case (because it sucks),
+    so abuse generous access to its internals to implement it here.
+    '''
+
+    log_file(zst_path, arcname, ZIP_ZSTANDARD)
+
+    zip64 = False
+
+    with zst_path.open('rb') as zst_file:
+        zst_size = zst_file.seek(0, 2)
+        zst_file.seek(0, 0)
+
+        zi = ZipInfo.from_file(str(zst_path), arcname=arcname)
+        zi.compress_type = ZIP_ZSTANDARD
+        zi.create_version = ZSTANDARD_VERSION
+        zi.extract_version = ZSTANDARD_VERSION
+        zi.compress_size = zst_size
+
+        if not zi.external_attr:
+            zi.external_attr = 0o600 << 16  # permissions: ?rw-------
+
+        # Unfortunately we must decompress it to compute crc32.
+        # We'll also compute file size from decompressed data instead of relying on frame headers.
+
+        zi.file_size = 0
+        zi.CRC = 0
+
+        for chunk in zstd_decompressor.read_to_iter(zst_file):
+            zi.file_size += len(chunk)
+            zi.CRC = zlib.crc32(chunk, zi.CRC)
+
+        if zf._seekable:
+            zf.fp.seek(zf.start_dir)
+
+        zi.header_offset = zf.fp.tell()
+
+        zf._writecheck(zi)
+        zf._didModify = True
+        zf.fp.write(zi.FileHeader(zip64))
+        zf._writing = True
+
+        try:
+            zst_file.seek(0, 0)
+            shutil.copyfileobj(zst_file, zf.fp)
+            assert zst_file.tell() == zi.compress_size
+
+            zf.filelist.append(zi)
+            zf.NameToInfo[zi.filename] = zi
+            zf.start_dir = zf.fp.tell()
+        finally:
+            zf._writing = False
+
+
+def log_file(path, arcname, comp_type=None):
+    if str(arcname).endswith('/'):
+        prefix = 'dir'
+    else:
+        prefix = compressor_names.get(comp_type, '???')
+
+    print('% 12s' % prefix, '|', arcname, '<--', str(path))
+
+
 def pack(args):
     nocompress_file = args.directory / '.nocompress'
+
+    if 1:
+        comp_type = ZIP_ZSTANDARD
+        comp_level = 20
+    else:
+        comp_type = ZIP_DEFLATED
+        comp_level = 9
 
     try:
         nocompress = list(map(re.compile, filter(None, nocompress_file.read_text().strip().split('\n'))))
@@ -35,9 +119,11 @@ def pack(args):
 
     zkwargs = {}
     if (sys.version_info.major, sys.version_info.minor) >= (3, 7):
-        zkwargs['compresslevel'] = 9
+        zkwargs['compresslevel'] = comp_level
 
-    with ZipFile(str(args.output), 'w', ZIP_DEFLATED, **zkwargs) as zf:
+    dependencies = []
+
+    with ZipFile(str(args.output), 'w', comp_type, **zkwargs) as zf:
         for path in sorted(args.directory.glob('**/*')):
             if path.name[0] == '.' or any(path.match(x) for x in args.exclude):
                 continue
@@ -48,23 +134,29 @@ def pack(args):
                 zi = ZipInfo(str(relpath) + "/", datetime.fromtimestamp(path.stat().st_mtime).timetuple())
                 zi.compress_type = ZIP_STORED
                 zi.external_attr = 0o40755 << 16  # drwxr-xr-x
+                log_file(path, zi.filename)
                 zf.writestr(zi, '')
             else:
-                ctype = ZIP_DEFLATED
+                dependencies.append(path)
 
-                for pattern in nocompress:
-                    if pattern.match(str(relpath)):
-                        ctype = ZIP_STORED
-                        break
+                if path.suffix == '.zst':
+                    write_zst_file(zf, path, str(relpath.with_suffix('')))
+                else:
+                    ctype = comp_type
 
-                zf.write(str(path), str(relpath), compress_type=ctype)
+                    for pattern in nocompress:
+                        if pattern.match(str(relpath)):
+                            ctype = ZIP_STORED
+                            break
 
-        if args.depfile is not None:
-            write_depfile(args.depfile, args.output,
-                [args.directory.resolve() / x for x in zf.namelist()] +
-                [str(Path(__file__).resolve())] +
-                list(filter(None, [nocompress_file]))
-            )
+                    log_file(path, relpath, ctype)
+                    zf.write(str(path), str(relpath), compress_type=ctype)
+
+    if args.depfile is not None:
+        if nocompress_file is not None:
+            dependencies.append(nocompress_file)
+        dependencies.append(Path(__file__).resolve())
+        write_depfile(args.depfile, args.output, dependencies)
 
 
 def main(args):

--- a/scripts/zipfile_zstd
+++ b/scripts/zipfile_zstd
@@ -1,0 +1,1 @@
+../external/python-zipfile-zstd/zipfile_zstd

--- a/src/main.c
+++ b/src/main.c
@@ -10,6 +10,7 @@
 
 #include <locale.h>
 #include <png.h>
+#include <zlib.h>
 
 #include "global.h"
 #include "video.h"

--- a/src/renderer/common/shaderlib/cache.c
+++ b/src/renderer/common/shaderlib/cache.c
@@ -221,7 +221,7 @@ bool shader_cache_get(const char *hash, const char *key, ShaderSource *entry) {
 		return false;
 	}
 
-	stream = SDL_RWWrapZReader(stream, BUFSIZ, true);
+	stream = SDL_RWWrapZlibReader(stream, BUFSIZ, true);
 	bool result = shader_cache_load_entry(stream, entry);
 	SDL_RWclose(stream);
 
@@ -244,7 +244,7 @@ static bool shader_cache_set_raw(const char *hash, const char *key, uint8_t *ent
 		return false;
 	}
 
-	out = SDL_RWWrapZWriter(out, BUFSIZ, true);
+	out = SDL_RWWrapZlibWriter(out, RW_DEFLATE_LEVEL_DEFAULT, BUFSIZ, true);
 	assert(out != NULL);
 
 	SDL_RWwrite(out, entry, entry_size, 1);

--- a/src/resource/font.c
+++ b/src/resource/font.c
@@ -723,6 +723,12 @@ void load_font(ResourceLoadState *st) {
 		return;
 	}
 
+	if(!font.source_path) {
+		log_error("%s: No source path specified", st->path);
+		res_load_failed(st);
+		return;
+	}
+
 	ht_create(&font.charcodes_to_glyph_ofs);
 	ht_create(&font.ftindex_to_glyph_ofs);
 

--- a/src/resource/texture_loader/basisu_cache.c
+++ b/src/resource/texture_loader/basisu_cache.c
@@ -73,7 +73,7 @@ bool texture_loader_basisu_load_cached(
 		return false;
 	}
 
-	rw = SDL_RWWrapZReader(rw, 1 << 20, true);
+	rw = SDL_RWWrapZlibReader(rw, 1 << 20, true);
 
 	bool deserialize_ok = pixmap_deserialize(rw, out_pixmap);
 	SDL_RWclose(rw);
@@ -176,7 +176,7 @@ bool texture_loader_basisu_cache(
 		return false;
 	}
 
-	rw = SDL_RWWrapZWriter(rw, 1 << 20, true);
+	rw = SDL_RWWrapZlibWriter(rw, RW_DEFLATE_LEVEL_DEFAULT, 1 << 20, true);
 
 	bool serialize_ok = pixmap_serialize(rw, pixmap);
 	SDL_RWclose(rw);

--- a/src/resource/texture_loader/basisu_cache.c
+++ b/src/resource/texture_loader/basisu_cache.c
@@ -10,7 +10,7 @@
 
 #include "basisu_cache.h"
 #include "pixmap/serialize.h"
-#include "rwops/rwops_zlib.h"
+#include "rwops/rwops_zstd.h"
 
 #include <basisu_transcoder_c_api.h>
 
@@ -73,7 +73,7 @@ bool texture_loader_basisu_load_cached(
 		return false;
 	}
 
-	rw = SDL_RWWrapZlibReader(rw, 1 << 20, true);
+	rw = SDL_RWWrapZstdReader(rw, true);
 
 	bool deserialize_ok = pixmap_deserialize(rw, out_pixmap);
 	SDL_RWclose(rw);
@@ -176,7 +176,7 @@ bool texture_loader_basisu_cache(
 		return false;
 	}
 
-	rw = SDL_RWWrapZlibWriter(rw, RW_DEFLATE_LEVEL_DEFAULT, 1 << 20, true);
+	rw = SDL_RWWrapZstdWriter(rw, RW_ZSTD_LEVEL_DEFAULT, true);
 
 	bool serialize_ok = pixmap_serialize(rw, pixmap);
 	SDL_RWclose(rw);

--- a/src/rwops/all.h
+++ b/src/rwops/all.h
@@ -17,6 +17,7 @@
 #include "rwops_segment.h"
 #include "rwops_sha256.h"
 #include "rwops_zlib.h"
+#include "rwops_zstd.h"
 
 #ifdef TAISEI_BUILDCONF_USE_ZIP
 #include "rwops_zipfile.h"

--- a/src/rwops/meson.build
+++ b/src/rwops/meson.build
@@ -6,6 +6,7 @@ rwops_src = files(
     'rwops_ro.c',
     'rwops_segment.c',
     'rwops_sha256.c',
+    'rwops_util.c',
     'rwops_zlib.c',
     'rwops_zstd.c',
 )

--- a/src/rwops/meson.build
+++ b/src/rwops/meson.build
@@ -7,6 +7,7 @@ rwops_src = files(
     'rwops_segment.c',
     'rwops_sha256.c',
     'rwops_zlib.c',
+    'rwops_zstd.c',
 )
 
 if taisei_deps.contains(dep_zip)

--- a/src/rwops/rwops_trace.h
+++ b/src/rwops/rwops_trace.h
@@ -13,6 +13,6 @@
 
 #include <SDL.h>
 
-SDL_RWops *SDL_RWWrapTrace(SDL_RWops *src, bool autoclose);
+SDL_RWops *SDL_RWWrapTrace(SDL_RWops *src, const char *tag, bool autoclose);
 
 #endif // IGUARD_rwops_rwops_trace_h

--- a/src/rwops/rwops_util.c
+++ b/src/rwops/rwops_util.c
@@ -1,0 +1,85 @@
+/*
+ * This software is licensed under the terms of the MIT License.
+ * See COPYING for further information.
+ * ---
+ * Copyright (c) 2011-2019, Lukas Weber <laochailan@web.de>.
+ * Copyright (c) 2012-2019, Andrei Alexeyev <akari@taisei-project.org>.
+*/
+
+#include "taisei.h"
+
+#include "rwops_util.h"
+#include "util.h"
+
+int64_t rwutil_compute_seek_pos(int64_t offset, int whence, int64_t pos, int64_t size) {
+	int64_t new_pos;
+
+	assert(pos >= 0);
+	assert(size < 0 || pos <= size);
+
+	switch(whence) {
+		case RW_SEEK_SET: new_pos = offset;        break;
+		case RW_SEEK_CUR: new_pos = pos + offset;  break;
+		case RW_SEEK_END:
+			if(size < 0) {
+				return -1;
+			}
+
+			new_pos = size - offset;
+			break;
+		default: UNREACHABLE;
+	}
+
+	if(new_pos < 0) {
+		new_pos = 0;
+	}
+
+	if(size > 0 && new_pos > size) {
+		new_pos = size;
+	}
+
+	return new_pos;
+}
+
+int64_t rwutil_seek_emulated(
+	SDL_RWops *rw, int64_t offset, int whence,
+	int64_t *pos, rwutil_reopen_func reopen, size_t readbuf_size, void *readbuf
+) {
+	int64_t sz = SDL_RWsize(rw);
+	int64_t new_pos = rwutil_compute_seek_pos(offset, whence, *pos, sz);
+
+	if(new_pos < 0) {
+		assert(sz < 0);
+		return sz;  // assume SDL_RWsize set an error;
+	}
+
+	return rwutil_seek_emulated_abs(rw, new_pos, pos, reopen, readbuf_size, readbuf);
+}
+
+int64_t rwutil_seek_emulated_abs(
+	SDL_RWops *rw, int64_t new_pos, int64_t *pos,
+	rwutil_reopen_func reopen, size_t readbuf_size, void *readbuf
+) {
+	assert(new_pos >= 0);
+
+	if(new_pos < *pos) {
+		int status;
+		if((status = reopen(rw)) < 0) {
+			return status;
+		}
+		assert(*pos == 0);
+	}
+
+	while(new_pos > *pos) {
+		size_t want_read_size = imin(new_pos - *pos, readbuf_size);
+		size_t read_size = SDL_RWread(rw, readbuf, 1, want_read_size);
+		assert(read_size <= want_read_size);
+
+		if(read_size < readbuf_size) {
+			break;
+		}
+	}
+
+	assert(new_pos == *pos);
+	return *pos;
+}

--- a/src/rwops/rwops_util.h
+++ b/src/rwops/rwops_util.h
@@ -45,5 +45,4 @@ int64_t rwutil_seek_emulated(SDL_RWops *rw, int64_t offset, int whence, int64_t 
  */
 int64_t rwutil_seek_emulated_abs(SDL_RWops *rw, int64_t new_pos, int64_t *pos, rwutil_reopen_func reopen, size_t readbuf_size, void *readbuf) attr_nonnull_all attr_nodiscard;
 
-
 #endif // IGUARD_rwops_rwops_util_h

--- a/src/rwops/rwops_util.h
+++ b/src/rwops/rwops_util.h
@@ -1,0 +1,49 @@
+/*
+ * This software is licensed under the terms of the MIT License.
+ * See COPYING for further information.
+ * ---
+ * Copyright (c) 2011-2019, Lukas Weber <laochailan@web.de>.
+ * Copyright (c) 2012-2019, Andrei Alexeyev <akari@taisei-project.org>.
+*/
+
+#ifndef IGUARD_rwops_rwops_util_h
+#define IGUARD_rwops_rwops_util_h
+
+#include "taisei.h"
+
+#include <SDL.h>
+
+typedef int (*rwutil_reopen_func)(SDL_RWops *rw);
+
+/*
+ * Compute an absolute seek position from `offset` and `whence`, give a stream open at `pos` of
+ * total size `size`.
+ *
+ * If `size` is negative, it is assumed to be unknown.
+ *
+ * The returned value is clamped to be >=0, and <=size if size is known.
+ *
+ * If whence is RW_SEEK_END and the size is unknown, this function will return a negative value.
+ */
+int64_t rwutil_compute_seek_pos(int64_t offset, int whence, int64_t pos, int64_t size);
+
+/*
+ * Emulate a seeking operation in a non-seekable stream.
+ * Forward seeks are implemented by reading and discarding data.
+ * Backward seeks are implemented by re-opening the stream and 'seeking' forward.
+ *
+ * `pos` must point to the current position within the stream. Read operations must update this
+ * position correctly.
+ * `reopen` must reset the stream position to 0.
+ *
+ * Returns the new value of *pos.
+ */
+int64_t rwutil_seek_emulated(SDL_RWops *rw, int64_t offset, int whence, int64_t *pos, rwutil_reopen_func reopen, size_t readbuf_size, void *readbuf) attr_nonnull_all attr_nodiscard;
+
+/*
+ * Like rwutil_seek_emulated, but takes an absolute position instead of offset and whence.
+ */
+int64_t rwutil_seek_emulated_abs(SDL_RWops *rw, int64_t new_pos, int64_t *pos, rwutil_reopen_func reopen, size_t readbuf_size, void *readbuf) attr_nonnull_all attr_nodiscard;
+
+
+#endif // IGUARD_rwops_rwops_util_h

--- a/src/rwops/rwops_zipfile.c
+++ b/src/rwops/rwops_zipfile.c
@@ -207,7 +207,7 @@ SDL_RWops *SDL_RWFromZipFile(VFSNode *znode, VFSZipPathData *pdata) {
 	rw->read = ziprw_read;
 	rw->write = ziprw_write;
 
-	if(pdata->seekable) {
+	if(pdata->compression == ZIP_CM_STORE) {
 		rw->seek = ziprw_seek;
 	} else {
 		rw->seek = ziprw_seek_emulated;

--- a/src/rwops/rwops_zlib.c
+++ b/src/rwops/rwops_zlib.c
@@ -354,11 +354,6 @@ static int inflate_reopen(SDL_RWops *rw) {
 
 static int64_t inflate_seek_emulated(SDL_RWops *rw, int64_t offset, int whence) {
 	ZData *z = ZDATA(rw);
-
-	if(!offset && whence == RW_SEEK_CUR) {
-		return ZDATA(rw)->pos;
-	}
-
 	char buf[1024];
 
 	return rwutil_seek_emulated(

--- a/src/rwops/rwops_zlib.c
+++ b/src/rwops/rwops_zlib.c
@@ -318,7 +318,3 @@ SDL_RWops* SDL_RWWrapZWriter(SDL_RWops *src, size_t bufsize, bool autoclose) {
 
 	return rw;
 }
-
-z_stream* SDL_RWGetZStream(SDL_RWops *rw) {
-	return ZDATA(rw)->stream;
-}

--- a/src/rwops/rwops_zlib.c
+++ b/src/rwops/rwops_zlib.c
@@ -416,7 +416,7 @@ SDL_RWops *SDL_RWWrapInflateReaderSeekable(SDL_RWops *src, int64_t uncompressed_
 }
 
 SDL_RWops *SDL_RWWrapZlibWriter(SDL_RWops *src, int clevel, size_t bufsize, bool autoclose) {
-	return wrap_writer(src, bufsize, autoclose, clevel, -15);
+	return wrap_writer(src, bufsize, autoclose, clevel, 15);
 }
 
 SDL_RWops *SDL_RWWrapDeflateWriter(SDL_RWops *src, int clevel, size_t bufsize, bool autoclose) {

--- a/src/rwops/rwops_zlib.h
+++ b/src/rwops/rwops_zlib.h
@@ -13,7 +13,17 @@
 
 #include <SDL.h>
 
-SDL_RWops *SDL_RWWrapZReader(SDL_RWops *src, size_t bufsize, bool autoclose);
-SDL_RWops *SDL_RWWrapZWriter(SDL_RWops *src, size_t bufsize, bool autoclose);
+#define RW_DEFLATE_LEVEL_DEFAULT -1
+
+SDL_RWops *SDL_RWWrapZlibReader(SDL_RWops *src, size_t bufsize, bool autoclose);
+SDL_RWops *SDL_RWWrapZlibWriter(SDL_RWops *src, int clevel, size_t bufsize, bool autoclose);
+
+// For raw deflate streams
+SDL_RWops *SDL_RWWrapInflateReader(SDL_RWops *src, size_t bufsize, bool autoclose);
+SDL_RWops *SDL_RWWrapDeflateWriter(SDL_RWops *src, int clevel, size_t bufsize, bool autoclose);
+
+// NOTE: uses inefficient emulation to implement seeking. Source must be seekable as well.
+SDL_RWops *SDL_RWWrapZlibReaderSeekable(SDL_RWops *src, int64_t uncompressed_size, size_t bufsize, bool autoclose);
+SDL_RWops *SDL_RWWrapInflateReaderSeekable(SDL_RWops *src, int64_t uncompressed_size, size_t bufsize, bool autoclose);
 
 #endif // IGUARD_rwops_rwops_zlib_h

--- a/src/rwops/rwops_zlib.h
+++ b/src/rwops/rwops_zlib.h
@@ -12,10 +12,8 @@
 #include "taisei.h"
 
 #include <SDL.h>
-#include <zlib.h>
 
-SDL_RWops* SDL_RWWrapZReader(SDL_RWops *src, size_t bufsize, bool autoclose);
-SDL_RWops* SDL_RWWrapZWriter(SDL_RWops *src, size_t bufsize, bool autoclose);
-z_stream* SDL_RWGetZStream(SDL_RWops *src);
+SDL_RWops *SDL_RWWrapZReader(SDL_RWops *src, size_t bufsize, bool autoclose);
+SDL_RWops *SDL_RWWrapZWriter(SDL_RWops *src, size_t bufsize, bool autoclose);
 
 #endif // IGUARD_rwops_rwops_zlib_h

--- a/src/rwops/rwops_zstd.c
+++ b/src/rwops/rwops_zstd.c
@@ -335,7 +335,8 @@ static size_t rwzstd_write(SDL_RWops *rw, const void *data_in, size_t size, size
 	size_t in_free = z->writer.in_buffer_alloc_size - in->size;
 
 	if(UNLIKELY(in_free < wsize)) {
-		in->src = realloc(in_root, z->writer.in_buffer_alloc_size + (wsize - in_free));
+		in_root = realloc(in_root, z->writer.in_buffer_alloc_size + (wsize - in_free));
+		in->src = in_root;
 	}
 
 	memcpy(in_root + in->size, data_in, wsize);

--- a/src/rwops/rwops_zstd.c
+++ b/src/rwops/rwops_zstd.c
@@ -157,13 +157,15 @@ static size_t rwzstd_read(SDL_RWops *rw, void *ptr, size_t size, size_t maxnum) 
 	};
 	ZSTD_DStream *stream = NOT_NULL(z->reader.stream);
 
-	while(out.pos < out.size) {
+	bool have_input = true;
+
+	while(out.pos < out.size && have_input) {
 		if(in->size - in->pos < z->reader.next_read_size) {
 			rwzstd_reader_fill_in_buffer(z, z->reader.next_read_size);
 
 			if(in->size - in->pos < z->reader.next_read_size) {
 				// end of stream
-				break;
+				have_input = false;
 			}
 		}
 

--- a/src/rwops/rwops_zstd.c
+++ b/src/rwops/rwops_zstd.c
@@ -1,0 +1,334 @@
+/*
+ * This software is licensed under the terms of the MIT License.
+ * See COPYING for further information.
+ * ---
+ * Copyright (c) 2011-2019, Lukas Weber <laochailan@web.de>.
+ * Copyright (c) 2012-2019, Andrei Alexeyev <akari@taisei-project.org>.
+*/
+
+#include "taisei.h"
+
+#include "rwops_zstd.h"
+#include "util.h"
+
+#include <zstd.h>
+
+typedef struct ZstdData {
+	SDL_RWops *wrapped;
+	size_t pos;
+
+	union {
+		struct {
+			ZSTD_CStream *stream;
+			ZSTD_inBuffer in_buffer;
+			size_t in_buffer_alloc_size;
+			ZSTD_outBuffer out_buffer;
+		} writer;
+
+		struct {
+			ZSTD_DStream *stream;
+			ZSTD_inBuffer in_buffer;
+			size_t in_buffer_alloc_size;
+			size_t next_read_size;
+		} reader;
+	};
+
+	bool autoclose;
+} ZstdData;
+
+#define ZDATA(rw) NOT_NULL((ZstdData*)(NOT_NULL(rw)->hidden.unknown.data1))
+
+static int64_t rwzstd_seek(SDL_RWops *rw, int64_t offset, int whence) {
+	if(!offset && whence == RW_SEEK_CUR) {
+		return ZDATA(rw)->pos;
+	}
+
+	return SDL_SetError("Can't seek in a zstd stream");
+}
+
+static int64_t rwzstd_size(SDL_RWops *rw) {
+	return SDL_SetError("Can't get size of a zstd stream");
+}
+
+static int rwzstd_close(SDL_RWops *rw) {
+	ZstdData *z = ZDATA(rw);
+
+	if(z->autoclose) {
+		SDL_RWclose(z->wrapped);
+	}
+
+	free(z);
+	SDL_FreeRW(rw);
+
+	return 0;
+}
+
+static size_t rwzstd_read_invalid(SDL_RWops *rw, void *ptr, size_t size, size_t maxnum) {
+	SDL_SetError("Can't read from a zstd writer stream");
+	return 0;
+}
+
+static size_t rwzstd_write_invalid(SDL_RWops *rw, const void *ptr, size_t size, size_t maxnum) {
+	SDL_SetError("Can't write to a zstd reader stream");
+	return 0;
+}
+
+static SDL_RWops *rwzstd_alloc(SDL_RWops *wrapped, bool autoclose) {
+	SDL_RWops *rw = SDL_AllocRW();
+
+	if(!rw) {
+		return NULL;
+	}
+
+	memset(rw, 0, sizeof(SDL_RWops));
+
+	rw->type = SDL_RWOPS_UNKNOWN;
+	rw->seek = rwzstd_seek;
+	rw->size = rwzstd_size;
+
+	ZstdData *z = calloc(1, sizeof(ZstdData));
+	z->wrapped = wrapped;
+	z->autoclose = autoclose;
+
+	rw->hidden.unknown.data1 = z;
+
+	return rw;
+}
+
+static size_t rwzstd_reader_fill_in_buffer(ZstdData *z, size_t request_size) {
+	ZSTD_inBuffer *in = &z->reader.in_buffer;
+
+	if(request_size > z->reader.in_buffer_alloc_size) {
+		z->reader.in_buffer_alloc_size = request_size;
+		in->src = realloc((void*)in->src, request_size);
+	}
+
+	if(request_size == 0) {
+		return 0;
+	}
+
+	size_t leftover_size = in->size - in->pos;
+	in->size = leftover_size;
+	assert(leftover_size <= request_size);
+
+	uint8_t *root = (uint8_t*)in->src;
+
+	if(UNLIKELY(leftover_size)) {
+		// some input has not been consumed; we must present it again
+		uint8_t *leftover = root + in->pos;
+		memmove(root, leftover, leftover_size);
+	}
+
+	in->pos = 0;
+
+	uint8_t *start = root + in->size;
+	uint8_t *end = root + request_size;
+	uint8_t *pos = start;
+
+	while(in->size < request_size) {
+		size_t read = SDL_RWread(z->wrapped, pos, 1, end - pos);
+
+		if(read == 0) {
+			break;
+		}
+
+		assert(read <= end - pos);
+
+		pos += read;
+		in->size += read;
+	}
+
+	assert(in->size <= z->reader.in_buffer_alloc_size);
+	return pos - start;
+}
+
+static size_t rwzstd_read(SDL_RWops *rw, void *ptr, size_t size, size_t maxnum) {
+	ZstdData *z = ZDATA(rw);
+	ZSTD_inBuffer *in = &z->reader.in_buffer;
+	ZSTD_outBuffer out = {
+		.dst = ptr,
+		.size = size * maxnum,
+	};
+	ZSTD_DStream *stream = NOT_NULL(z->reader.stream);
+
+	while(out.pos < out.size) {
+		if(in->size - in->pos < z->reader.next_read_size) {
+			rwzstd_reader_fill_in_buffer(z, z->reader.next_read_size);
+
+			if(in->size - in->pos < z->reader.next_read_size) {
+				// end of stream
+				break;
+			}
+		}
+
+		size_t status = ZSTD_decompressStream(stream, &out, in);
+
+		if(UNLIKELY(ZSTD_isError(status))) {
+			SDL_SetError("ZSTD_decompressStream() failed: %s", ZSTD_getErrorName(status));
+			log_debug("%s", SDL_GetError());
+			return 0;
+		}
+
+		z->reader.next_read_size = status;
+	}
+
+	z->pos += out.pos;
+	return out.pos / size;
+}
+
+static int rwzstd_reader_close(SDL_RWops *rw) {
+	ZstdData *z = ZDATA(rw);
+	ZSTD_freeDStream(z->reader.stream);
+	free((void*)z->reader.in_buffer.src);
+	return rwzstd_close(rw);
+}
+
+SDL_RWops *SDL_RWWrapZstdReader(SDL_RWops *src, bool autoclose) {
+	if(!src) {
+		return NULL;
+	}
+
+	SDL_RWops *rw = rwzstd_alloc(src, autoclose);
+
+	if(!rw) {
+		return NULL;
+	}
+
+	rw->write = rwzstd_write_invalid;
+	rw->read = rwzstd_read;
+	rw->close = rwzstd_reader_close;
+
+	ZstdData *z = ZDATA(rw);
+	z->reader.stream = NOT_NULL(ZSTD_createDStream());
+	z->reader.next_read_size = ZSTD_initDStream(z->reader.stream);
+	z->reader.in_buffer_alloc_size = imax(z->reader.next_read_size, 16384);
+	z->reader.in_buffer.src = calloc(1, z->reader.in_buffer_alloc_size);
+	z->reader.next_read_size = z->reader.in_buffer_alloc_size;
+
+	return rw;
+}
+
+static bool rwzstd_compress(SDL_RWops *rw, ZSTD_EndDirective edir, size_t *status) {
+	ZstdData *z = ZDATA(rw);
+	ZSTD_outBuffer *out = &z->writer.out_buffer;
+	ZSTD_inBuffer *in = &z->reader.in_buffer;
+
+	*status = ZSTD_compressStream2(z->writer.stream, out, in, edir);
+
+	if(UNLIKELY(ZSTD_isError(*status))) {
+		SDL_SetError("ZSTD_compressStream2() failed: %s", ZSTD_getErrorName(*status));
+		log_debug("%s", SDL_GetError());
+		return false;
+	}
+
+	if(out->pos > 0) {
+		size_t written = SDL_RWwrite(z->wrapped, out->dst, 1, out->pos);
+
+		if(UNLIKELY(written != out->pos)) {
+			SDL_SetError("SDL_RWwrite() returned %zi; expected %zi. Error: %s", written, out->pos, SDL_GetError());
+			log_debug("%s", SDL_GetError());
+			return false;
+		}
+
+		out->pos = 0;
+	}
+
+	return true;
+}
+
+static size_t rwzstd_write(SDL_RWops *rw, const void *data_in, size_t size, size_t maxnum) {
+	ZstdData *z = ZDATA(rw);
+	size_t wsize = size * maxnum;
+
+	ZSTD_inBuffer *in = &z->writer.in_buffer;
+	uint8_t *in_root = (uint8_t*)in->src;
+
+	assert(in->pos <= in->size);
+
+	if(in->pos > 0) {
+		in->size -= in->pos;
+		memmove(in_root, in_root + in->pos, in->size);
+		in->pos = 0;
+	}
+
+	size_t in_free = z->writer.in_buffer_alloc_size - in->size;
+
+	if(UNLIKELY(in_free < wsize)) {
+		in->src = realloc(in_root, z->writer.in_buffer_alloc_size + (wsize - in_free));
+	}
+
+	memcpy(in_root + in->size, data_in, wsize);
+	in->size += wsize;
+	z->pos += wsize;
+
+	size_t status;
+
+	if(LIKELY(rwzstd_compress(rw, ZSTD_e_continue, &status))) {
+		return maxnum;
+	}
+
+	return 0;
+}
+
+static bool rwzstd_writer_flush(SDL_RWops *rw, ZSTD_EndDirective edir) {
+	size_t status;
+
+	do {
+		if(UNLIKELY(!rwzstd_compress(rw, edir, &status))) {
+			return false;
+		}
+	} while(status != 0);
+
+	return true;
+}
+
+static int rwzstd_writer_close(SDL_RWops *rw) {
+	ZstdData *z = ZDATA(rw);
+
+	bool flush_ok = rwzstd_writer_flush(rw, ZSTD_e_end);
+
+	ZSTD_freeCStream(z->writer.stream);
+	free(z->writer.out_buffer.dst);
+	free((void*)z->writer.in_buffer.src);
+
+	int r = rwzstd_close(rw);
+
+	if(!flush_ok && r >= 0) {
+		return -1;
+	}
+
+	return r;
+}
+
+SDL_RWops *SDL_RWWrapZstdWriter(SDL_RWops *src, int clevel, bool autoclose) {
+	if(!src) {
+		return NULL;
+	}
+
+	SDL_RWops *rw = rwzstd_alloc(src, autoclose);
+
+	if(!rw) {
+		return NULL;
+	}
+
+	rw->write = rwzstd_write;
+	rw->read = rwzstd_read_invalid;
+	rw->close = rwzstd_writer_close;
+
+	ZstdData *z = ZDATA(rw);
+	z->writer.stream = NOT_NULL(ZSTD_createCStream());
+	z->writer.out_buffer.size = ZSTD_CStreamOutSize();
+	z->writer.out_buffer.dst = calloc(1, z->writer.out_buffer.size);
+	z->writer.in_buffer_alloc_size = ZSTD_CStreamInSize();
+	z->writer.in_buffer.src = calloc(1, z->writer.in_buffer_alloc_size);
+
+	if(clevel < ZSTD_minCLevel() || clevel > ZSTD_maxCLevel()) {
+		log_warn("Invalid compression level %i", clevel);
+		clevel = RW_ZSTD_LEVEL_DEFAULT;
+		assert(0);
+	}
+
+	ZSTD_CCtx_setParameter(z->writer.stream, ZSTD_c_compressionLevel, clevel);
+
+	return rw;
+}

--- a/src/rwops/rwops_zstd.h
+++ b/src/rwops/rwops_zstd.h
@@ -18,4 +18,7 @@
 SDL_RWops *SDL_RWWrapZstdReader(SDL_RWops *src, bool autoclose);
 SDL_RWops *SDL_RWWrapZstdWriter(SDL_RWops *src, int clevel, bool autoclose);
 
+// NOTE: uses inefficient emulation to implement seeking. Source must be seekable as well.
+SDL_RWops *SDL_RWWrapZstdReaderSeekable(SDL_RWops *src, int64_t uncompressed_size, bool autoclose);
+
 #endif // IGUARD_rwops_rwops_zstd_h

--- a/src/rwops/rwops_zstd.h
+++ b/src/rwops/rwops_zstd.h
@@ -1,0 +1,21 @@
+/*
+ * This software is licensed under the terms of the MIT License.
+ * See COPYING for further information.
+ * ---
+ * Copyright (c) 2011-2019, Lukas Weber <laochailan@web.de>.
+ * Copyright (c) 2012-2019, Andrei Alexeyev <akari@taisei-project.org>.
+*/
+
+#ifndef IGUARD_rwops_rwops_zstd_h
+#define IGUARD_rwops_rwops_zstd_h
+
+#include "taisei.h"
+
+#include <SDL.h>
+
+#define RW_ZSTD_LEVEL_DEFAULT 0
+
+SDL_RWops *SDL_RWWrapZstdReader(SDL_RWops *src, bool autoclose);
+SDL_RWops *SDL_RWWrapZstdWriter(SDL_RWops *src, int clevel, bool autoclose);
+
+#endif // IGUARD_rwops_rwops_zstd_h

--- a/src/util/strbuf.c
+++ b/src/util/strbuf.c
@@ -21,12 +21,33 @@ int strbuf_printf(StringBuffer *strbuf, const char *format, ...) {
 	return r;
 }
 
-int strbuf_vprintf(StringBuffer *strbuf, const char *format, va_list args) {
+static size_t strbuf_size_available(StringBuffer *strbuf) {
 	ptrdiff_t offset = strbuf->pos - strbuf->start;
 	assume_nolog(offset >= 0);
 
 	ptrdiff_t size_available = strbuf->buf_size - offset;
 	assume_nolog(size_available >= 0);
+
+	return size_available;
+}
+
+static size_t strbuf_reserve(StringBuffer *strbuf, size_t size_required) {
+	size_t size_available = strbuf_size_available(strbuf);
+
+	if(size_required >= size_available) {
+		ptrdiff_t offset = strbuf->pos - strbuf->start;
+		size_t new_size = topow2_u64(strbuf->buf_size + (size_required - size_available + 1));
+		strbuf->start = realloc(strbuf->start, new_size);
+		strbuf->pos = strbuf->start + offset;
+		strbuf->buf_size = new_size;
+		size_available = new_size - offset;
+	}
+
+	return size_available;
+}
+
+int strbuf_vprintf(StringBuffer *strbuf, const char *format, va_list args) {
+	size_t size_available = strbuf_size_available(strbuf);
 
 	va_list args_copy;
 	va_copy(args_copy, args);
@@ -34,16 +55,10 @@ int strbuf_vprintf(StringBuffer *strbuf, const char *format, va_list args) {
 	va_end(args_copy);
 
 	if(size_required >= size_available) {
-		size_t new_size = topow2_u64(strbuf->buf_size + (size_required - size_available + 1));
-		strbuf->start = realloc(strbuf->start, new_size);
-		strbuf->pos = strbuf->start + offset;
-		strbuf->buf_size = new_size;
-		size_available = new_size - offset;
-
+		size_available = strbuf_reserve(strbuf, size_required);
 		va_copy(args_copy, args);
 		size_required = vsnprintf(strbuf->pos, size_available, format, args_copy);
 		va_end(args_copy);
-
 		assume_nolog(size_required < size_available);
 	}
 
@@ -51,6 +66,18 @@ int strbuf_vprintf(StringBuffer *strbuf, const char *format, va_list args) {
 	assume_nolog(*strbuf->pos == 0);
 
 	return size_required;
+}
+
+void strbuf_ncat(StringBuffer *strbuf, size_t datasize, const char data[datasize]) {
+	datasize += 1;
+	strbuf_reserve(strbuf, datasize);
+	assert_nolog(strbuf_size_available(strbuf) >= datasize);
+	memcpy(strbuf->pos, data, datasize - 1);
+	strbuf->pos[datasize - 1] = 0;
+}
+
+void strbuf_cat(StringBuffer *strbuf, const char *str) {
+	strbuf_ncat(strbuf, strlen(str), str);
 }
 
 void strbuf_clear(StringBuffer *strbuf) {

--- a/src/util/strbuf.h
+++ b/src/util/strbuf.h
@@ -31,4 +31,10 @@ void strbuf_clear(StringBuffer *strbuf)
 void strbuf_free(StringBuffer *strbuf)
 	attr_nonnull(1);
 
+void strbuf_ncat(StringBuffer *strbuf, size_t datasize, const char data[datasize])
+	attr_nonnull(1, 3);
+
+void strbuf_cat(StringBuffer *strbuf, const char *str)
+	attr_nonnull(1, 2);
+
 #endif // IGUARD_util_strbuf_h

--- a/src/vfs/decompress_wrapper.c
+++ b/src/vfs/decompress_wrapper.c
@@ -1,0 +1,274 @@
+/*
+ * This software is licensed under the terms of the MIT License.
+ * See COPYING for further information.
+ * ---
+ * Copyright (c) 2011-2019, Lukas Weber <laochailan@web.de>.
+ * Copyright (c) 2012-2019, Andrei Alexeyev <akari@taisei-project.org>.
+*/
+
+#include "taisei.h"
+
+#include "decompress_wrapper.h"
+#include "rwops/rwops_ro.h"
+#include "rwops/rwops_zstd.h"
+#include "util/strbuf.h"
+
+// NOTE: Largely based on readonly_wrapper. Sorry for the copypasta.
+// This is currently hardcoded to only support transparent decompression of .zst files.
+
+#define ZST_SUFFIX ".zst"
+#define WRAPPED(n) ((VFSNode*)(n)->data1)
+
+struct decomp_data {
+	uint compr_zstd : 1;
+};
+
+static_assert_nomsg(sizeof(struct decomp_data) <= sizeof(void*));
+
+static char *vfs_decomp_repr(VFSNode *node) {
+	char *wrapped_repr = vfs_node_repr(WRAPPED(node), false);
+	char *repr = strjoin("decompress view of ", wrapped_repr, NULL);
+	free(wrapped_repr);
+	return repr;
+}
+
+static void vfs_decomp_free(VFSNode *node) {
+	vfs_decref(WRAPPED(node));
+}
+
+static VFSInfo vfs_decomp_query(VFSNode *node) {
+	VFSInfo info = vfs_node_query(WRAPPED(node));
+	info.is_readonly = true;
+	return info;
+}
+
+static char *vfs_decomp_syspath(VFSNode *node) {
+	return vfs_node_syspath(WRAPPED(node));
+}
+
+static bool vfs_decomp_mount(VFSNode *mountroot, const char *subname, VFSNode *mountee) {
+	vfs_set_error("Read-only filesystem");
+	return false;
+}
+
+static bool vfs_decomp_unmount(VFSNode *mountroot, const char *subname) {
+	vfs_set_error("Read-only filesystem");
+	return false;
+}
+
+static bool vfs_decomp_mkdir(VFSNode *parent, const char *subdir) {
+	vfs_set_error("Read-only filesystem");
+	return false;
+}
+
+static VFSNode *vfs_decomp_locate(VFSNode *dirnode, const char *path) {
+	VFSNode *wrapped = WRAPPED(dirnode);
+	VFSNode *child = vfs_node_locate(wrapped, path);
+	struct decomp_data data = { 0 };
+
+	VFSNode *ochild = NULL;
+
+	if(child != NULL && !vfs_node_query(child).exists) {
+		ochild = child;
+		child = NULL;
+	}
+
+	if(child == NULL) {
+		size_t plen = strlen(path);
+		char p[plen + sizeof(ZST_SUFFIX)];
+		memcpy(p, path, plen);
+		memcpy(p + plen, ZST_SUFFIX, sizeof(ZST_SUFFIX));
+
+		child = vfs_node_locate(wrapped, p);
+		VFSInfo i = vfs_node_query(child);
+
+		if(i.error || i.is_dir) {
+			vfs_decref(child);
+			child = ochild;
+		} else {
+			data.compr_zstd = true;
+
+			if(ochild) {
+				vfs_decref(ochild);
+				ochild = NULL;
+			}
+		}
+	}
+
+	if(child == NULL) {
+		return NULL;
+	}
+
+	VFSNode *wrapped_child = NOT_NULL(vfs_decomp_wrap(child));
+	vfs_decref(child);
+	memcpy(&wrapped_child->data2, &data, sizeof(data));
+
+	return wrapped_child;
+}
+
+static SDL_RWops *vfs_decomp_open(VFSNode *filenode, VFSOpenMode mode) {
+	if(mode & VFS_MODE_WRITE) {
+		vfs_set_error("Read-only filesystem");
+		return NULL;
+	}
+
+	struct decomp_data data;
+	memcpy(&data, &filenode->data2, sizeof(data));
+
+	SDL_RWops *raw = vfs_node_open(WRAPPED(filenode), mode);
+
+	if(!raw) {
+		return NULL;
+	}
+
+	if(data.compr_zstd) {
+		return SDL_RWWrapZstdReaderSeekable(raw, -1, true);
+	}
+
+	return SDL_RWWrapReadOnly(raw, true);
+}
+
+struct decomp_iter_data {
+	ht_str2int_t visited;
+	void *opaque;
+	StringBuffer temp_buf;
+	bool clear_buffer;
+};
+
+static const char *_vfs_decomp_iter(VFSNode *wrapped, struct decomp_iter_data *i) {
+	if(i->temp_buf.buf_size > 0 && i->temp_buf.start[0]) {
+		if(i->clear_buffer) {
+			i->temp_buf.start[0] = 0;
+			strbuf_clear(&i->temp_buf);
+		} else {
+			i->clear_buffer = true;
+			return i->temp_buf.start;
+		}
+	}
+
+	const char *r = vfs_node_iter(wrapped, &i->opaque);
+
+	if(!r) {
+		vfs_node_iter_stop(wrapped, &i->opaque);
+		i->opaque = NULL;
+		return NULL;
+	}
+
+	if(strendswith(r, ZST_SUFFIX)) {
+		strbuf_ncat(&i->temp_buf, strlen(r) - sizeof(ZST_SUFFIX) + 1, r);
+	}
+
+	return r;
+}
+
+static const char *vfs_decomp_iter(VFSNode *node, void **opaque) {
+	VFSNode *wrapped = WRAPPED(node);
+	struct decomp_iter_data *i = *opaque;
+
+	if(!i) {
+		i = calloc(1, sizeof(*i));
+		ht_create(&i->visited);
+		*opaque = i;
+	}
+
+	for(;;) {
+		const char *r = _vfs_decomp_iter(wrapped, i);
+
+		if(!r) {
+			return NULL;
+		}
+
+		if(!ht_get(&i->visited, r, false)) {
+			ht_set(&i->visited, r, true);
+			return r;
+		}
+	}
+}
+
+static void vfs_decomp_iter_stop(VFSNode *node, void **opaque) {
+	VFSNode *wrapped = WRAPPED(node);
+	struct decomp_iter_data *i = *opaque;
+
+	if(i) {
+		vfs_node_iter_stop(wrapped, &i->opaque);
+		ht_destroy(&i->visited);
+		strbuf_free(&i->temp_buf);
+		free(i);
+		*opaque = NULL;
+	}
+}
+
+static VFSNodeFuncs vfs_funcs_decomp = {
+	.repr = vfs_decomp_repr,
+	.query = vfs_decomp_query,
+	.free = vfs_decomp_free,
+	.locate = vfs_decomp_locate,
+	.syspath = vfs_decomp_syspath,
+	.iter = vfs_decomp_iter,
+	.iter_stop = vfs_decomp_iter_stop,
+	.mkdir = vfs_decomp_mkdir,
+	.open = vfs_decomp_open,
+	.mount = vfs_decomp_mount,
+	.unmount = vfs_decomp_unmount,
+};
+
+VFSNode *vfs_decomp_wrap(VFSNode *base) {
+	if(base == NULL) {
+		return NULL;
+	}
+
+	vfs_incref(base);
+
+	VFSNode *wrapper = vfs_alloc();
+	wrapper->funcs = &vfs_funcs_decomp;
+	wrapper->data1 = base;
+	return wrapper;
+}
+
+bool vfs_make_decompress_view(const char *path) {
+	char buf[strlen(path)+1], *path_parent, *path_subdir;
+	vfs_path_normalize(path, buf);
+
+	char npath[strlen(path)+1];
+	strcpy(npath, buf);
+
+	if(vfs_query(path).is_readonly) {
+		return true;
+	}
+
+	vfs_path_split_right(buf, &path_parent, &path_subdir);
+
+	VFSNode *parent = vfs_locate(vfs_root, path_parent);
+
+	if(parent == NULL) {
+		return false;
+	}
+
+	VFSNode *node = vfs_locate(parent, path_subdir);
+
+	if(node == NULL) {
+		vfs_decref(parent);
+		return false;
+	}
+
+	if(!vfs_node_unmount(parent, path_subdir)) {
+		vfs_decref(node);
+		vfs_decref(parent);
+		return false;
+	}
+
+	VFSNode *wrapper = vfs_decomp_wrap(node);
+	assert(wrapper != NULL);
+	vfs_decref(node);
+
+	if(!vfs_node_mount(parent, path_subdir, wrapper)) {
+		log_error("Couldn't remount '%s' - VFS left in inconsistent state! Error: %s", npath, vfs_get_error());
+		vfs_decref(parent);
+		vfs_decref(wrapper);
+		return false;
+	}
+
+	vfs_decref(parent);
+	assert(vfs_query(path).is_readonly);
+	return true;
+}

--- a/src/vfs/decompress_wrapper.h
+++ b/src/vfs/decompress_wrapper.h
@@ -1,0 +1,19 @@
+/*
+ * This software is licensed under the terms of the MIT License.
+ * See COPYING for further information.
+ * ---
+ * Copyright (c) 2011-2019, Lukas Weber <laochailan@web.de>.
+ * Copyright (c) 2012-2019, Andrei Alexeyev <akari@taisei-project.org>.
+*/
+
+#ifndef IGUARD_vfs_decompress_wrapper_h
+#define IGUARD_vfs_decompress_wrapper_h
+
+#include "taisei.h"
+
+#include "decompress_wrapper_public.h"
+#include "private.h"
+
+VFSNode *vfs_decomp_wrap(VFSNode *base);
+
+#endif // IGUARD_vfs_decompress_wrapper_h

--- a/src/vfs/decompress_wrapper_public.h
+++ b/src/vfs/decompress_wrapper_public.h
@@ -1,0 +1,16 @@
+/*
+ * This software is licensed under the terms of the MIT License.
+ * See COPYING for further information.
+ * ---
+ * Copyright (c) 2011-2019, Lukas Weber <laochailan@web.de>.
+ * Copyright (c) 2012-2019, Andrei Alexeyev <akari@taisei-project.org>.
+*/
+
+#ifndef IGUARD_vfs_decompress_wrapper_public_h
+#define IGUARD_vfs_decompress_wrapper_public_h
+
+#include "taisei.h"
+
+bool vfs_make_decompress_view(const char *path);
+
+#endif // IGUARD_vfs_decompress_wrapper_public_h

--- a/src/vfs/meson.build
+++ b/src/vfs/meson.build
@@ -1,5 +1,6 @@
 
 vfs_src = files(
+    'decompress_wrapper.c',
     'loadpacks.c',
     'nodeapi.c',
     'pathutil.c',

--- a/src/vfs/setup.h
+++ b/src/vfs/setup.h
@@ -36,7 +36,7 @@ static inline void vfs_setup_fixedpaths_onsync(CallChainResult ccr, VfsSetupFixe
 
 	vfs_create_union_mountpoint("/res");
 
-	if(!vfs_mount_syspath("/res-dir", paths->res_path, VFS_SYSPATH_MOUNT_READONLY)) {
+	if(!vfs_mount_syspath("/res-dir", paths->res_path, VFS_SYSPATH_MOUNT_READONLY | VFS_SYSPATH_MOUNT_DECOMPRESSVIEW)) {
 		log_fatal("Failed to mount '%s': %s", paths->res_path, vfs_get_error());
 	}
 

--- a/src/vfs/setup_generic.c
+++ b/src/vfs/setup_generic.c
@@ -48,10 +48,10 @@ void vfs_setup(CallChain next) {
 		{ "storage",      storage_path,        false,         false,         VFS_SYSPATH_MOUNT_MKDIR },
 
 		// system-wide directory, contains all of the game assets
-		{ "resdirs",      res_path,            true,          true,          VFS_SYSPATH_MOUNT_READONLY },
+		{ "resdirs",      res_path,            true,          true,          VFS_SYSPATH_MOUNT_READONLY | VFS_SYSPATH_MOUNT_DECOMPRESSVIEW },
 
 		// subpath of storage, files here override the global assets
-		{ "resdirs",      local_res_path,      true,          false,         VFS_SYSPATH_MOUNT_MKDIR | VFS_SYSPATH_MOUNT_READONLY },
+		{ "resdirs",      local_res_path,      true,          false,         VFS_SYSPATH_MOUNT_MKDIR | VFS_SYSPATH_MOUNT_READONLY | VFS_SYSPATH_MOUNT_DECOMPRESSVIEW },
 
 		// per-user directory, to contain various cached resources to speed up loading times
 		{ "cache",        cache_path,          false,         false,         VFS_SYSPATH_MOUNT_MKDIR },

--- a/src/vfs/syspath_public.c
+++ b/src/vfs/syspath_public.c
@@ -10,6 +10,7 @@
 
 #include "syspath.h"
 #include "readonly_wrapper.h"
+#include "decompress_wrapper.h"
 
 static void striptrailing(char *p, char **pend) {
 	while(*pend > p && strchr(vfs_syspath_separators, *(*pend - 1))) {
@@ -64,6 +65,12 @@ bool vfs_mount_syspath(const char *mountpoint, const char *fspath, uint flags) {
 		vfs_set_error("Can't create directory: %s", vfs_get_error());
 		vfs_decref(rdir);
 		return false;
+	}
+
+	if(flags & VFS_SYSPATH_MOUNT_DECOMPRESSVIEW) {
+		VFSNode *rdir_decomp = vfs_decomp_wrap(rdir);
+		vfs_decref(rdir);
+		rdir = rdir_decomp;
 	}
 
 	if(flags & VFS_SYSPATH_MOUNT_READONLY) {

--- a/src/vfs/syspath_public.h
+++ b/src/vfs/syspath_public.h
@@ -14,6 +14,7 @@
 enum {
 	VFS_SYSPATH_MOUNT_READONLY = (1 << 0),
 	VFS_SYSPATH_MOUNT_MKDIR = (1 << 1),
+	VFS_SYSPATH_MOUNT_DECOMPRESSVIEW = (1 << 2),
 };
 
 bool vfs_mount_syspath(const char *mountpoint, const char *fspath, uint flags)

--- a/src/vfs/zipfile_impl.h
+++ b/src/vfs/zipfile_impl.h
@@ -52,7 +52,7 @@ typedef struct VFSZipPathData {
 	uint64_t index;
 	ssize_t size;
 	VFSInfo info;
-	bool seekable;
+	uint16_t compression;
 } VFSZipPathData;
 
 void vfs_zippath_init(VFSNode *node, VFSNode *zipnode, zip_int64_t idx);

--- a/src/vfs/zipfile_impl.h
+++ b/src/vfs/zipfile_impl.h
@@ -17,6 +17,10 @@ DIAGNOSTIC_CLANG(ignored "-Wnullability-extension")
 #include <zip.h>
 DIAGNOSTIC_CLANG(pop)
 
+#ifndef ZIP_CM_ZSTD
+	#define ZIP_CM_ZSTD 93
+#endif
+
 #include "private.h"
 #include "hashtable.h"
 
@@ -51,6 +55,7 @@ typedef struct VFSZipPathData {
 	VFSNode *zipnode;
 	uint64_t index;
 	ssize_t size;
+	ssize_t compressed_size;
 	VFSInfo info;
 	uint16_t compression;
 } VFSZipPathData;

--- a/src/vfs/zippath.c
+++ b/src/vfs/zippath.c
@@ -115,6 +115,7 @@ void vfs_zippath_init(VFSNode *node, VFSNode *zipnode, zip_int64_t idx) {
 	zdata->zipnode = zipnode;
 	zdata->index = idx;
 	zdata->size = -1;
+	zdata->compressed_size = -1;
 	zdata->compression = ZIP_CM_STORE;
 	node->data1 = zdata;
 
@@ -132,6 +133,10 @@ void vfs_zippath_init(VFSNode *node, VFSNode *zipnode, zip_int64_t idx) {
 	} else {
 		if(zstat.valid & ZIP_STAT_SIZE) {
 			zdata->size = zstat.size;
+		}
+
+		if(zstat.valid & ZIP_STAT_COMP_SIZE) {
+			zdata->compressed_size = zstat.comp_size;
 		}
 
 		if(zstat.valid & ZIP_STAT_COMP_METHOD) {

--- a/src/vfs/zippath.c
+++ b/src/vfs/zippath.c
@@ -88,7 +88,7 @@ static SDL_RWops* vfs_zippath_open(VFSNode *node, VFSOpenMode mode) {
 
 	VFSZipPathData *zdata = node->data1;
 
-	if(mode & VFS_MODE_SEEKABLE && !zdata->seekable) {
+	if(mode & VFS_MODE_SEEKABLE && zdata->compression != ZIP_CM_STORE) {
 		char *repr = vfs_node_repr(node, true);
 		log_warn("Opening compressed file '%s' in seekable mode, this is suboptimal. Consider storing this file without compression", repr);
 		free(repr);
@@ -115,6 +115,7 @@ void vfs_zippath_init(VFSNode *node, VFSNode *zipnode, zip_int64_t idx) {
 	zdata->zipnode = zipnode;
 	zdata->index = idx;
 	zdata->size = -1;
+	zdata->compression = ZIP_CM_STORE;
 	node->data1 = zdata;
 
 	zdata->info.exists = true;
@@ -134,7 +135,7 @@ void vfs_zippath_init(VFSNode *node, VFSNode *zipnode, zip_int64_t idx) {
 		}
 
 		if(zstat.valid & ZIP_STAT_COMP_METHOD) {
-			zdata->seekable = (zstat.comp_method == ZIP_CM_STORE);
+			zdata->compression = zstat.comp_method;
 		}
 	}
 

--- a/subprojects/.gitignore
+++ b/subprojects/.gitignore
@@ -7,6 +7,7 @@ glslang
 libpng
 libwebp
 libzip
+libzstd
 ogg
 opus
 opusfile

--- a/subprojects/libzstd.wrap
+++ b/subprojects/libzstd.wrap
@@ -1,0 +1,5 @@
+[wrap-git]
+directory=libzstd
+url=https://github.com/taisei-project/zstd.git
+push-url=git@github.com:taisei-project/zstd.git
+revision=meson-1.4.9


### PR DESCRIPTION
Roadmap:

* [x] Implement RWops stream wrappers for compression and decompression.
* [x] Add libzstd subproject wrap.
* [x] Support loading zstd-compressed UASTC basis files; possibly via transparent decompression of `.zst` files at VFS level.
* [x] Decompress zstd entries in zips manually if libzip has no zstd support.
* [x] Rewrite `scripts/pack.py` to use zstd instead of deflate.
* [x] Add automatic zstd compression for UASTC to `scripts/mkbasis.py`
* [x] Switch from deflate to zstd in our internal formats:
    * [x] Texture cache
    * [x] Shader cache
    * [ ] ~~Progress file~~  Probably not happening; it needs to be readable by older versions
    * [ ] ~~Replays~~  Next time there's a struct format revision