### PR TITLE
Custom parameters for boss attacks

### DIFF
--- a/src/boss.c
+++ b/src/boss.c
@@ -1408,7 +1408,7 @@ TASK(attack_task_helper, {
 	// NOTE: We could do INVOKE_TASK_INDIRECT here, but that's a bit wasteful.
 	// A better idea than both that and this contraption would be to come up
 	// with an INVOKE_TASK_INDIRECT_WHEN.
-	ARGS.task._cotask_BossAttack_thunk(&ARGS.task_args);
+	ARGS.task._cotask_BossAttack_thunk(&ARGS.task_args, sizeof(ARGS.task_args));
 }
 
 static void setup_attack_task(Boss *boss, Attack *a, BossAttackTask task) {

--- a/src/boss.h
+++ b/src/boss.h
@@ -100,16 +100,14 @@ struct Attack {
 	AttackType type;
 
 	int starttime;
-	int timeout;
 	int endtime;
 	int endtime_undelayed;
+	int failtime;
+	int timeout;
 
 	float bonus_base;
 	float maxhp;
 	float hp;
-
-	bool finished;
-	int failtime;
 
 	BossRule rule;
 	BossRule draw_rule;
@@ -123,6 +121,22 @@ struct Attack {
 
 	AttackInfo *info; // NULL for attacks created directly through boss_add_attack
 };
+
+static inline bool attack_has_started(const Attack *atk) {
+	return atk->events.started.num_signaled;
+}
+
+static inline bool attack_has_finished(const Attack *atk) {
+	return atk->events.finished.num_signaled;
+}
+
+static inline bool attack_was_failed(const Attack *atk) {
+	return atk->failtime > 0;
+}
+
+static inline bool attack_is_active(const Attack *atk) {
+	return attack_has_started(atk) && !attack_has_finished(atk);
+}
 
 DEFINE_ENTITY_TYPE(Boss, {
 	cmplx pos;
@@ -213,5 +227,8 @@ void boss_preload(void);
 Boss *init_boss_attack_task(BoxedBoss boss, Attack *attack);
 #define INIT_BOSS_ATTACK() init_boss_attack_task(ARGS.boss, ARGS.attack)
 #define BEGIN_BOSS_ATTACK() WAIT_EVENT_OR_DIE(&ARGS.attack->events.started)
+
+int attacktype_start_delay(AttackType t) attr_const;
+int attacktype_end_delay(AttackType t) attr_const;
 
 #endif // IGUARD_boss_h

--- a/src/boss.h
+++ b/src/boss.h
@@ -57,6 +57,7 @@ DEFINE_TASK_INTERFACE(BossAttack, {
 
 typedef TASK_INDIRECT_TYPE(BossAttack) BossAttackTask;
 typedef TASK_IFACE_ARGS_TYPE(BossAttack) BossAttackTaskArgs;
+typedef TASK_IFACE_ARGS_SIZED_PTR_TYPE(BossAttack) BossAttackTaskCustomArgs;
 
 struct AttackInfo {
 	/*
@@ -203,7 +204,9 @@ Attack *boss_add_attack(Boss *boss, AttackType type, char *name, float timeout, 
 	attr_nonnull(1) attr_returns_nonnull;
 Attack *boss_add_attack_task(Boss *boss, AttackType type, char *name, float timeout, int hp, BossAttackTask task, BossRule draw_rule)
 	attr_nonnull(1) attr_returns_nonnull;
-Attack *boss_add_attack_from_info(Boss *boss, AttackInfo *info, char move)
+Attack *boss_add_attack_from_info(Boss *boss, AttackInfo *info, bool move)
+	attr_nonnull(1, 2) attr_returns_nonnull;
+Attack *boss_add_attack_from_info_with_args(Boss *boss, AttackInfo *info, BossAttackTaskCustomArgs args)
 	attr_nonnull(1, 2) attr_returns_nonnull;
 void boss_set_attack_bonus(Attack *a, int rank) attr_nonnull(1);
 
@@ -228,10 +231,12 @@ void boss_preload(void);
 #define BOSS_DEFAULT_GO_POS (VIEWPORT_W * 0.5 + 200.0*I)
 #define BOSS_NOMOVE (-3142-39942.0*I)
 
-Boss *_init_boss_attack_task(BoxedBoss boss, Attack *attack);
-void _begin_boss_attack_task(BoxedBoss boss, Attack *attack);
-#define INIT_BOSS_ATTACK() _init_boss_attack_task(ARGS.boss, ARGS.attack)
-#define BEGIN_BOSS_ATTACK() _begin_boss_attack_task(ARGS.boss, ARGS.attack)
+Boss *_init_boss_attack_task(const BossAttackTaskArgs *args)
+	attr_nonnull_all attr_returns_nonnull;
+void _begin_boss_attack_task(const BossAttackTaskArgs *args)
+	attr_nonnull_all;
+#define INIT_BOSS_ATTACK(_args) _init_boss_attack_task(_args)
+#define BEGIN_BOSS_ATTACK(_args) _begin_boss_attack_task(_args)
 
 int attacktype_start_delay(AttackType t) attr_const;
 int attacktype_end_delay(AttackType t) attr_const;

--- a/src/boss.h
+++ b/src/boss.h
@@ -178,6 +178,9 @@ DEFINE_ENTITY_TYPE(Boss, {
 	} healthbar;
 
 	struct {
+		Attack *a_prev;
+		Attack *a_cur;
+		Attack *a_next;
 		float global_opacity;
 		float spell_opacity;
 		float plrproximity_opacity;
@@ -206,7 +209,8 @@ void boss_set_attack_bonus(Attack *a, int rank) attr_nonnull(1);
 
 void boss_set_portrait(Boss *boss, const char *name, const char *variant, const char *face) attr_nonnull(1);
 
-void boss_start_attack(Boss *b, Attack *a) attr_nonnull(1, 2);
+void boss_engage(Boss *b) attr_nonnull(1);
+void boss_start_next_attack(Boss *b, Attack *a) attr_nonnull(1, 2);
 void boss_finish_current_attack(Boss *boss) attr_nonnull(1);
 
 bool boss_is_dying(Boss *boss) attr_nonnull(1); // true if the last attack is over but the BOSS_DEATH_DELAY has not elapsed.
@@ -224,9 +228,10 @@ void boss_preload(void);
 #define BOSS_DEFAULT_GO_POS (VIEWPORT_W * 0.5 + 200.0*I)
 #define BOSS_NOMOVE (-3142-39942.0*I)
 
-Boss *init_boss_attack_task(BoxedBoss boss, Attack *attack);
-#define INIT_BOSS_ATTACK() init_boss_attack_task(ARGS.boss, ARGS.attack)
-#define BEGIN_BOSS_ATTACK() WAIT_EVENT_OR_DIE(&ARGS.attack->events.started)
+Boss *_init_boss_attack_task(BoxedBoss boss, Attack *attack);
+void _begin_boss_attack_task(BoxedBoss boss, Attack *attack);
+#define INIT_BOSS_ATTACK() _init_boss_attack_task(ARGS.boss, ARGS.attack)
+#define BEGIN_BOSS_ATTACK() _begin_boss_attack_task(ARGS.boss, ARGS.attack)
 
 int attacktype_start_delay(AttackType t) attr_const;
 int attacktype_end_delay(AttackType t) attr_const;

--- a/src/coroutine.c
+++ b/src/coroutine.c
@@ -860,6 +860,10 @@ static void coevent_wake_subscribers(CoEvent *evt, uint num_subs, BoxedTask subs
 }
 
 void coevent_signal(CoEvent *evt) {
+	if(UNLIKELY(evt->unique_id == 0)) {
+		return;
+	}
+
 	++evt->num_signaled;
 	EVT_DEBUG("Signal event %p (uid = %u; num_signaled = %u)", (void*)evt, evt->unique_id, evt->num_signaled);
 	assert(evt->num_signaled != 0);
@@ -888,7 +892,6 @@ void coevent_cancel(CoEvent *evt) {
 
 	EVT_DEBUG("[%lu] BEGIN Cancel event %p (uid = %u; num_signaled = %u)", ev,  (void*)evt, evt->unique_id, evt->num_signaled);
 	EVT_DEBUG("[%lu] SUBS = %p", ev,  (void*)evt->subscribers.data);
-	evt->num_signaled = 0;
 	evt->unique_id = 0;
 
 	if(evt->subscribers.num_elements) {

--- a/src/player.c
+++ b/src/player.c
@@ -375,13 +375,15 @@ DEFINE_TASK(player_indicators) {
 }
 
 static void player_fail_spell(Player *plr) {
-	if( !global.boss ||
-		!global.boss->current ||
-		global.boss->current->finished ||
-		global.boss->current->failtime ||
-		global.boss->current->starttime >= global.frames ||
-		global.stage->type == STAGE_SPELL
-	) {
+	Boss *boss = global.boss;
+
+	if(!boss || global.stage->type == STAGE_SPELL) {
+		return;
+	}
+
+	Attack *atk = boss->current;
+
+	if(!atk || !attack_is_active(atk) || attack_was_failed(atk)) {
 		return;
 	}
 

--- a/src/stages/dpstest.c
+++ b/src/stages/dpstest.c
@@ -60,8 +60,8 @@ static void dpstest_multi(void) {
 }
 
 TASK_WITH_INTERFACE(boss_regen, BossAttack) {
-	INIT_BOSS_ATTACK();
-	BEGIN_BOSS_ATTACK();
+	INIT_BOSS_ATTACK(&ARGS);
+	BEGIN_BOSS_ATTACK(&ARGS);
 
 	Attack *a = ARGS.attack;
 

--- a/src/stages/dpstest.c
+++ b/src/stages/dpstest.c
@@ -77,7 +77,7 @@ static void dpstest_boss(void) {
 		global.boss, AT_Spellcard, "Masochism “Eternal Torment”",
 		5184000, 90000, TASK_INDIRECT(BossAttack, boss_regen), NULL
 	);
-	boss_start_attack(global.boss, global.boss->attacks);
+	boss_engage(global.boss);
 }
 
 StageProcs stage_dpstest_single_procs = {

--- a/src/stages/stage1/nonspells/boss_nonspell_1.c
+++ b/src/stages/stage1/nonspells/boss_nonspell_1.c
@@ -15,9 +15,9 @@
 #include "global.h"
 
 DEFINE_EXTERN_TASK(stage1_boss_nonspell_1) {
-	Boss *boss = INIT_BOSS_ATTACK();
+	Boss *boss = INIT_BOSS_ATTACK(&ARGS);
 	boss->move = move_towards(VIEWPORT_W/2.0 + 100.0*I, 0.05);
-	BEGIN_BOSS_ATTACK();
+	BEGIN_BOSS_ATTACK(&ARGS);
 
 	for(;;) {
 		WAIT(20);

--- a/src/stages/stage1/nonspells/boss_nonspell_2.c
+++ b/src/stages/stage1/nonspells/boss_nonspell_2.c
@@ -112,9 +112,9 @@ TASK(spiralshot, {
 }
 
 DEFINE_EXTERN_TASK(stage1_boss_nonspell_2) {
-	Boss *boss = INIT_BOSS_ATTACK();
+	Boss *boss = INIT_BOSS_ATTACK(&ARGS);
 	boss->move = move_towards(VIEWPORT_W/2.0 + 100.0*I, 0.02);
-	BEGIN_BOSS_ATTACK();
+	BEGIN_BOSS_ATTACK(&ARGS);
 
 	for(;;) {
 		WAIT(20);

--- a/src/stages/stage1/nonspells/midboss_nonspell_1.c
+++ b/src/stages/stage1/nonspells/midboss_nonspell_1.c
@@ -90,9 +90,9 @@ TASK(make_snowflake, {
 }
 
 DEFINE_EXTERN_TASK(stage1_midboss_nonspell_1) {
-	Boss *boss = INIT_BOSS_ATTACK();
+	Boss *boss = INIT_BOSS_ATTACK(&ARGS);
 	boss->move = move_towards(CMPLX(VIEWPORT_W/2, 200), 0.02);
-	BEGIN_BOSS_ATTACK();
+	BEGIN_BOSS_ATTACK(&ARGS);
 	boss->move = move_stop(0.8);
 
 	int flake_spawn_interval = difficulty_value(11, 10, 9, 8);

--- a/src/stages/stage1/spells/crystal_blizzard.c
+++ b/src/stages/stage1/spells/crystal_blizzard.c
@@ -64,9 +64,9 @@ TASK(cirno_frostbolt, { cmplx pos; cmplx vel; }) {
 }
 
 DEFINE_EXTERN_TASK(stage1_spell_crystal_blizzard) {
-	Boss *boss = INIT_BOSS_ATTACK();
+	Boss *boss = INIT_BOSS_ATTACK(&ARGS);
 	boss->move = move_towards(VIEWPORT_W / 2.0 + 300 * I, 0.1);
-	BEGIN_BOSS_ATTACK();
+	BEGIN_BOSS_ATTACK(&ARGS);
 
 	int frostbolt_period = difficulty_value(4, 3, 2, 1);
 

--- a/src/stages/stage1/spells/crystal_rain.c
+++ b/src/stages/stage1/spells/crystal_rain.c
@@ -76,8 +76,8 @@ TASK(crystal_rain_cirno_shoot, { BoxedBoss boss; int charge_time; }) {
 }
 
 DEFINE_EXTERN_TASK(stage1_spell_crystal_rain) {
-	Boss *boss = INIT_BOSS_ATTACK();
-	BEGIN_BOSS_ATTACK();
+	Boss *boss = INIT_BOSS_ATTACK(&ARGS);
+	BEGIN_BOSS_ATTACK(&ARGS);
 
 	INVOKE_SUBTASK(crystal_rain_drops);
 	boss->move = move_towards_power(boss->pos, 0.1, 0.5);

--- a/src/stages/stage1/spells/icicle_cascade.c
+++ b/src/stages/stage1/spells/icicle_cascade.c
@@ -38,9 +38,9 @@ TASK(cirno_icicle, { cmplx pos; cmplx vel; }) {
 }
 
 DEFINE_EXTERN_TASK(stage1_spell_icicle_cascade) {
-	Boss *boss = INIT_BOSS_ATTACK();
+	Boss *boss = INIT_BOSS_ATTACK(&ARGS);
 	boss->move = move_towards(VIEWPORT_W / 2.0 + 120.0*I, 0.01);
-	BEGIN_BOSS_ATTACK();
+	BEGIN_BOSS_ATTACK(&ARGS);
 
 	int icicle_interval = difficulty_value(30, 22, 16, 8);
 	int icicles = 4;

--- a/src/stages/stage1/spells/perfect_freeze.c
+++ b/src/stages/stage1/spells/perfect_freeze.c
@@ -37,8 +37,8 @@ TASK(move_frozen, { BoxedProjectileArray *parray; }) {
 }
 
 DEFINE_EXTERN_TASK(stage1_spell_perfect_freeze) {
-	Boss *boss = INIT_BOSS_ATTACK();
-	BEGIN_BOSS_ATTACK();
+	Boss *boss = INIT_BOSS_ATTACK(&ARGS);
+	BEGIN_BOSS_ATTACK(&ARGS);
 
 	for(int run = 1;;run++) {
 		boss->move = move_towards(VIEWPORT_W/2.0 + 100.0*I, 0.04);

--- a/src/stages/stage1/spells/snow_halation.c
+++ b/src/stages/stage1/spells/snow_halation.c
@@ -151,9 +151,9 @@ TASK(halation_chase, { BoxedBoss boss; }) {
 }
 
 DEFINE_EXTERN_TASK(stage1_spell_snow_halation) {
-	Boss *boss = INIT_BOSS_ATTACK();
+	Boss *boss = INIT_BOSS_ATTACK(&ARGS);
 	boss->move = move_towards(VIEWPORT_W/2.0 + 100.0*I, 0.05);
-	BEGIN_BOSS_ATTACK();
+	BEGIN_BOSS_ATTACK(&ARGS);
 
 	cmplx center;
 	real rotation = 0;

--- a/src/stages/stage1/stage1.c
+++ b/src/stages/stage1/stage1.c
@@ -79,7 +79,7 @@ static void stage1_spellpractice_start(void) {
 
 	Boss *cirno = stage1_spawn_cirno(BOSS_DEFAULT_SPAWN_POS);
 	boss_add_attack_from_info(cirno, global.stage->spell, true);
-	boss_start_attack(cirno, cirno->attacks);
+	boss_engage(cirno);
 	global.boss = cirno;
 
 	stage_start_bgm("stage1boss");

--- a/src/stages/stage1/timeline.c
+++ b/src/stages/stage1/timeline.c
@@ -572,14 +572,14 @@ TASK(waveshot_fairies, { int duration; }) {
 }
 
 TASK_WITH_INTERFACE(midboss_intro, BossAttack) {
-	Boss *boss = INIT_BOSS_ATTACK();
-	BEGIN_BOSS_ATTACK();
+	Boss *boss = INIT_BOSS_ATTACK(&ARGS);
+	BEGIN_BOSS_ATTACK(&ARGS);
 	boss->move = move_towards(VIEWPORT_W/2.0 + 200.0*I, 0.035);
 }
 
 TASK_WITH_INTERFACE(midboss_flee, BossAttack) {
-	Boss *boss = INIT_BOSS_ATTACK();
-	BEGIN_BOSS_ATTACK();
+	Boss *boss = INIT_BOSS_ATTACK(&ARGS);
+	BEGIN_BOSS_ATTACK(&ARGS);
 	boss->move = move_towards(-250 + 30 * I, 0.02);
 }
 

--- a/src/stages/stage1/timeline.c
+++ b/src/stages/stage1/timeline.c
@@ -595,7 +595,7 @@ TASK(spawn_midboss, NO_ARGS) {
 	}
 	boss_add_attack_task(boss, AT_Move, "Flee", 2, 0, TASK_INDIRECT(BossAttack, midboss_flee), NULL);
 
-	boss_start_attack(boss, boss->attacks);
+	boss_engage(boss);
 
 	WAIT(60);
 	stage1_bg_enable_snow();
@@ -684,7 +684,7 @@ TASK(spawn_boss, NO_ARGS) {
 	boss_add_attack_from_info(boss, &stage1_spells.boss.icicle_cascade, false);
 	boss_add_attack_from_info(boss, &stage1_spells.extra.crystal_blizzard, false);
 
-	boss_start_attack(boss, boss->attacks);
+	boss_engage(boss);
 }
 
 static void stage1_dialog_post_boss(void) {

--- a/src/stages/stage1/timeline.c
+++ b/src/stages/stage1/timeline.c
@@ -671,6 +671,8 @@ TASK(spawn_boss, NO_ARGS) {
 	INVOKE_TASK_WHEN(&e->music_changes, common_start_bgm, "stage1boss");
 	WAIT_EVENT(&global.dialog->events.fadeout_began);
 
+	STAGE_BOOKMARK(boss-postdialog);
+
 	boss_add_attack_task(boss, AT_Normal, "Iceplosion 0", 20, 26000, TASK_INDIRECT(BossAttack, stage1_boss_nonspell_1), NULL);
 	boss_add_attack_from_info(boss, &stage1_spells.boss.crystal_rain, false);
 	boss_add_attack_task(boss, AT_Normal, "Iceplosion 1", 20, 30000, TASK_INDIRECT(BossAttack, stage1_boss_nonspell_2), NULL);

--- a/src/stages/stage2/nonspells/boss_nonspell_1.c
+++ b/src/stages/stage2/nonspells/boss_nonspell_1.c
@@ -28,8 +28,8 @@ TASK(wander, { BoxedBoss boss; }) {
 DEFINE_EXTERN_TASK(stage2_boss_nonspell_1) {
 	STAGE_BOOKMARK(boss-non1);
 
-	Boss *boss = INIT_BOSS_ATTACK();
-	BEGIN_BOSS_ATTACK();
+	Boss *boss = INIT_BOSS_ATTACK(&ARGS);
+	BEGIN_BOSS_ATTACK(&ARGS);
 
 	INVOKE_SUBTASK_DELAYED(420, wander, ENT_BOX(boss));
 

--- a/src/stages/stage2/nonspells/boss_nonspell_2.c
+++ b/src/stages/stage2/nonspells/boss_nonspell_2.c
@@ -67,9 +67,9 @@ TASK(balls, { BoxedBoss boss; }) {
 DEFINE_EXTERN_TASK(stage2_boss_nonspell_2) {
 	STAGE_BOOKMARK(boss-non2);
 
-	Boss *boss = INIT_BOSS_ATTACK();
+	Boss *boss = INIT_BOSS_ATTACK(&ARGS);
 	boss->move = move_towards(VIEWPORT_W/2 + 100*I, 0.01);
-	BEGIN_BOSS_ATTACK();
+	BEGIN_BOSS_ATTACK(&ARGS);
 
 	INVOKE_SUBTASK(speen, ENT_BOX(boss));
 	INVOKE_SUBTASK_DELAYED(150, balls, ENT_BOX(boss));

--- a/src/stages/stage2/nonspells/boss_nonspell_3.c
+++ b/src/stages/stage2/nonspells/boss_nonspell_3.c
@@ -163,9 +163,9 @@ static void random_move(Boss *boss) {
 }
 
 DEFINE_EXTERN_TASK(stage2_boss_nonspell_3) {
-	Boss *boss = INIT_BOSS_ATTACK();
+	Boss *boss = INIT_BOSS_ATTACK(&ARGS);
 	boss->move = move_towards(VIEWPORT_W/2.0 + 100.0*I, 0.02);
-	BEGIN_BOSS_ATTACK();
+	BEGIN_BOSS_ATTACK(&ARGS);
 
 	real dir_sign = rng_sign();
 

--- a/src/stages/stage2/nonspells/midboss_nonspell_1.c
+++ b/src/stages/stage2/nonspells/midboss_nonspell_1.c
@@ -90,9 +90,9 @@ static void wriggle_anim_end_charge(Boss *boss) {
 DEFINE_EXTERN_TASK(stage2_midboss_nonspell_1) {
 	STAGE_BOOKMARK(non1);
 
-	Boss *boss = INIT_BOSS_ATTACK();
+	Boss *boss = INIT_BOSS_ATTACK(&ARGS);
 	boss->move = move_towards(VIEWPORT_W/2 + 100.0*I, 0.02);
-	BEGIN_BOSS_ATTACK();
+	BEGIN_BOSS_ATTACK(&ARGS);
 
 	DECLARE_ENT_ARRAY(Projectile, bugs, 512);
 

--- a/src/stages/stage2/spells/amulet_of_harm.c
+++ b/src/stages/stage2/spells/amulet_of_harm.c
@@ -179,9 +179,9 @@ TASK(fan_burst, { Boss *boss; }) {
 }
 
 DEFINE_EXTERN_TASK(stage2_spell_amulet_of_harm) {
-	Boss *boss = INIT_BOSS_ATTACK();
+	Boss *boss = INIT_BOSS_ATTACK(&ARGS);
 	boss->move = move_towards(VIEWPORT_W/2 + 200.0*I, 0.02);
-	BEGIN_BOSS_ATTACK();
+	BEGIN_BOSS_ATTACK(&ARGS);
 
 	Rect wander_bounds = viewport_bounds(64);
 	wander_bounds.top += 64;

--- a/src/stages/stage2/spells/bad_pick.c
+++ b/src/stages/stage2/spells/bad_pick.c
@@ -80,9 +80,9 @@ TASK(walls, { int duration; }) {
 }
 
 DEFINE_EXTERN_TASK(stage2_spell_bad_pick) {
-	Boss *boss = INIT_BOSS_ATTACK();
+	Boss *boss = INIT_BOSS_ATTACK(&ARGS);
 	boss->move = move_towards(pick_boss_position(), 0.02);
-	BEGIN_BOSS_ATTACK();
+	BEGIN_BOSS_ATTACK(&ARGS);
 
 	int balls_per_slot = difficulty_value(15, 15, 20, 25);
 

--- a/src/stages/stage2/spells/monty_hall_danmaku.c
+++ b/src/stages/stage2/spells/monty_hall_danmaku.c
@@ -139,13 +139,13 @@ TASK(cards, { BoxedBoss boss; }) {
 }
 
 DEFINE_EXTERN_TASK(stage2_spell_monty_hall_danmaku) {
-	Boss *boss = INIT_BOSS_ATTACK();
+	Boss *boss = INIT_BOSS_ATTACK(&ARGS);
 
 	COEVENTS_ARRAY(goat_trigger) events;
 	TASK_HOST_EVENTS(events);
 
 	boss->move = move_towards(VIEWPORT_W/2.0 + VIEWPORT_H/2.0 * I, 0.06);
-	BEGIN_BOSS_ATTACK();
+	BEGIN_BOSS_ATTACK(&ARGS);
 
 	int plr_slot;
 	int goat1_slot;

--- a/src/stages/stage2/spells/wheel_of_fortune.c
+++ b/src/stages/stage2/spells/wheel_of_fortune.c
@@ -66,9 +66,9 @@ TASK(wheel, { BoxedBoss boss; real spin_dir; int duration; }) {
 }
 
 DEFINE_EXTERN_TASK(stage2_spell_wheel_of_fortune) {
-	Boss *boss = INIT_BOSS_ATTACK();
+	Boss *boss = INIT_BOSS_ATTACK(&ARGS);
 	boss->move = move_towards(VIEWPORT_W/2 + VIEWPORT_H/2*I, 0.02);
-	BEGIN_BOSS_ATTACK();
+	BEGIN_BOSS_ATTACK(&ARGS);
 
 	aniplayer_queue(&boss->ani, "guruguru", 0);
 

--- a/src/stages/stage2/stage2.c
+++ b/src/stages/stage2/stage2.c
@@ -58,7 +58,7 @@ static void stage2_spellpractice_start(void) {
 
 	Boss *hina = stage2_spawn_hina(BOSS_DEFAULT_SPAWN_POS);
 	boss_add_attack_from_info(hina, global.stage->spell, true);
-	boss_start_attack(hina, hina->attacks);
+	boss_engage(hina);
 	global.boss = hina;
 
 	stage_start_bgm("stage2boss");

--- a/src/stages/stage2/timeline.c
+++ b/src/stages/stage2/timeline.c
@@ -488,7 +488,7 @@ TASK(spawn_midboss, NO_ARGS) {
 	boss_add_attack_task(boss, AT_Normal, "", 20, 26000, TASK_INDIRECT(BossAttack, stage2_midboss_nonspell_1), NULL);
 	boss_add_attack(boss, AT_Move, "Flee", 5, 0, wiggle_mid_flee, NULL);
 
-	boss_start_attack(boss, boss->attacks);
+	boss_engage(boss);
 }
 
 TASK(redwall_side_fairies, { int num; }) {
@@ -637,7 +637,7 @@ TASK(spawn_boss, NO_ARGS) {
 	boss_add_attack_from_info(boss, &stage2_spells.boss.wheel_of_fortune, false);
 	boss_add_attack_from_info(boss, &stage2_spells.extra.monty_hall_danmaku, false);
 
-	boss_start_attack(boss, boss->attacks);
+	boss_engage(boss);
 }
 
 DEFINE_EXTERN_TASK(stage2_timeline) {

--- a/src/stages/stage3.c
+++ b/src/stages/stage3.c
@@ -295,7 +295,7 @@ static void stage3_spellpractice_start(void) {
 	}
 
 	boss_add_attack_from_info(global.boss, global.stage->spell, true);
-	boss_start_attack(global.boss, global.boss->attacks);
+	boss_engage(global.boss);
 }
 
 static void stage3_spellpractice_events(void) {

--- a/src/stages/stage3_events.c
+++ b/src/stages/stage3_events.c
@@ -751,7 +751,7 @@ static Boss* stage3_create_midboss(void) {
 	boss_add_attack(scuttle, AT_Move, "Runaway", 2, 1, scuttle_outro, NULL);
 	scuttle->zoomcolor = *RGB(0.4, 0.1, 0.4);
 
-	boss_start_attack(scuttle, scuttle->attacks);
+	boss_engage(scuttle);
 	return scuttle;
 }
 
@@ -1439,7 +1439,7 @@ static Boss* stage3_create_boss(void) {
 	boss_add_attack_from_info(wriggle, &stage3_spells.boss.firefly_storm, false);
 	boss_add_attack_from_info(wriggle, &stage3_spells.extra.light_singularity, false);
 
-	boss_start_attack(wriggle, wriggle->attacks);
+	boss_engage(wriggle);
 	return wriggle;
 }
 

--- a/src/stages/stage4/stage4.c
+++ b/src/stages/stage4/stage4.c
@@ -77,7 +77,7 @@ static void stage4_spellpractice_start(void) {
 
 	global.boss = stage4_spawn_kurumi(BOSS_DEFAULT_SPAWN_POS);
 	boss_add_attack_from_info(global.boss, global.stage->spell, true);
-	boss_start_attack(global.boss, global.boss->attacks);
+	boss_engage(global.boss);
 
 	stage_start_bgm("stage4boss");
 }

--- a/src/stages/stage4/timeline.c
+++ b/src/stages/stage4/timeline.c
@@ -363,7 +363,7 @@ static Boss *create_kurumi_mid(void) {
 		boss_add_attack_from_info(b, &stage4_spells.mid.red_spike, false);
 	}
 	boss_add_attack(b, AT_Move, "Outro", 2, 1, kurumi_outro, NULL);
-	boss_start_attack(b, b->attacks);
+	boss_engage(b);
 	return b;
 }
 
@@ -451,7 +451,7 @@ static Boss *create_kurumi(void) {
 	boss_add_attack_from_info(b, &stage4_spells.boss.bloody_danmaku, false);
 	boss_add_attack_from_info(b, &stage4_spells.boss.blow_the_walls, false);
 	boss_add_attack_from_info(b, &stage4_spells.extra.vlads_army, false);
-	boss_start_attack(b, b->attacks);
+	boss_engage(b);
 
 	return b;
 }

--- a/src/stages/stage5/stage5.c
+++ b/src/stages/stage5/stage5.c
@@ -98,7 +98,7 @@ static void stage5_spellpractice_start(void) {
 
 	global.boss = stage5_spawn_iku(BOSS_DEFAULT_SPAWN_POS);
 	boss_add_attack_from_info(global.boss, global.stage->spell, true);
-	boss_start_attack(global.boss, global.boss->attacks);
+	boss_engage(global.boss);
 
 	stage_start_bgm("stage5boss");
 }

--- a/src/stages/stage5/timeline.c
+++ b/src/stages/stage5/timeline.c
@@ -250,7 +250,7 @@ static Boss *stage5_spawn_midboss(void) {
 	// suppress the boss death effects (this triggers the "boss fleeing" case)
 	boss_add_attack(b, AT_Move, "", 0, 0, midboss_dummy, NULL);
 
-	boss_start_attack(b, b->attacks);
+	boss_engage(b);
 	b->attacks->starttime = global.frames;	// HACK: thwart attack delay
 
 	return b;
@@ -275,7 +275,7 @@ static Boss* stage5_spawn_boss(void) {
 
 	boss_add_attack_from_info(b, &stage5_spells.extra.overload, false);
 
-	boss_start_attack(b, b->attacks);
+	boss_engage(b);
 	return b;
 }
 

--- a/src/stages/stage6/stage6.c
+++ b/src/stages/stage6/stage6.c
@@ -173,7 +173,7 @@ static void stage6_spellpractice_start(void) {
 	}
 
 	boss_add_attack_from_info(global.boss, global.stage->spell, true);
-	boss_start_attack(global.boss, global.boss->attacks);
+	boss_engage(global.boss);
 }
 
 static void stage6_spellpractice_events(void) {

--- a/src/stages/stage6/timeline.c
+++ b/src/stages/stage6/timeline.c
@@ -220,7 +220,7 @@ static Boss* create_elly(void) {
 	boss_add_attack(b, AT_Immediate, "Final dialog", 0, 0, elly_insert_interboss_dialog, NULL);
 	boss_add_attack(b, AT_Move, "ToE transition", 7, 0, elly_begin_toe, NULL);
 	boss_add_attack_from_info(b, &stage6_spells.final.theory_of_everything, false);
-	boss_start_attack(b, b->attacks);
+	boss_engage(b);
 
 	return b;
 }


### PR DESCRIPTION
This cleans up some of the boss code and adds necessary changes to the boss and coroutine subsystems to support scheduling task-based attacks with arbitrary custom parameters. It is necessary to port stage 6. See individual commits for more details.



### Example usage

Declaring a custom interface for your attack, and the attack itself.
```c
DEFINE_TASK_INTERFACE_WITH_BASE(CustomAttack, BossAttack, {
	int foo;
	BoxedProjectile bar;	
});

// Alias for the type of `ARGS`, for convenience. Not required.
typedef TASK_IFACE_ARGS_TYPE(CustomAttack) CustomAttackArgs;

DECLARE_EXTERN_TASK_WITH_INTERFACE(my_attack_task, CustomAttack);
```

Implementing the attack.
```c
DEFINE_EXTERN_TASK(my_attack_task) {
	// Note that for attacks without custom args, you have to pass just `&ARGS` here
	Boss *boss = INIT_BOSS_ATTACK(&ARGS.base);

	// Accessing the arguments
	int my_foo = ARGS.foo;
	Enemy *my_bar = ENT_UNBOX(ARGS.bar);

	// Standard BossAttack args are accessible through `.base`
	Attack *atk = ARGS.base.attack;

	// You can now arbitrarily delay the attack start (e.g. spellcard declaration)
	// with the usual macros here, which wasn't possible before
	WAIT(42);

	// This actually initiates the attack and waits out the inherent delay
	BEGIN_BOSS_ATTACK(&ARGS.base);

	// Implement the attack here
```

Scheduling the attack. Note that this currently requires `AttackInfo`, which we only use for spell cards, but non-spells can be easily accommodated later if needed.
```c
boss_add_attack_from_info_with_args(boss, &stageX_spells.boss.my_custom_attack,
	TASK_IFACE_SARGS(CustomAttack,
		.foo = 69,
		.bar = ENT_BOX(proj)
	).base
);
```

### Motivation

One of the strongest points of the task model is being able to freely pass data between tasks without type or size limitations, and without relying on global state. Depriving boss attack tasks of that feature severely hinders their flexibility, and makes things like persistent slaves/familiars cumbersome to implement.

Note that for non-spells, it was already possible to overcome this limitation by subscribing to the event directly:
```c
// Add "empty" attack
Attack *atk = boss_add_attack(boss, AT_Normal, "My Non-Spell Attack", 69, 420000, NULL, NULL);
// Attach a custom task, which does not have to implement `BossAttack`
INVOKE_TASK_WHEN(&atk->events.started, my_custom_attack, 
	.boss = ENT_BOX(boss),
	.attack = atk,
	my, custom, parameters
);
```

However, this can not work so easily for spell cards, which need a standardized interface to support spell practice. Although it is technically possible to work around this by using separate entry points for spell practice and in-stage versions of the spell, the required boilerplate for such an arrangement gets ugly quickly. By making the base attack interface extensible, we can keep using a single entry point.

### Notes & issues

In spell practice mode, the custom parameters are zero-initialized. The task must be prepared to deal with such an input, e.g. by spawning the missing familiars.

In `AttackInfo` definitions of stage spells, you still have to use `TASK_INDIRECT_INIT(BossAttack, my_task)` to refer to the attack task, even if it uses a custom interface. Unfortunately this is not type-safe. The normal `TASK_INDIRECT` macro is safe, but can't be used in a static initializer. I'm not sure if it's possible to fix that.

When scheduling the attack, it is crucial to pass the correct interface name to `TASK_IFACE_SARGS`, because **the compiler will not help you here**. It won't compile if you make a typo, but if you put in a valid but wrong interface that also happens to inherit from `BossAttack`, good luck debugging that. A possible alternative could be requiring the name of the task instead.



