### PR TITLE
Switch CI test builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -292,7 +292,6 @@ jobs:
 
         echo EM_LATEST_TAG=$EM_LATEST_TAG >> $GITHUB_ENV
 
-        # only run if version is different
         if [[ $EM_LATEST_TAG != ${{ env.EM_VERSION }} ]]; then
           echo "Versions differ (latest: $EM_LATEST_TAG, stable: ${{ env.EM_VERSION }}), running test build";
           echo '::set-output name=run::true';

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,9 +3,7 @@ on:
   push:
     branches:
       - master
-      - v*.*
-    tags:
-      - v*.*
+      - v[0-9].[0-9]**
     paths:
       - "**.c"
       - "**.h"
@@ -236,14 +234,14 @@ jobs:
     - name: Install Emscripten SDK
       if: steps.emsdk-cache.outputs.cache-hit != 'true'
       run: |
-        rm -rf emsdk/
-        git clone https://github.com/emscripten-core/emsdk.git
-        emsdk/emsdk install ${{ env.EM_VERSION }}
-        emsdk/emsdk activate ${{ env.EM_VERSION }}
+        rm -rf ./${{ env.EM_CACHE_FOLDER }}/
+        git clone https://github.com/emscripten-core/emsdk.git ${{ env.EM_CACHE_FOLDER }}
+        ${{ env.EM_CACHE_FOLDER }}/emsdk install ${{ env.EM_VERSION }}
+        ${{ env.EM_CACHE_FOLDER }}/emsdk activate ${{ env.EM_VERSION }}
 
     - name: Verify Emscripten SDK
       run: |
-        source emsdk/emsdk_env.sh
+        source ${{ env.EM_CACHE_FOLDER }}/emsdk_env.sh
         emcc -v
         tee misc/ci/emscripten-ephemeral-ci.ini <<EOF >/dev/null
         [constants]
@@ -252,7 +250,7 @@ jobs:
 
     - name: Configure
       run: >
-        source emsdk/emsdk_env.sh
+        source ${{ env.EM_CACHE_FOLDER }}/emsdk_env.sh
 
         meson setup build/
         --cross-file misc/ci/emscripten-ephemeral-ci.ini
@@ -265,7 +263,7 @@ jobs:
 
     - name: Build
       run: |
-        source emsdk/emsdk_env.sh
+        source ${{ env.EM_CACHE_FOLDER }}/emsdk_env.sh
         # TODO: SPIRV-Tools has a race condition where it sometimes fails, fix that
         meson compile tar -C build/ --verbose || true
         meson compile tar -C build/ --verbose
@@ -288,20 +286,21 @@ jobs:
       run: >
         git clone https://github.com/emscripten-core/emsdk.git
 
-        git --git-dir=emsdk/.git fetch --tags
+        git --git-dir=${{ env.EM_CACHE_FOLDER }}/.git fetch --tags
 
-        export EM_LATEST_TAG=$(git --git-dir=emsdk/.git describe --abbrev=0 --tags)
+        export EM_LATEST_TAG=$(git --git-dir=${{ env.EM_CACHE_FOLDER }}/.git describe --abbrev=0 --tags)
 
         echo EM_LATEST_TAG=$EM_LATEST_TAG >> $GITHUB_ENV
 
+        # only run if version is different
         if [[ $EM_LATEST_TAG != ${{ env.EM_VERSION }} ]]; then
-          echo "Versions differ (stable: $EM_LATEST_TAG, latest: ${{ env.EM_VERSION }}), running test build";
+          echo "Versions differ (latest: $EM_LATEST_TAG, stable: ${{ env.EM_VERSION }}), running test build";
           echo '::set-output name=run::true';
         else
-          echo "Same tag as in stable build (stable: $EM_LATEST_TAG, latest: ${{ env.EM_VERSION }}), skipping";
-        fi # only run if version is different
+          echo "Same tag as in stable build (latest: $EM_LATEST_TAG, stable: ${{ env.EM_VERSION }}), skipping";
+        fi
 
-        rm -rf emsdk # cleanup
+        rm -rf ./${{ env.EM_CACHE_FOLDER }} # cleanup
 
     - name: Checkout Code
       if: steps.emsdk-tag.outputs.run == 'true'
@@ -341,14 +340,14 @@ jobs:
     - name: Install Emscripten SDK
       if: steps.emsdk-tag.outputs.run == 'true' && steps.emsdk-cache.outputs.cache-hit != 'true'
       run: |
