### PR TITLE
Use 'create-dmg' on macOS for prettier .dmg files

### DIFF
--- a/scripts/macos-gen-dmg.py
+++ b/scripts/macos-gen-dmg.py
@@ -32,24 +32,21 @@ def main(args):
         # for compiling on Darwin as 'genisoimage' doesn't exist
         # uses 'create-dmg' (brew install create-dmg)
         if platform == "darwin":
-            command = shlex.split(' \
-                create-dmg \
-                --volname "Taisei" \
-                --volicon "Taisei.app/Contents/Resources/Taisei.icns" \
-                --window-pos 200 120 \
-                --window-size 550 480 \
-                --icon-size 64 \
-                --icon "Taisei.app" 100 50 \
-                --icon "README.txt" 50 200 \
-                --icon "STORY.txt" 200 200 \
-                --icon "GAME.html" 350 200 \
-                --icon "COPYING" 125 350 \
-                --icon "ENVIRON.html" 275 350 \
-                --hide-extension "Taisei.app" \
-                --app-drop-link 300 50') + [
-                args.output,
-                str(install_path),
-            ]
+            command = shlex.split('''create-dmg
+                --volname "Taisei"
+                --volicon "Taisei.app/Contents/Resources/Taisei.icns"
+                --window-pos 200 120
+                --window-size 550 480
+                --icon-size 64
+                --icon "Taisei.app" 100 50
+                --icon "README.txt" 50 200
+                --icon "STORY.txt" 200 200
+                --icon "GAME.html" 350 200
+                --icon "COPYING" 125 350
+                --icon "ENVIRON.html" 275 350
+                --hide-extension "Taisei.app"
+                --app-drop-link 300 50
+                {0} {1}'''.format(args.output, str(install_path)))
         else:
             (install_path / 'Applications').symlink_to('/Applications')
 

--- a/scripts/macos-gen-dmg.py
+++ b/scripts/macos-gen-dmg.py
@@ -45,8 +45,7 @@ def main(args):
                 --icon "COPYING" 125 350
                 --icon "ENVIRON.html" 275 350
                 --hide-extension "Taisei.app"
-                --app-drop-link 300 50
-                {0} {1}'''.format(args.output, str(install_path)))
+                --app-drop-link 300 50''') + [args.output, str(install_path)]
         else:
             (install_path / 'Applications').symlink_to('/Applications')
 


### PR DESCRIPTION
Like it says on the tin.

This would even let us use background images in the future, should we get art for that (or care enough to do it).

Still lets you use `genisoimage` on non-macOS platforms for testing purposes.