### PR TITLE
Emscripten CI test builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,9 +20,8 @@ on:
       - "**.yaml"
       - "**.build"
 
-# TODO: use later fixed version of emscripten when it releases
 env:
-  EM_VERSION: '2.0.19'
+  EM_VERSION: '2.0.21'
   EM_CACHE_FOLDER: 'emsdk'
   TAISEI_NOPRELOAD: 0
   TAISEI_PRELOAD_REQUIRED: 1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,11 +1,11 @@
-name: Taisei Test Build (CI)
+name: Test Builds
 on:
   push:
     branches:
       - master
-      - v1.*
+      - v*.*
     tags:
-      - v1.*
+      - v*.*
     paths:
       - "**.c"
       - "**.h"
@@ -24,12 +24,13 @@ env:
   EM_VERSION: '2.0.21'
   EM_VERSION_EXPERIMENTAL: 'latest'
   EM_CACHE_FOLDER: 'emsdk'
+  MESON_VERSION: '0.56.2'
   TAISEI_NOPRELOAD: 0
   TAISEI_PRELOAD_REQUIRED: 1
 
 jobs:
   linux-test-build:
-    name: Linux Test (x64)
+    name: Linux (x64)
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     runs-on: ubuntu-20.04
     steps:
@@ -45,7 +46,7 @@ jobs:
 
     - name: Install Tools
       run: >
-        sudo apt update || true
+        sudo apt update || true # debian cache is not atomic and can sometimes fail
 
         sudo apt install -y -qq
         build-essential
@@ -62,7 +63,7 @@ jobs:
         libzstd-dev
 
         pip install
-        meson==0.56.2
+        meson==${{ env.MESON_VERSION }}
         ninja
         zstandard
 
@@ -77,7 +78,7 @@ jobs:
         meson compile -C build/ --verbose
         meson install -C build/
 
-    - name: Test (Taisei)
+    - name: (Taisei)
       run: $(pwd)/build-test/bin/taisei -R $(pwd)/misc/ci/tests/test-replay.tsr
       env:
         TAISEI_NOPRELOAD: ${{ env.TAISEI_NOPRELOAD }}
@@ -91,7 +92,7 @@ jobs:
         if-no-files-found: warn
 
   macos-test-build:
-    name: macOS Test (x64)
+    name: macOS (x64)
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     runs-on: macos-10.15
     steps:
@@ -121,7 +122,7 @@ jobs:
         ninja
 
         pip install
-        meson==0.56.2
+        meson==${{ env.MESON_VERSION }}
         ninja
         zstandard
 
@@ -136,7 +137,7 @@ jobs:
         meson compile -C build/ --verbose
         meson install -C build/
 
-    - name: Test (Taisei)
+    - name: (Taisei)
       run: $(pwd)/build-test/Taisei.app/Contents/MacOS/Taisei -R $(pwd)/misc/ci/tests/test-replay.tsr
       env:
         TAISEI_NOPRELOAD: ${{ env.TAISEI_NOPRELOAD }}
@@ -150,7 +151,7 @@ jobs:
         if-no-files-found: warn
 
   windows-test-build:
-    name: Windows Test (x64)
+    name: Windows (x64)
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     runs-on: ubuntu-20.04
     container: mstorsjo/llvm-mingw:20210423 # cross-compiler with mingw
@@ -170,7 +171,7 @@ jobs:
         nsis
 
         pip3 install
-        meson==0.56.2
+        meson==${{ env.MESON_VERSION }}
         ninja
         zstandard
 
@@ -198,7 +199,7 @@ jobs:
         if-no-files-found: warn
 
   emscripten-test-build:
-    name: "Emscripten Test (emsdk: stable) (WebGL)"
+    name: "Emscripten (emsdk: stable)"
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     runs-on: ubuntu-20.04
     steps:
@@ -222,7 +223,7 @@ jobs:
         git
 
         pip install
-        meson==0.56.2
+        meson==${{ env.MESON_VERSION }}
         ninja
         zstandard
 
@@ -247,7 +248,7 @@ jobs:
         emcc -v
         tee misc/ci/emscripten-ephemeral-ci.ini <<EOF >/dev/null
         [constants]
-        toolchain = '$(pwd)/emsdk/upstream/emscripten/'
+        toolchain = '$(pwd)/${{ env.EM_CACHE_FOLDER }}/upstream/emscripten/'
         EOF
 
     - name: Configure
@@ -278,7 +279,7 @@ jobs:
         if-no-files-found: warn
 
   emscripten-test-build-latest:
-    name: "Emscripten Test (emsdk: experimental) (WebGL)"
+    name: "Emscripten (emsdk: latest)"
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     runs-on: ubuntu-20.04
     continue-on-error: true
@@ -303,7 +304,7 @@ jobs:
         git
 
         pip install