-        git clone https://github.com/emscripten-core/emsdk.git
-        emsdk/emsdk install ${{ env.EM_LATEST_TAG }} || true
-        emsdk/emsdk activate ${{ env.EM_LATEST_TAG }}
+        git clone https://github.com/emscripten-core/emsdk.git ${{ env.EM_CACHE_FOLDER }}
+        ${{ env.EM_CACHE_FOLDER }}/emsdk install ${{ env.EM_LATEST_TAG }} || true
+        ${{ env.EM_CACHE_FOLDER }}/emsdk activate ${{ env.EM_LATEST_TAG }}
 
     - name: Verify Emscripten SDK
       if: steps.emsdk-tag.outputs.run == 'true'
       run: |
-        source emsdk/emsdk_env.sh
+        source ${{ env.EM_CACHE_FOLDER }}/emsdk_env.sh
         emcc -v
         tee misc/ci/emscripten-ephemeral-ci.ini <<EOF >/dev/null
         [constants]
@@ -358,7 +357,7 @@ jobs:
     - name: Configure
       if: steps.emsdk-tag.outputs.run == 'true'
       run: >
-        source emsdk/emsdk_env.sh
+        source ${{ env.EM_CACHE_FOLDER }}/emsdk_env.sh
 
         meson setup build/
         --cross-file misc/ci/emscripten-ephemeral-ci.ini
@@ -373,7 +372,7 @@ jobs:
       if: steps.emsdk-tag.outputs.run == 'true'
       run: |
         # this build is allowed to fail
-        source emsdk/emsdk_env.sh
+        source ${{ env.EM_CACHE_FOLDER }}/emsdk_env.sh
         # TODO: SPIRV-Tools has a race condition where it sometimes fails, fix that
         meson compile tar -C build/ --verbose || true
         meson compile tar -C build/ --verbose

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -174,7 +174,7 @@ jobs:
         ninja
         zstandard
 
-    - name: Checkout Code (Git)
+    - name: Checkout Code
       uses: actions/checkout@v2
       with:
         submodules: 'recursive'
@@ -383,5 +383,36 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: taisei_emscripten_latest_build_log
+        path: build/meson-logs/meson-log.txt
+
+  switch-test-build:
+    name: Switch (ARM64)
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    runs-on: ubuntu-20.04
+    container: taiseiproject/switch-toolkit:20210520
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v2
+      with:
+        submodules: 'recursive'
+
+    - name: Configure
+      run: >
+        switch/crossfile.sh > misc/ci/switch-crossfile-ci.ini
+
+        meson setup build/
+        --cross-file=misc/ci/switch-crossfile-ci.ini
+        --prefix=$(pwd)/build-test
+
+    - name: Build
+      run: >
+        meson compile -C build/ --verbose
+        --cross-file=misc/ci/switch-crossfile-ci.ini
+        --prefix=$(pwd)/build-test
+
+    - name: Upload Log
+      uses: actions/upload-artifact@v2
+      with:
+        name: taisei_switch_build_log
         path: build/meson-logs/meson-log.txt
         if-no-files-found: warn

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -405,10 +405,7 @@ jobs:
         --prefix=$(pwd)/build-test
 
     - name: Build
-      run: >
-        meson compile -C build/ --verbose
-        --cross-file=misc/ci/switch-crossfile-ci.ini
-        --prefix=$(pwd)/build-test
+      run: meson compile -C build/ --verbose
 
     - name: Upload Log
       uses: actions/upload-artifact@v2

--- a/switch/crossfile.sh
+++ b/switch/crossfile.sh
@@ -33,11 +33,12 @@ pkgconfig = '$(bin_path pkg-config)'
 elf2nro = '$(which elf2nro)'
 nacptool = '$(which nacptool)'
 
-[properties]
+[built-in options]
 c_args = [$(meson_arg_list $CPPFLAGS $CFLAGS)]
 c_link_args = [$(meson_arg_list $LDFLAGS $LIBS $ADDITIONAL_LINK_FLAGS)]
 cpp_args = [$(meson_arg_list $CPPFLAGS $CXXFLAGS)]
 cpp_link_args = [$(meson_arg_list $LDFLAGS $LIBS $ADDITIONAL_LINK_FLAGS)]
+werror = false
 
 [host_machine]
 system = 'nx'


### PR DESCRIPTION
This adds Switch CI test builds. Also modernizes the Switch crossfile a tiny bit.

One thing of note is that I had to build my own Docker image to get the tools on a modern version of Debian which plays nicely with GHA, as the devkitpro team hasn't tagged/released an image with modern Debian yet. This actually significantly cuts down on the test time as well since I pre-installed everything it needs, and might be something we should consider for the other builds, too.

I've also added the `Dockerfile` I used to the `docker` branch, seen here: https://github.com/taisei-project/taisei/blob/docker/misc/ci/Dockerfile.switch 

This is technically on my own person Docker Hub account, but it can be built by anyone, and the `starwitch/*` can be replaced with their username.