### PR TITLE
Add -lwebgl.js to fix macOS Emscripten build error

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -193,6 +193,7 @@ if host_machine.system() == 'emscripten'
         '-s', 'LLD_REPORT_UNDEFINED',
         '-lGL',
         '-lgl',
+        '-lwebgl.js',
         '-legl.js',
         '-lidbfs.js',
     ]


### PR DESCRIPTION
Simple one-line fix.

See: https://github.com/emscripten-core/emscripten/issues/10171