-        meson==0.56.2
+        meson==${{ env.MESON_VERSION }}
         ninja
         zstandard
 
@@ -319,7 +320,7 @@ jobs:
         if [[ ! -d ./emsdk ]]; then
           git clone https://github.com/emscripten-core/emsdk.git
         else
-          bash -c "cd emsdk; git pull"
+          bash -c "cd emsdk; git fetch --all; git reset --hard origin/master"
         fi
         emsdk/emsdk install ${{ env.EM_VERSION_EXPERIMENTAL }} || true
         emsdk/emsdk activate ${{ env.EM_VERSION_EXPERIMENTAL }}
@@ -330,7 +331,7 @@ jobs:
         emcc -v
         tee misc/ci/emscripten-ephemeral-ci.ini <<EOF >/dev/null
         [constants]
-        toolchain = '$(pwd)/emsdk/upstream/emscripten/'
+        toolchain = '$(pwd)/${{ env.EM_CACHE_FOLDER }}/upstream/emscripten/'
         EOF
 
     - name: Configure

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,10 +21,9 @@ on:
       - "**.build"
 
 env:
-  EM_VERSION: '2.0.21'
-  EM_VERSION_EXPERIMENTAL: 'latest'
-  EM_CACHE_FOLDER: 'emsdk'
   MESON_VERSION: '0.56.2'
+  EM_VERSION: '2.0.21'
+  EM_CACHE_FOLDER: 'emsdk'
   TAISEI_NOPRELOAD: 0
   TAISEI_PRELOAD_REQUIRED: 1
 
@@ -228,14 +227,14 @@ jobs:
         zstandard
 
     - name: Fetch Cached Emscripten SDK
-      id: cache-emsdk
+      id: emsdk-cache
       uses: actions/cache@v2
       with:
         path: ${{ env.EM_CACHE_FOLDER }}
         key: ${{ env.EM_VERSION }}-${{ runner.os }}
 
     - name: Install Emscripten SDK
-      if: steps.cache-emsdk.outputs.cache-hit != 'true'
+      if: steps.emsdk-cache.outputs.cache-hit != 'true'
       run: |
         rm -rf emsdk/
         git clone https://github.com/emscripten-core/emsdk.git
@@ -284,17 +283,40 @@ jobs:
     runs-on: ubuntu-20.04
     continue-on-error: true
     steps:
+    - name: Get Latest Emscripten SDK Tag
+      id: emsdk-tag
+      run: >
+        git clone https://github.com/emscripten-core/emsdk.git
+
+        git --git-dir=emsdk/.git fetch --tags
+
+        export EM_LATEST_TAG=$(git --git-dir=emsdk/.git describe --abbrev=0 --tags)
+
+        echo EM_LATEST_TAG=$EM_LATEST_TAG >> $GITHUB_ENV
+
+        if [[ $EM_LATEST_TAG != ${{ env.EM_VERSION }} ]]; then
+          echo "Versions differ (stable: $EM_LATEST_TAG, latest: ${{ env.EM_VERSION }}), running test build";
+          echo '::set-output name=run::true';
+        else
+          echo "Same tag as in stable build (stable: $EM_LATEST_TAG, latest: ${{ env.EM_VERSION }}), skipping";
+        fi # only run if version is different
+
+        rm -rf emsdk # cleanup
+
     - name: Checkout Code
+      if: steps.emsdk-tag.outputs.run == 'true'
       uses: actions/checkout@v2
       with:
         submodules: 'recursive'
 
     - name: Install Python
+      if: steps.emsdk-tag.outputs.run == 'true'
       uses: actions/setup-python@v2
       with:
         python-version: '3.x'
 
     - name: Install Tools
+      if: steps.emsdk-tag.outputs.run == 'true'
       run: >
         sudo apt update || true
 
@@ -308,13 +330,23 @@ jobs:
         ninja
         zstandard
 
+    - name: Fetch Cached Emscripten SDK
+      if: steps.emsdk-tag.outputs.run == 'true'
+      id: emsdk-cache
+      uses: actions/cache@v2
+      with:
+        path: ${{ env.EM_CACHE_FOLDER }}
+        key: ${{ env.EM_LATEST_TAG }}-${{ runner.os }}
+
     - name: Install Emscripten SDK
+      if: steps.emsdk-tag.outputs.run == 'true' && steps.emsdk-cache.outputs.cache-hit != 'true'
       run: |
         git clone https://github.com/emscripten-core/emsdk.git
-        emsdk/emsdk install ${{ env.EM_VERSION_EXPERIMENTAL }} || true
-        emsdk/emsdk activate ${{ env.EM_VERSION_EXPERIMENTAL }}
+        emsdk/emsdk install ${{ env.EM_LATEST_TAG }} || true
+        emsdk/emsdk activate ${{ env.EM_LATEST_TAG }}
 
     - name: Verify Emscripten SDK
