### PR TITLE
Switch port fixes

### DIFF
--- a/src/arch_switch.c
+++ b/src/arch_switch.c
@@ -9,6 +9,7 @@
 
 #include "arch_switch.h"
 
+#include <unistd.h>
 #include <switch/services/applet.h>
 #include <switch/services/fs.h>
 #include <switch/services/ssl.h>

--- a/switch/crossfile.sh
+++ b/switch/crossfile.sh
@@ -20,6 +20,9 @@ function bin_path() {
 
 ADDITIONAL_LINK_FLAGS="-specs=$DEVKITPRO/libnx/switch.specs"
 
+# Revert upstream MSYS2 support mitigation
+CPPFLAGS="$(echo "$CPPFLAGS" | sed "s/-I /-I/g")"
+
 cat <<DOCEND
 [binaries]
 c = '$(bin_path gcc)'


### PR DESCRIPTION
* Fix missing include required to call getcwd
* Revert a fix made in the switch vars to allow MSYS2 path translation to happen, but broke meson type size deduction ( https://github.com/devkitPro/pacman-packages/commit/2e9c76f1a3e4afd3788856922cf2bb18afb45093 ) 