### PR TITLE
events: reduce processing overhead

### DIFF
--- a/src/dynarray.c
+++ b/src/dynarray.c
@@ -90,7 +90,3 @@ void _dynarray_filter(dynarray_size_t sizeof_element, DynamicArray *darr, dynarr
 		p += sizeof_element;
 	}
 }
-
-#if 0
-
-#endif

--- a/src/events.h
+++ b/src/events.h
@@ -51,32 +51,34 @@ typedef enum {
 } TaiseiEvent;
 
 typedef enum {
-	EPRIO_DEFAULT = 0,
-
 	// from highest to lowest
 	// feel free to add new prios as needed, just don't randomly reorder stuff
 
-	EPRIO_SYSTEM,       // for events not associated with user input
+	EPRIO_SYSTEM = -4,  // for events not associated with user input
 	EPRIO_TRANSLATION,  // for translating raw input events into higher level Taisei events
 	EPRIO_CAPTURE,      // for capturing raw user input before it's further processed
 	EPRIO_HOTKEYS,      // for global keybindings
 	EPRIO_NORMAL,       // for everything else
 
-	NUM_EPRIOS
+	EPRIO_DEFAULT = EPRIO_NORMAL,
+	EPRIO_FIRST = EPRIO_SYSTEM,
+	EPRIO_LAST = EPRIO_NORMAL,
+	NUM_EPRIOS = EPRIO_LAST - EPRIO_FIRST + 1,
 } EventPriority;
+
+static_assert_nomsg(EPRIO_DEFAULT == 0);
 
 typedef enum {
 	EFLAG_MENU = (1 << 0),
 	EFLAG_GAME = (1 << 1),
 	EFLAG_TEXT = (1 << 2),
+	EFLAG_NOPUMP = (1 << 3),
 } EventFlags;
 
 typedef enum {
 	INDEV_KEYBOARD,
 	INDEV_GAMEPAD,
 } InputDevice;
-
-#define EPRIO_DEFAULT_REMAP EPRIO_NORMAL
 
 // if the this returns true, the event won't be passed down to lower priority handlers
 typedef bool (*EventHandlerProc)(SDL_Event *event, void *arg);

--- a/src/gamepad.c
+++ b/src/gamepad.c
@@ -287,7 +287,14 @@ bool gamepad_update_devices(void) {
 	return true;
 }
 
+static inline void set_events_state(int state) {
+	SDL_JoystickEventState(state);
+	SDL_GameControllerEventState(state);
+}
+
 void gamepad_init(void) {
+	set_events_state(SDL_IGNORE);
+
 	if(!config_get_int(CONFIG_GAMEPAD_ENABLED) || gamepad.initialized) {
 		return;
 	}
@@ -309,7 +316,7 @@ void gamepad_init(void) {
 		.priority = EPRIO_TRANSLATION,
 	});
 
-	SDL_GameControllerEventState(SDL_ENABLE);
+	set_events_state(SDL_ENABLE);
 }
 
 void gamepad_shutdown(void) {
@@ -330,7 +337,7 @@ void gamepad_shutdown(void) {
 
 	free(gamepad.devices);
 
-	SDL_GameControllerEventState(SDL_IGNORE);
+	set_events_state(SDL_IGNORE);
 	SDL_QuitSubSystem(SDL_INIT_GAMECONTROLLER);
 
 	memset(&gamepad, 0, sizeof(gamepad));

--- a/src/stage.c
+++ b/src/stage.c
@@ -422,11 +422,19 @@ static bool stage_handle_bgm_change(SDL_Event *evt, void *a) {
 }
 
 static void stage_input(void) {
-	events_poll((EventHandler[]){
-		{ .proc = stage_input_handler_gameplay },
-		{ .proc = stage_handle_bgm_change, .event_type = MAKE_TAISEI_EVENT(TE_AUDIO_BGM_STARTED) },
-		{NULL}
-	}, EFLAG_GAME);
+	if(stage_is_skip_mode()) {
+		events_poll((EventHandler[]){
+			{ .proc = stage_handle_bgm_change, .event_type = MAKE_TAISEI_EVENT(TE_AUDIO_BGM_STARTED) },
+			{NULL}
+		}, EFLAG_NOPUMP);
+	} else {
+		events_poll((EventHandler[]){
+			{ .proc = stage_input_handler_gameplay },
+			{ .proc = stage_handle_bgm_change, .event_type = MAKE_TAISEI_EVENT(TE_AUDIO_BGM_STARTED) },
+			{NULL}
+		}, EFLAG_GAME);
+	}
+
 	player_fix_input(&global.plr);
 	player_applymovement(&global.plr);
 }
@@ -631,6 +639,11 @@ void stage_finish(int gameover) {
 			++p->num_cleared;
 			log_debug("Stage cleared %u times now", p->num_cleared);
 		}
+	}
+
+	if(gameover == GAMEOVER_SCORESCREEN && stage_is_skip_mode()) {
+		// don't get stuck in an infinite loop
+		taisei_quit();
 	}
 }
 


### PR DESCRIPTION
This is mostly aimed at speeding up `TAISEI_SKIP_TO_BOOKMARK` mode

- Store global handlers in a dynamic array
- Merge global and local handlers more efficiently, and only do it once per `events_poll()` call
- Do not pump SDL events while skipping through stages
- Avoid expensive system call when pushing custom events to the queue
- Process SDL events in batches; do not pump after every event
- Simplify handling of `EventPriority` enum - `EPRIO_DEFAULT` equals to 0, no remapping required