+      if: steps.emsdk-tag.outputs.run == 'true'
       run: |
         source emsdk/emsdk_env.sh
         emcc -v
@@ -324,6 +356,7 @@ jobs:
         EOF
 
     - name: Configure
+      if: steps.emsdk-tag.outputs.run == 'true'
       run: >
         source emsdk/emsdk_env.sh
 
@@ -337,6 +370,7 @@ jobs:
         build/
 
     - name: Build
+      if: steps.emsdk-tag.outputs.run == 'true'
       run: |
         # this build is allowed to fail
         source emsdk/emsdk_env.sh
@@ -345,8 +379,9 @@ jobs:
         meson compile tar -C build/ --verbose
 
     - name: Upload Log
+      if: steps.emsdk-tag.outputs.run == 'true'
       uses: actions/upload-artifact@v2
       with:
-        name: taisei_emscripten_experimental_build_log
+        name: taisei_emscripten_latest_build_log
         path: build/meson-logs/meson-log.txt
         if-no-files-found: warn

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,7 @@ on:
 
 env:
   EM_VERSION: '2.0.21'
+  EM_VERSION_EXPERIMENTAL: 'latest'
   EM_CACHE_FOLDER: 'emsdk'
   TAISEI_NOPRELOAD: 0
   TAISEI_PRELOAD_REQUIRED: 1
@@ -197,7 +198,7 @@ jobs:
         if-no-files-found: warn
 
   emscripten-test-build:
-    name: Emscripten Test (Pinned Version) (WebGL)
+    name: "Emscripten Test (emsdk: stable) (WebGL)"
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     runs-on: ubuntu-20.04
     steps:
@@ -272,14 +273,15 @@ jobs:
     - name: Upload Log
       uses: actions/upload-artifact@v2
       with:
-        name: taisei_emscripten_pinned_build_log
-        path: build/emscripten/meson-logs/meson-log.txt
+        name: taisei_emscripten_stable_build_log
+        path: build/meson-logs/meson-log.txt
         if-no-files-found: warn
 
   emscripten-test-build-latest:
-    name: Emscripten Test (Latest Version) (WebGL)
+    name: "Emscripten Test (emsdk: experimental) (WebGL)"
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     runs-on: ubuntu-20.04
+    continue-on-error: true
     steps:
     - name: Checkout Code
       uses: actions/checkout@v2
@@ -310,7 +312,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ${{ env.EM_CACHE_FOLDER }}
-        key: latest-${{ runner.os }}
+        key: ${{ env.EM_VERSION_EXPERIMENTAL }}-${{ runner.os }}
 
     - name: Install emsdk
       run: |
@@ -319,8 +321,8 @@ jobs:
         else
           bash -c "cd emsdk; git pull"
         fi
-        emsdk/emsdk install latest || true
-        emsdk/emsdk activate latest
+        emsdk/emsdk install ${{ env.EM_VERSION_EXPERIMENTAL }} || true
+        emsdk/emsdk activate ${{ env.EM_VERSION_EXPERIMENTAL }}
 
     - name: Verify emsdk
       run: |
@@ -346,6 +348,7 @@ jobs:
 
     - name: Build
       run: |
+        # this build is allowed to fail
         source emsdk/emsdk_env.sh
         # TODO: SPIRV-Tools has a race condition where it sometimes fails, fix that
         meson compile tar -C build/ --verbose || true
@@ -354,6 +357,6 @@ jobs:
     - name: Upload Log
       uses: actions/upload-artifact@v2
       with:
-        name: taisei_emscripten_latest_build_log
-        path: build/emscripten/meson-logs/meson-log.txt
+        name: taisei_emscripten_experimental_build_log
+        path: build/meson-logs/meson-log.txt
         if-no-files-found: warn

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -197,7 +197,7 @@ jobs:
         if-no-files-found: warn
 
   emscripten-test-build:
-    name: Emscripten Test (WebGL)
+    name: Emscripten Test (Pinned Version) (WebGL)
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     runs-on: ubuntu-20.04
     steps:
@@ -272,6 +272,88 @@ jobs:
     - name: Upload Log
       uses: actions/upload-artifact@v2
       with:
-        name: taisei_emscripten_build_log
+        name: taisei_emscripten_pinned_build_log
+        path: build/emscripten/meson-logs/meson-log.txt
+        if-no-files-found: warn
+
+  emscripten-test-build-latest:
+    name: Emscripten Test (Latest Version) (WebGL)
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v2
+      with:
+        submodules: 'recursive'
+
+    - name: Install Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+
+    - name: Install Tools
+      run: >
+        sudo apt update || true
+
+        sudo apt install -y -qq
+        python3-docutils
+        python3-pip
+        git
+
+        pip install
+        meson==0.56.2
+        ninja
+        zstandard
+
+    - name: Pull cached emsdk
+      id: cache-emsdk
+      uses: actions/cache@v2
+      with:
+        path: ${{ env.EM_CACHE_FOLDER }}
+        key: latest-${{ runner.os }}
+
+    - name: Install emsdk
+      run: |
+        if [[ ! -d ./emsdk ]]; then
+          git clone https://github.com/emscripten-core/emsdk.git
+        else
+          bash -c "cd emsdk; git pull"
+        fi
+        emsdk/emsdk install latest || true
+        emsdk/emsdk activate latest
+
+    - name: Verify emsdk
+      run: |
+        source emsdk/emsdk_env.sh
+        emcc -v
+        tee misc/ci/emscripten-ephemeral-ci.ini <<EOF >/dev/null
+        [constants]
+        toolchain = '$(pwd)/emsdk/upstream/emscripten/'
+        EOF
+
+    - name: Configure
+      run: >
+        source emsdk/emsdk_env.sh
+
+        meson setup build/
+        --cross-file misc/ci/emscripten-ephemeral-ci.ini
+        --cross-file misc/ci/emscripten-build-test-ci.ini
+        --prefix=$(pwd)/build-test
+
+        meson configure
+        -Dbuild.cpp_std=gnu++14
+        build/
+
+    - name: Build
+      run: |
+        source emsdk/emsdk_env.sh
+        # TODO: SPIRV-Tools has a race condition where it sometimes fails, fix that
+        meson compile tar -C build/ --verbose || true
+        meson compile tar -C build/ --verbose
+
+    - name: Upload Log
+      uses: actions/upload-artifact@v2
+      with:
+        name: taisei_emscripten_latest_build_log
         path: build/emscripten/meson-logs/meson-log.txt
         if-no-files-found: warn

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -308,20 +308,9 @@ jobs:
         ninja
         zstandard
 
-    - name: Fetch Cached Emscripten SDK
-      id: cache-emsdk
-      uses: actions/cache@v2
-      with:
-        path: ${{ env.EM_CACHE_FOLDER }}
-        key: ${{ env.EM_VERSION_EXPERIMENTAL }}-${{ runner.os }}
-
     - name: Install Emscripten SDK
       run: |
-        if [[ ! -d ./emsdk ]]; then
-          git clone https://github.com/emscripten-core/emsdk.git
-        else
-          bash -c "cd emsdk; git fetch --all; git reset --hard origin/main"
-        fi
+        git clone https://github.com/emscripten-core/emsdk.git
         emsdk/emsdk install ${{ env.EM_VERSION_EXPERIMENTAL }} || true
         emsdk/emsdk activate ${{ env.EM_VERSION_EXPERIMENTAL }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -227,14 +227,14 @@ jobs:
         ninja
         zstandard
 
-    - name: Pull cached emsdk
+    - name: Fetch Cached Emscripten SDK
       id: cache-emsdk
       uses: actions/cache@v2
       with:
         path: ${{ env.EM_CACHE_FOLDER }}
         key: ${{ env.EM_VERSION }}-${{ runner.os }}
 
-    - name: Install emsdk
+    - name: Install Emscripten SDK
       if: steps.cache-emsdk.outputs.cache-hit != 'true'
       run: |
         rm -rf emsdk/
@@ -242,7 +242,7 @@ jobs:
         emsdk/emsdk install ${{ env.EM_VERSION }}
         emsdk/emsdk activate ${{ env.EM_VERSION }}
 
-    - name: Verify emsdk
+    - name: Verify Emscripten SDK
       run: |
         source emsdk/emsdk_env.sh
         emcc -v
@@ -308,14 +308,14 @@ jobs:
         ninja
         zstandard
 
-    - name: Pull cached emsdk
+    - name: Fetch Cached Emscripten SDK
       id: cache-emsdk
       uses: actions/cache@v2
       with:
         path: ${{ env.EM_CACHE_FOLDER }}
         key: ${{ env.EM_VERSION_EXPERIMENTAL }}-${{ runner.os }}
 
-    - name: Install emsdk
+    - name: Install Emscripten SDK
       run: |
         if [[ ! -d ./emsdk ]]; then
           git clone https://github.com/emscripten-core/emsdk.git
@@ -325,7 +325,7 @@ jobs:
         emsdk/emsdk install ${{ env.EM_VERSION_EXPERIMENTAL }} || true
         emsdk/emsdk activate ${{ env.EM_VERSION_EXPERIMENTAL }}
 
-    - name: Verify emsdk
+    - name: Verify Emscripten SDK
       run: |
         source emsdk/emsdk_env.sh
         emcc -v

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,7 +78,7 @@ jobs:
         meson compile -C build/ --verbose
         meson install -C build/
 
-    - name: (Taisei)
+    - name: Run Test
       run: $(pwd)/build-test/bin/taisei -R $(pwd)/misc/ci/tests/test-replay.tsr
       env:
         TAISEI_NOPRELOAD: ${{ env.TAISEI_NOPRELOAD }}
@@ -137,7 +137,7 @@ jobs:
         meson compile -C build/ --verbose
         meson install -C build/
 
-    - name: (Taisei)
+    - name: Run Test
       run: $(pwd)/build-test/Taisei.app/Contents/MacOS/Taisei -R $(pwd)/misc/ci/tests/test-replay.tsr
       env:
         TAISEI_NOPRELOAD: ${{ env.TAISEI_NOPRELOAD }}
@@ -320,7 +320,7 @@ jobs:
         if [[ ! -d ./emsdk ]]; then
           git clone https://github.com/emscripten-core/emsdk.git
         else
-          bash -c "cd emsdk; git fetch --all; git reset --hard origin/master"
+          bash -c "cd emsdk; git fetch --all; git reset --hard origin/main"
         fi
         emsdk/emsdk install ${{ env.EM_VERSION_EXPERIMENTAL }} || true
         emsdk/emsdk activate ${{ env.EM_VERSION_EXPERIMENTAL }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Taisei Test Builds (CI)
+name: Taisei Test Build (CI)
 on:
   push:
     branches:
@@ -29,7 +29,7 @@ env:
 
 jobs:
   linux-test-build:
-    name: Linux Test Build (x64)
+    name: Linux Test (x64)
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     runs-on: ubuntu-20.04
     steps:
@@ -43,7 +43,7 @@ jobs:
       with:
         python-version: '3.x'
 
-    - name: Install Build Tools (apt)
+    - name: Install Tools
       run: >
         sudo apt update || true
 
@@ -77,7 +77,7 @@ jobs:
         meson compile -C build/ --verbose
         meson install -C build/
 
-    - name: Run Test
+    - name: Test (Taisei)
       run: $(pwd)/build-test/bin/taisei -R $(pwd)/misc/ci/tests/test-replay.tsr
       env:
         TAISEI_NOPRELOAD: ${{ env.TAISEI_NOPRELOAD }}
@@ -91,7 +91,7 @@ jobs:
         if-no-files-found: warn
 
   macos-test-build:
-    name: macOS Test Build (x64)
+    name: macOS Test (x64)
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     runs-on: macos-10.15
     steps:
@@ -100,12 +100,12 @@ jobs:
       with:
         submodules: 'recursive'
 
-    - name: Set Up Build Environment
+    - name: Install Python
       uses: actions/setup-python@v2
       with:
         python-version: '3.x'
 
-    - name: Install Build Tools
+    - name: Install Tools
       run: >
         brew install
         gcc
@@ -136,7 +136,7 @@ jobs:
         meson compile -C build/ --verbose
         meson install -C build/
 
-    - name: Run Test
+    - name: Test (Taisei)
       run: $(pwd)/build-test/Taisei.app/Contents/MacOS/Taisei -R $(pwd)/misc/ci/tests/test-replay.tsr
       env:
         TAISEI_NOPRELOAD: ${{ env.TAISEI_NOPRELOAD }}
@@ -150,12 +150,12 @@ jobs:
         if-no-files-found: warn
 
   windows-test-build:
-    name: Windows Test Build (x64)
+    name: Windows Test (x64)
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     runs-on: ubuntu-20.04
     container: mstorsjo/llvm-mingw:20210423 # cross-compiler with mingw
     steps:
-    - name: Install tools (Apt)
+    - name: Install Tools
       run: >
         apt update || true
 
@@ -198,7 +198,7 @@ jobs:
         if-no-files-found: warn
 
   emscripten-test-build:
-    name: Emscripten Test Build (WebGL)
+    name: Emscripten Test (WebGL)
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     runs-on: ubuntu-20.04
     steps:
@@ -207,12 +207,12 @@ jobs:
       with:
         submodules: 'recursive'
 
-    - name: Set Up Build Environment
+    - name: Install Python
       uses: actions/setup-python@v2
       with:
         python-version: '3.x'
 
-    - name: Install Build Tools
+    - name: Install Tools
       run: >
         sudo apt update || true
 
@@ -266,7 +266,7 @@ jobs:
     - name: Build
       run: |
         source emsdk/emsdk_env.sh
-        # run twice due to a header race condition with SPIRV-Tools
+        # TODO: SPIRV-Tools has a race condition where it sometimes fails, fix that
         meson compile tar -C build/ --verbose || true
         meson compile tar -C build/ --verbose
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: taisei-build-tests
+name: Taisei Test Builds (CI)
 on:
   push:
     branches:
@@ -20,8 +20,16 @@ on:
       - "**.yaml"
       - "**.build"
 
+# TODO: use later version when it releases
+env:
+  EM_VERSION: '2.0.19'
+  EM_CACHE_FOLDER: 'emsdk'
+  TAISEI_NOPRELOAD: 0
+  TAISEI_PRELOAD_REQUIRED: 1
+
 jobs:
   linux-test-build:
+    name: Linux Test Build (x64)
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     runs-on: ubuntu-20.04
     steps:
@@ -54,7 +62,7 @@ jobs:
         libzstd-dev
 
         pip install
-        meson==0.55.3
+        meson==0.56.2
         ninja
         zstandard
 
@@ -72,8 +80,8 @@ jobs:
     - name: Run Test
       run: $(pwd)/build-test/bin/taisei -R $(pwd)/misc/ci/tests/test-replay.tsr
       env:
-        TAISEI_NOPRELOAD: 0
-        TAISEI_PRELOAD_REQUIRED: 1
+        TAISEI_NOPRELOAD: ${{ env.TAISEI_NOPRELOAD }}
+        TAISEI_PRELOAD_REQUIRED: ${{ env.TAISEI_PRELOAD_REQUIRED }}
 
     - name: Upload Log
       uses: actions/upload-artifact@v2
@@ -83,6 +91,7 @@ jobs:
         if-no-files-found: warn
 
   macos-test-build:
+    name: macOS Test Build (x64)
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     runs-on: macos-10.15
     steps:
@@ -112,7 +121,7 @@ jobs:
         ninja
 
         pip install
-        meson==0.55.3
+        meson==0.56.2
         ninja
         zstandard
 
@@ -130,8 +139,8 @@ jobs:
     - name: Run Test
       run: $(pwd)/build-test/Taisei.app/Contents/MacOS/Taisei -R $(pwd)/misc/ci/tests/test-replay.tsr
       env:
-        TAISEI_NOPRELOAD: 0
-        TAISEI_PRELOAD_REQUIRED: 1
+        TAISEI_NOPRELOAD: ${{ env.TAISEI_NOPRELOAD }}
+        TAISEI_PRELOAD_REQUIRED: ${{ env.TAISEI_PRELOAD_REQUIRED }}
 
     - name: Upload Log
       uses: actions/upload-artifact@v2
@@ -141,6 +150,7 @@ jobs:
         if-no-files-found: warn
 
   windows-test-build:
+    name: Windows Test Build (x64)
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     runs-on: ubuntu-20.04
     container: mstorsjo/llvm-mingw:20210423 # cross-compiler with mingw
@@ -160,7 +170,7 @@ jobs:
         nsis
 
         pip3 install
-        meson==0.55.3
+        meson==0.56.2
         ninja
         zstandard
 
@@ -184,5 +194,80 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: taisei_windows_fail_log
+        path: build/meson-logs/meson-log.txt
+        if-no-files-found: warn
+
+  emscripten-test-build:
+    name: Emscripten Test Build (WebGL)
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v2
+      with:
+        submodules: 'recursive'
+
+    - name: Set Up Build Environment
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+
+    - name: Install Build Tools
+      run: >
+        sudo apt update
+
+        sudo apt install -y -qq
+        python3-docutils
+        python3-pip
+        git
+
+        pip install
+        meson==0.56.2
+        ninja
+        zstandard
+
+    - name: Pull cached emsdk
+      id: cache-emsdk
+      uses: actions/cache@v2
+      with:
+        path: ${{ env.EM_CACHE_FOLDER }}
+        key: ${{ env.EM_VERSION }}-${{ runner.os }}
+
+    - name: Install emsdk
+      if: steps.cache-emsdk.outputs.cache-hit != 'true'
+      run: |
+        rm -rf emsdk/
+        git clone https://github.com/emscripten-core/emsdk.git
+        emsdk/emsdk install ${{ env.EM_VERSION }}
+        emsdk/emsdk activate ${{ env.EM_VERSION }}
+
+    - name: Verify emsdk
+      run: |
+        source emsdk/emsdk_env.sh
+        emcc -v
+
+    - name: Configure (Meson)
+      run: >
+        source emsdk/emsdk_env.sh
+
+        meson setup build/
+        --cross-file misc/ci/emscripten-build-test-ci.ini
+        --prefix=$(pwd)/build-test
+
+        meson configure
+        -Dbuild.cpp_std=gnu++14
+        build/
+
+    - name: Build
+      run: |
+        source emsdk/emsdk_env.sh
+        # run twice due to a header race condition with SPIRV-Tools
+        meson compile txz -C build/ --verbose || true
+        meson compile txz -C build/ --verbose
+
+    - name: Upload Log
+      uses: actions/upload-artifact@v2
+      with:
+        name: taisei_emscripten_build_log
         path: build/meson-logs/meson-log.txt
         if-no-files-found: warn

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,13 +66,13 @@ jobs:
         ninja
         zstandard
 
-    - name: Configure (Meson)
+    - name: Configure
       run: >
         meson setup build/
-        --prefix=$(pwd)/build-test
         --native-file misc/ci/linux-x86_64-build-test-ci.ini
+        --prefix=$(pwd)/build-test
 
-    - name: Build & Install
+    - name: Build
       run: |
         meson compile -C build/ --verbose
         meson install -C build/
@@ -125,13 +125,13 @@ jobs:
         ninja
         zstandard
 
-    - name: Configure (Meson)
+    - name: Configure
       run: >
         meson setup build/
         --native-file misc/ci/macos-x86_64-build-test-ci.ini
         --prefix=$(pwd)/build-test
 
-    - name: Build & Install
+    - name: Build
       run: |
         meson compile -C build/ --verbose
         meson install -C build/
@@ -182,10 +182,10 @@ jobs:
     - name: Configure Taisei (Meson)
       run: >
         meson setup build/
-        --prefix=$(pwd)/build-test
         --cross-file misc/ci/windows-llvm_mingw-x86_64-build-test-ci.ini
+        --prefix=$(pwd)/build-test
 
-    - name: Build & Install
+    - name: Build
       run: |
         meson compile -C build/ --verbose
         meson install -C build/
@@ -250,7 +250,7 @@ jobs:
         toolchain = '$(pwd)/emsdk/upstream/emscripten/'
         EOF
 
-    - name: Configure (Meson)
+    - name: Configure
       run: >
         source emsdk/emsdk_env.sh
 
@@ -274,5 +274,5 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: taisei_emscripten_build_log
-        path: build/meson-logs/meson-log.txt
+        path: build/emscripten/meson-logs/meson-log.txt
         if-no-files-found: warn

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ on:
       - "**.yaml"
       - "**.build"
 
-# TODO: use later version when it releases
+# TODO: use later fixed version of emscripten when it releases
 env:
   EM_VERSION: '2.0.19'
   EM_CACHE_FOLDER: 'emsdk'
@@ -45,7 +45,7 @@ jobs:
 
     - name: Install Build Tools (apt)
       run: >
-        sudo apt update
+        sudo apt update || true
 
         sudo apt install -y -qq
         build-essential
@@ -157,7 +157,7 @@ jobs:
     steps:
     - name: Install tools (Apt)
       run: >
-        apt update
+        apt update || true
 
         apt install -y -qq software-properties-common
 
@@ -214,7 +214,7 @@ jobs:
 
     - name: Install Build Tools
       run: >
-        sudo apt update
+        sudo apt update || true
 
         sudo apt install -y -qq
         python3-docutils
@@ -245,12 +245,17 @@ jobs:
       run: |
         source emsdk/emsdk_env.sh
         emcc -v
+        tee misc/ci/emscripten-ephemeral-ci.ini <<EOF >/dev/null
+        [constants]
+        toolchain = '$(pwd)/emsdk/upstream/emscripten/'
+        EOF
 
     - name: Configure (Meson)
       run: >
         source emsdk/emsdk_env.sh
 
         meson setup build/
+        --cross-file misc/ci/emscripten-ephemeral-ci.ini
         --cross-file misc/ci/emscripten-build-test-ci.ini
         --prefix=$(pwd)/build-test
 
@@ -262,8 +267,8 @@ jobs:
       run: |
         source emsdk/emsdk_env.sh
         # run twice due to a header race condition with SPIRV-Tools
-        meson compile txz -C build/ --verbose || true
-        meson compile txz -C build/ --verbose
+        meson compile tar -C build/ --verbose || true
+        meson compile tar -C build/ --verbose
 
     - name: Upload Log
       uses: actions/upload-artifact@v2

--- a/misc/ci/emscripten-build-test-ci.ini
+++ b/misc/ci/emscripten-build-test-ci.ini
@@ -3,11 +3,11 @@ cflags = []
 ldflags = ['-v']
 
 [binaries]
-ar = 'emar'
-c = 'emcc'
-cpp = 'em++'
-ranlib = 'emranlib'
-file_packager = '/home/runner/work/taisei/taisei/emsdk/upstream/emscripten/tools/file_packager'
+ar = toolchain / 'emar'
+c = toolchain / 'emcc'
+cpp = toolchain / 'em++'
+ranlib = toolchain / 'emranlib'
+file_packager = toolchain / 'tool/file_packager'
 
 [properties]
 needs_exe_wrapper = true

--- a/misc/ci/emscripten-build-test-ci.ini
+++ b/misc/ci/emscripten-build-test-ci.ini
@@ -16,6 +16,7 @@ source_map_base = 'http://localhost:6931/'
 [built-in options]
 b_ndebug = 'true'
 b_pie = false
+b_pch = false
 b_staticpic = false
 c_args = cflags
 c_link_args = ldflags

--- a/misc/ci/emscripten-build-test-ci.ini
+++ b/misc/ci/emscripten-build-test-ci.ini
@@ -1,0 +1,53 @@
+[constants]
+cflags = []
+ldflags = ['-v']
+
+[binaries]
+ar = 'emar'
+c = 'emcc'
+cpp = 'em++'
+ranlib = 'emranlib'
+file_packager = '/home/runner/work/taisei/taisei/emsdk/upstream/emscripten/tools/file_packager'
+
+[properties]
+needs_exe_wrapper = true
+source_map_base = 'http://localhost:6931/'
+
+[built-in options]
+b_ndebug = 'true'
+b_pie = false
+b_staticpic = false
+c_args = cflags
+c_link_args = ldflags
+c_thread_count = 0
+cpp_args = cflags
+cpp_eh = 'none'
+cpp_link_args = ldflags
+cpp_rtti = false
+cpp_thread_count = 0
+default_library = 'static'
+optimization = 's'
+wrap_mode = 'forcefallback'
+
+[project options]
+enable_zip = false
+force_vendored_shader_tools = true
+package_data = 'false'
+
+[sdl2_mixer:project options]
+enable_vorbis = 'disabled'
+enable_wav = 'disabled'
+
+[sdl2:project options]
+use_audio_alsa = 'disabled'
+use_audio_pulseaudio = 'disabled'
+use_loadso = 'disabled'
+use_threads = 'disabled'
+use_video_wayland = 'disabled'
+use_video_x11 = 'disabled'
+
+[host_machine]
+cpu = 'mvp'
+cpu_family = 'wasm32'
+endian = 'little'
+system = 'emscripten'

--- a/misc/ci/emscripten-build-test-ci.ini
+++ b/misc/ci/emscripten-build-test-ci.ini
@@ -7,7 +7,7 @@ ar = toolchain / 'emar'
 c = toolchain / 'emcc'
 cpp = toolchain / 'em++'
 ranlib = toolchain / 'emranlib'
-file_packager = toolchain / 'tool/file_packager'
+file_packager = toolchain / 'tools/file_packager'
 
 [properties]
 needs_exe_wrapper = true

--- a/misc/ci/linux-x86_64-build-test-ci.ini
+++ b/misc/ci/linux-x86_64-build-test-ci.ini
@@ -15,10 +15,10 @@ cpp_args = cflags
 cpp_link_args = ldflags
 wrap_mode = 'nofallback'
 force_fallback_for = 'cglm'
-werror = false
+werror = true
 b_pch = false
 b_lto = false
 strip = false
 
-[basis_universal: built-in options]
+[basis_universal:built-in options]
 werror = false

--- a/misc/ci/macos-x86_64-build-test-ci.ini
+++ b/misc/ci/macos-x86_64-build-test-ci.ini
@@ -22,5 +22,5 @@ b_pch = false
 b_lto = false
 strip = false
 
-[basis_universal: built-in options]
+[basis_universal:built-in options]
 werror = false

--- a/misc/ci/windows-llvm_mingw-x86_64-build-test-ci.ini
+++ b/misc/ci/windows-llvm_mingw-x86_64-build-test-ci.ini
@@ -44,22 +44,10 @@ cpp_args = cflags
 cpp_link_args = ldflags
 wrap_mode = 'forcefallback'
 force_fallback_for = 'cglm'
-werror = true
+werror = false
 strip = false
 b_pch = false
 b_lto = false
-
-[sdl2:built-in options]
-werror = false
-
-[cglm:built-in options]
-werror = false
-
-[libzip:built-in options]
-werror = false
-
-[basis_universal:built-in options]
-werror = false
 
 [cmake]
 CMAKE_C_COMPILER = cc

--- a/misc/ci/windows-llvm_mingw-x86_64-build-test-ci.ini
+++ b/misc/ci/windows-llvm_mingw-x86_64-build-test-ci.ini
@@ -49,6 +49,9 @@ strip = false
 b_pch = false
 b_lto = false
 
+[sdl2:built-in options]
+werror = false
+
 [cglm:built-in options]
 werror = false
 

--- a/misc/ci/windows-llvm_mingw-x86_64-build-test-ci.ini
+++ b/misc/ci/windows-llvm_mingw-x86_64-build-test-ci.ini
@@ -44,7 +44,7 @@ cpp_args = cflags
 cpp_link_args = ldflags
 wrap_mode = 'forcefallback'
 force_fallback_for = 'cglm'
-werror = false
+werror = true
 strip = false
 b_pch = false
 b_lto = false
@@ -53,6 +53,9 @@ b_lto = false
 werror = false
 
 [libzip:built-in options]
+werror = false
+
+[basis_universal:built-in options]
 werror = false
 
 [cmake]


### PR DESCRIPTION
Provides a simple Emscripten test build to make sure the damn thing still compiles with its arcane toolchain.

Also adds:
* prettier labels for the tests themselves (i.e: `Linux Test Build (CI)`)
* moves to meson `0.56.2`
* fixes a couple of syntax errors in the machine files
* turns `werror` back on for all builds

See: #289 