### PR TITLE
Cubemap support

### DIFF
--- a/resources/00-taisei.pkgdir/shader/lib/util.glslh
+++ b/resources/00-taisei.pkgdir/shader/lib/util.glslh
@@ -142,6 +142,10 @@ vec2 flip_native_to_bottomleft(vec2 v) {
     return v;
 }
 
+vec3 fixCubeCoord(vec3 v) {
+	return v.xzy * vec3(1, -1, 1);
+}
+
 /*
  * Adapted from https://github.com/tobspr/GLSL-Color-Spaces/blob/master/ColorSpaces.inc.glsl
  */

--- a/src/renderer/api.c
+++ b/src/renderer/api.c
@@ -431,12 +431,12 @@ void r_texture_set_wrap(Texture *tex, TextureWrapMode ws, TextureWrapMode wt) {
 	B.texture_set_wrap(tex, ws, wt);
 }
 
-void r_texture_fill(Texture *tex, uint mipmap, const Pixmap *image_data) {
-	B.texture_fill(tex, mipmap, image_data);
+void r_texture_fill(Texture *tex, uint mipmap, uint layer, const Pixmap *image_data) {
+	B.texture_fill(tex, mipmap, layer, image_data);
 }
 
-void r_texture_fill_region(Texture *tex, uint mipmap, uint x, uint y, const Pixmap *image_data) {
-	B.texture_fill_region(tex, mipmap, x, y, image_data);
+void r_texture_fill_region(Texture *tex, uint mipmap, uint layer, uint x, uint y, const Pixmap *image_data) {
+	B.texture_fill_region(tex, mipmap, layer, x, y, image_data);
 }
 
 void r_texture_invalidate(Texture *tex) {

--- a/src/renderer/api.h
+++ b/src/renderer/api.h
@@ -280,11 +280,15 @@ typedef enum UniformType {
 	UNIFORM_IVEC2,
 	UNIFORM_IVEC3,
 	UNIFORM_IVEC4,
-	UNIFORM_SAMPLER,
+	UNIFORM_SAMPLER_2D,
+	UNIFORM_SAMPLER_CUBE,
 	UNIFORM_MAT3,
 	UNIFORM_MAT4,
 	UNIFORM_UNKNOWN,
 } UniformType;
+
+#define UNIFORM_TYPE_IS_SAMPLER(ut) \
+	((ut) == UNIFORM_SAMPLER_2D || (ut) == UNIFORM_SAMPLER_CUBE)
 
 typedef struct UniformTypeInfo {
 	// Refers to vector elements, not array elements.

--- a/src/renderer/api.h
+++ b/src/renderer/api.h
@@ -122,6 +122,12 @@ typedef enum TextureType {
 #define COMPRESSION_FORMAT_TO_TEX_TYPE(cfmt) ((TextureType)((cfmt) | TEX_TYPE_COMPRESSED_BIT))
 #define TEX_TYPE_IS_DEPTH(type)              ((type) >= TEX_TYPE_DEPTH_8 && (type) <= TEX_TYPE_DEPTH_32_FLOAT)
 
+typedef enum TextureClass {
+	// NOTE: whichever is placed first here is considered the "default" where applicable.
+	TEXTURE_CLASS_2D,
+	TEXTURE_CLASS_CUBEMAP,
+} TextureClass;
+
 typedef enum TextureFilterMode {
 	// NOTE: whichever is placed first here is considered the "default" where applicable.
 	TEX_FILTER_LINEAR,
@@ -157,10 +163,21 @@ enum {
 	#define TEX_MIPMAPS_MAX ((uint)(-1))
 };
 
+typedef enum CubemapFace {
+	CUBEMAP_FACE_POS_X,
+	CUBEMAP_FACE_NEG_X,
+	CUBEMAP_FACE_POS_Y,
+	CUBEMAP_FACE_NEG_Y,
+	CUBEMAP_FACE_POS_Z,
+	CUBEMAP_FACE_NEG_Z,
+} CubemapFace;
+
 typedef struct TextureParams {
 	uint width;
 	uint height;
+	uint layers;
 	TextureType type;
+	TextureClass class;
 
 	struct {
 		TextureFilterMode mag;
@@ -712,8 +729,8 @@ const char* r_texture_get_debug_label(Texture *tex) attr_nonnull(1);
 void r_texture_set_debug_label(Texture *tex, const char *label) attr_nonnull(1);
 void r_texture_set_filter(Texture *tex, TextureFilterMode fmin, TextureFilterMode fmag) attr_nonnull(1);
 void r_texture_set_wrap(Texture *tex, TextureWrapMode ws, TextureWrapMode wt) attr_nonnull(1);
-void r_texture_fill(Texture *tex, uint mipmap, const Pixmap *image_data) attr_nonnull(1, 3);
-void r_texture_fill_region(Texture *tex, uint mipmap, uint x, uint y, const Pixmap *image_data) attr_nonnull(1, 5);
+void r_texture_fill(Texture *tex, uint mipmap, uint layer, const Pixmap *image_data) attr_nonnull(1, 4);
+void r_texture_fill_region(Texture *tex, uint mipmap, uint layer, uint x, uint y, const Pixmap *image_data) attr_nonnull(1, 6);
 void r_texture_invalidate(Texture *tex) attr_nonnull(1);
 void r_texture_clear(Texture *tex, const Color *clr) attr_nonnull(1, 2);
 void r_texture_destroy(Texture *tex) attr_nonnull(1);

--- a/src/renderer/common/backend.h
+++ b/src/renderer/common/backend.h
@@ -73,8 +73,8 @@ typedef struct RendererFuncs {
 	void (*texture_set_wrap)(Texture *tex, TextureWrapMode ws, TextureWrapMode wt);
 	void (*texture_destroy)(Texture *tex);
 	void (*texture_invalidate)(Texture *tex);
-	void (*texture_fill)(Texture *tex, uint mipmap, const Pixmap *image_data);
-	void (*texture_fill_region)(Texture *tex, uint mipmap, uint x, uint y, const Pixmap *image_data);
+	void (*texture_fill)(Texture *tex, uint mipmap, uint layer, const Pixmap *image_data);
+	void (*texture_fill_region)(Texture *tex, uint mipmap, uint layer, uint x, uint y, const Pixmap *image_data);
 	void (*texture_clear)(Texture *tex, const Color *clr);
 	bool (*texture_type_query)(TextureType type, TextureFlags flags, PixmapFormat pxfmt, PixmapOrigin pxorigin, TextureTypeQueryResult *result);
 

--- a/src/renderer/gl33/gl33.h
+++ b/src/renderer/gl33/gl33.h
@@ -35,7 +35,27 @@ GLenum gl33_prim_to_gl_prim(Primitive prim);
 void gl33_begin_draw(VertexArray *varr, void **state);
 void gl33_end_draw(void *state);
 
-uint gl33_bind_texture(Texture *texture, bool for_rendering, int preferred_unit);
+// Allocates an OpenGL texturing unit for `texture`.
+// `texture->binding_unit` is set to point to the gl33 TextureUnit struct.
+// The texture will become bound to the unit on next state sync.
+// To force a sync, call gl33_sync_texunit(texture->binding_unit, ...) next.
+//
+// `texture` may be NULL, in which case a unit with empty binding will be choosen.
+//
+// If `lock_target` is not 0, the unit becomes "locked", so that subsequent calls to
+// gl33_bind_texture can not clobber it. The lock remains active until gl33_sync_texunit
+// is called with prepare_rendering=true, which normally happens before every draw call.
+//
+// The non-0 value of `lock_target` must be a valid texture target, like TEXTURE_2D.
+// If `texture` is not NULL, then `lock_target` must be equal to `texture->binding_target`.
+// Distinct values are useful with NULL textures: gl33_bind_texture will always distinct samplers
+// for distinct lock_target values.
+//
+// If `preferred_unit` is >= 0, it suggests which texturing unit to choose. This is a mere hint,
+// it is not guaranteed to be honored.
+//
+// Returns the numeric ID of the choosen texturing unit.
+uint gl33_bind_texture(Texture *texture, GLuint lock_target, int preferred_unit);
 
 void gl33_bind_vao(GLuint vao);
 void gl33_sync_vao(void);

--- a/src/renderer/gl33/shader_program.c
+++ b/src/renderer/gl33/shader_program.c
@@ -311,17 +311,18 @@ static bool cache_uniforms(ShaderProgram *prog) {
 		}
 
 		switch(type) {
-			case GL_FLOAT:      uni.type = UNIFORM_FLOAT;   break;
-			case GL_FLOAT_VEC2: uni.type = UNIFORM_VEC2;    break;
-			case GL_FLOAT_VEC3: uni.type = UNIFORM_VEC3;    break;
-			case GL_FLOAT_VEC4: uni.type = UNIFORM_VEC4;    break;
-			case GL_INT:        uni.type = UNIFORM_INT;     break;
-			case GL_INT_VEC2:   uni.type = UNIFORM_IVEC2;   break;
-			case GL_INT_VEC3:   uni.type = UNIFORM_IVEC3;   break;
-			case GL_INT_VEC4:   uni.type = UNIFORM_IVEC4;   break;
-			case GL_SAMPLER_2D: uni.type = UNIFORM_SAMPLER; break;
-			case GL_FLOAT_MAT3: uni.type = UNIFORM_MAT3;    break;
-			case GL_FLOAT_MAT4: uni.type = UNIFORM_MAT4;    break;
+			case GL_FLOAT:        uni.type = UNIFORM_FLOAT;   break;
+			case GL_FLOAT_VEC2:   uni.type = UNIFORM_VEC2;    break;
+			case GL_FLOAT_VEC3:   uni.type = UNIFORM_VEC3;    break;
+			case GL_FLOAT_VEC4:   uni.type = UNIFORM_VEC4;    break;
+			case GL_INT:          uni.type = UNIFORM_INT;     break;
+			case GL_INT_VEC2:     uni.type = UNIFORM_IVEC2;   break;
+			case GL_INT_VEC3:     uni.type = UNIFORM_IVEC3;   break;
+			case GL_INT_VEC4:     uni.type = UNIFORM_IVEC4;   break;
+			case GL_SAMPLER_2D:   uni.type = UNIFORM_SAMPLER; break;
+			case GL_SAMPLER_CUBE: uni.type = UNIFORM_SAMPLER; break;
+			case GL_FLOAT_MAT3:   uni.type = UNIFORM_MAT3;    break;
+			case GL_FLOAT_MAT4:   uni.type = UNIFORM_MAT4;    break;
 
 			default:
 				log_warn("Uniform '%s' is of an unsupported type 0x%04x and will be ignored.", name, type);

--- a/src/renderer/gl33/texture.c
+++ b/src/renderer/gl33/texture.c
@@ -576,3 +576,18 @@ const char *gl33_texture_get_debug_label(Texture *tex) {
 void gl33_texture_set_debug_label(Texture *tex, const char *label) {
 	glcommon_set_debug_label(tex->debug_label, "Texture", GL_TEXTURE, tex->gl_handle, label);
 }
+
+bool gl33_texture_sampler_compatible(Texture *tex, UniformType sampler_type) {
+	assert(UNIFORM_TYPE_IS_SAMPLER(sampler_type));
+
+	switch(tex->bind_target) {
+		case GL_TEXTURE_2D:
+			return sampler_type == UNIFORM_SAMPLER_2D;
+
+		case GL_TEXTURE_CUBE_MAP:
+			return sampler_type == UNIFORM_SAMPLER_CUBE;
+
+		default:
+			UNREACHABLE;
+	}
+}

--- a/src/renderer/gl33/texture.c
+++ b/src/renderer/gl33/texture.c
@@ -210,7 +210,7 @@ static void gl33_texture_set(Texture *tex, uint mipmap, uint layer, const Pixmap
 
 	GLuint prev_pbo = 0;
 
-	gl33_bind_texture(tex, false, -1);
+	gl33_bind_texture(tex, 0, -1);
 	gl33_sync_texunit(tex->binding_unit, false, true);
 
 	if(tex->pbo) {
@@ -361,7 +361,7 @@ Texture *gl33_texture_create(const TextureParams *params) {
 
 	glGenTextures(1, &tex->gl_handle);
 	snprintf(tex->debug_label, sizeof(tex->debug_label), "Texture #%i", tex->gl_handle);
-	gl33_bind_texture(tex, false, -1);
+	gl33_bind_texture(tex, 0, -1);
 	gl33_sync_texunit(tex->binding_unit, false, true);
 
 	tex->fmt_info = pick_format(params->type, params->flags);
@@ -422,14 +422,14 @@ void gl33_texture_get_params(Texture *tex, TextureParams *params) {
 
 void gl33_texture_set_filter(Texture *tex, TextureFilterMode fmin, TextureFilterMode fmag) {
 	if(tex->params.filter.min != fmin) {
-		gl33_bind_texture(tex, false, -1);
+		gl33_bind_texture(tex, 0, -1);
 		gl33_sync_texunit(tex->binding_unit, false, true);
 		tex->params.filter.min = fmin;
 		glTexParameteri(tex->bind_target, GL_TEXTURE_MIN_FILTER, r_filter_to_gl_filter(fmin, tex->fmt_info));
 	}
 
 	if(tex->params.filter.mag != fmag) {
-		gl33_bind_texture(tex, false, -1);
+		gl33_bind_texture(tex, 0, -1);
 		gl33_sync_texunit(tex->binding_unit, false, true);
 		tex->params.filter.mag = fmag;
 		glTexParameteri(tex->bind_target, GL_TEXTURE_MAG_FILTER, r_filter_to_gl_filter(fmag, tex->fmt_info));
@@ -438,14 +438,14 @@ void gl33_texture_set_filter(Texture *tex, TextureFilterMode fmin, TextureFilter
 
 void gl33_texture_set_wrap(Texture *tex, TextureWrapMode ws, TextureWrapMode wt) {
 	if(tex->params.wrap.s != ws) {
-		gl33_bind_texture(tex, false, -1);
+		gl33_bind_texture(tex, 0, -1);
 		gl33_sync_texunit(tex->binding_unit, false, true);
 		tex->params.wrap.s = ws;
 		glTexParameteri(tex->bind_target, GL_TEXTURE_WRAP_S, r_wrap_to_gl_wrap(ws));
 	}
 
 	if(tex->params.wrap.t != wt) {
-		gl33_bind_texture(tex, false, -1);
+		gl33_bind_texture(tex, 0, -1);
 		gl33_sync_texunit(tex->binding_unit, false, true);
 		tex->params.wrap.t = wt;
 		glTexParameteri(tex->bind_target, GL_TEXTURE_WRAP_T, r_wrap_to_gl_wrap(wt));
@@ -458,7 +458,7 @@ void gl33_texture_invalidate(Texture *tex) {
 		return;
 	}
 
-	gl33_bind_texture(tex, false, -1);
+	gl33_bind_texture(tex, 0, -1);
 	gl33_sync_texunit(tex->binding_unit, false, true);
 
 	GLenum ifmt = tex->fmt_info->internal_format;
@@ -490,7 +490,7 @@ void gl33_texture_fill(Texture *tex, uint mipmap, uint layer, const Pixmap *imag
 void gl33_texture_fill_region(Texture *tex, uint mipmap, uint layer, uint x, uint y, const Pixmap *image) {
 	assert(mipmap == 0 || tex->params.mipmap_mode != TEX_MIPMAP_AUTO);
 
-	gl33_bind_texture(tex, false, -1);
+	gl33_bind_texture(tex, 0, -1);
 	gl33_sync_texunit(tex->binding_unit, false, true);
 
 	TextureTypeQueryResult qr;
@@ -562,7 +562,7 @@ void gl33_texture_prepare(Texture *tex) {
 	if(tex->params.mipmap_mode == TEX_MIPMAP_AUTO && tex->mipmaps_outdated) {
 		// log_debug("Generating mipmaps for %s (%u)", tex->debug_label, tex->gl_handle);
 
-		gl33_bind_texture(tex, false, -1);
+		gl33_bind_texture(tex, 0, -1);
 		gl33_sync_texunit(tex->binding_unit, false, true);
 		glGenerateMipmap(tex->bind_target);
 		tex->mipmaps_outdated = false;

--- a/src/renderer/gl33/texture.h
+++ b/src/renderer/gl33/texture.h
@@ -44,5 +44,6 @@ void gl44_texture_clear(Texture *tex, const Color *clr);
 void gl33_texture_clear(Texture *tex, const Color *clr);
 void gl33_texture_destroy(Texture *tex);
 bool gl33_texture_type_query(TextureType type, TextureFlags flags, PixmapFormat pxfmt, PixmapOrigin pxorigin, TextureTypeQueryResult *result);
+bool gl33_texture_sampler_compatible(Texture *tex, UniformType sampler_type) attr_nonnull(1);
 
 #endif // IGUARD_renderer_gl33_texture_h

--- a/src/renderer/gl33/texture.h
+++ b/src/renderer/gl33/texture.h
@@ -22,6 +22,7 @@ typedef struct Texture {
 	TextureUnit *binding_unit;
 	GLuint gl_handle;
 	GLuint pbo;
+	GLenum bind_target;
 	TextureParams params;
 	bool mipmaps_outdated;
 	char debug_label[R_DEBUG_LABEL_SIZE];
@@ -35,8 +36,8 @@ void gl33_texture_set_debug_label(Texture *tex, const char *label);
 void gl33_texture_set_filter(Texture *tex, TextureFilterMode fmin, TextureFilterMode fmag);
 void gl33_texture_set_wrap(Texture *tex, TextureWrapMode ws, TextureWrapMode wt);
 void gl33_texture_invalidate(Texture *tex);
-void gl33_texture_fill(Texture *tex, uint mipmap, const Pixmap *image);
-void gl33_texture_fill_region(Texture *tex, uint mipmap, uint x, uint y, const Pixmap *image);
+void gl33_texture_fill(Texture *tex, uint mipmap, uint layer, const Pixmap *image);
+void gl33_texture_fill_region(Texture *tex, uint mipmap, uint layer, uint x, uint y, const Pixmap *image);
 void gl33_texture_prepare(Texture *tex);
 void gl33_texture_taint(Texture *tex);
 void gl44_texture_clear(Texture *tex, const Color *clr);

--- a/src/renderer/glcommon/opengl.c
+++ b/src/renderer/glcommon/opengl.c
@@ -226,6 +226,20 @@ static void glcommon_ext_pixel_buffer_object(void) {
 #endif
 }
 
+static void glcommon_ext_seamless_cubemap(void) {
+	EXT_FLAG(seamless_cubemap);
+
+#ifndef STATIC_GLES3
+	// NOTE: GLES3 seems to provide seamless sampling by default,
+	// but it must be glEnabled in plain OpenGL, which is what this extension is about.
+
+	CHECK_CORE(GL_ATLEAST(3, 2));
+	CHECK_EXT(GL_ARB_seamless_cube_map);
+#endif
+
+	EXT_MISSING();
+}
+
 static void glcommon_ext_depth_texture(void) {
 	EXT_FLAG(depth_texture);
 
@@ -898,6 +912,7 @@ void glcommon_check_capabilities(void) {
 	glcommon_ext_instanced_arrays();
 	glcommon_ext_internalformat_query2();
 	glcommon_ext_pixel_buffer_object();
+	glcommon_ext_seamless_cubemap();
 	glcommon_ext_texture_filter_anisotropic();
 	glcommon_ext_texture_float();
 	glcommon_ext_texture_float_linear();

--- a/src/renderer/glcommon/opengl.h
+++ b/src/renderer/glcommon/opengl.h
@@ -178,6 +178,7 @@ struct glext_s {
 	ext_flag_t instanced_arrays;
 	ext_flag_t internalformat_query2;
 	ext_flag_t pixel_buffer_object;
+	ext_flag_t seamless_cubemap;
 	ext_flag_t texture_filter_anisotropic;
 	ext_flag_t texture_float;
 	ext_flag_t texture_float_linear;

--- a/src/renderer/null/null.c
+++ b/src/renderer/null/null.c
@@ -85,8 +85,8 @@ static void null_texture_set_debug_label(Texture *tex, const char *label) { }
 static const char* null_texture_get_debug_label(Texture *tex) { return "null texture"; }
 static void null_texture_set_filter(Texture *tex, TextureFilterMode fmin, TextureFilterMode fmag) { }
 static void null_texture_set_wrap(Texture *tex, TextureWrapMode fmin, TextureWrapMode fmag) { }
-static void null_texture_fill(Texture *tex, uint mipmap, const Pixmap *image_data) { }
-static void null_texture_fill_region(Texture *tex, uint mipmap, uint x, uint y, const Pixmap *image_data) { }
+static void null_texture_fill(Texture *tex, uint mipmap, uint layer, const Pixmap *image_data) { }
+static void null_texture_fill_region(Texture *tex, uint mipmap, uint layer, uint x, uint y, const Pixmap *image_data) { }
 static void null_texture_invalidate(Texture *tex) { }
 static void null_texture_destroy(Texture *tex) { }
 static void null_texture_clear(Texture *tex, const Color *color) { }

--- a/src/resource/font.c
+++ b/src/resource/font.c
@@ -406,7 +406,7 @@ static bool add_glyph_to_spritesheet(Glyph *glyph, Pixmap *pixmap, SpriteSheet *
 
 	r_texture_fill_region(
 		ss->tex,
-		0,
+		0, 0,
 		rect_x(sprite_pos),
 		rect_y(sprite_pos),
 		pixmap

--- a/src/resource/postprocess.c
+++ b/src/resource/postprocess.c
@@ -67,7 +67,7 @@ static bool postprocess_load_callback(const char *key, const char *value, void *
 	UniformType type = r_uniform_type(uni);
 	const UniformTypeInfo *type_info = r_uniform_type_info(type);
 
-	if(type == UNIFORM_SAMPLER) {
+	if(UNIFORM_TYPE_IS_SAMPLER(type)) {
 		Texture *tex = get_resource_data(RES_TEXTURE, value, ldata->resflags);
 
 		if(tex) {

--- a/src/resource/texture_loader/texture_loader.h
+++ b/src/resource/texture_loader/texture_loader.h
@@ -15,12 +15,18 @@
 #include "resource/resource.h"
 #include "resource/texture.h"
 
-typedef struct TextureLoadData {
-	Pixmap pixmap;
-	Pixmap pixmap_alphamap;
+typedef struct TextureLoadCubemap {
+	Pixmap faces[6];
+} TextureLoadCubemap;
 
-	uint num_mipmaps;
-	Pixmap *mipmaps;
+typedef struct TextureLoadData {
+	Pixmap alphamap;
+
+	union {
+		Pixmap *pixmaps;
+		TextureLoadCubemap *cubemaps;
+	};
+	uint num_pixmaps;
 
 	TextureParams params;
 
@@ -34,10 +40,11 @@ typedef struct TextureLoadData {
 	// NOTE: Despite being a PixmapFormat, this is also used to pick a proper TextureType later. Irrelevant for compressed textures, unless decompression fallback is used.
 	PixmapFormat preferred_format;
 
-	const char *tex_src_path;
-	const char *alphamap_src_path;
-	char *tex_src_path_allocated;
-	char *alphamap_src_path_allocated;
+	struct {
+		char *main;
+		char *alphamap;
+		char *cubemap[6];
+	} src_paths;
 
 	ResourceLoadState *st;
 } TextureLoadData;


### PR DESCRIPTION
On the renderer side, the concept of a "texture class" has been introduced. There are currently two texture classes: 2D and Cubemap. These map to `sampler2D` and `samplerCube` in shaders, respectively. Textures now also have an additional `layers` property. Its meaning depends on the texture class. For simple 2D textures, there is always only 1 layer. Cubemaps always have 6 layers, one for each face. In the future, layers could be used to represent depth in 3D textures and individual images in array textures.

Much of the texture loading code has been refactored, as it wasn't adequate for loading multiple images for a single texture. Both Basis Universal cubemaps and traditional image-based cubemaps are supported, although no runtime preprocessing is implemented for cubemaps. The Basis Universal format is strongly recommended.

The mkbasis utility can now convert 2:1 equirectangular panoramas into `.basis` cubemaps with the --equirect-cubemap map.

A `vec3 fixCubeCoord(vec3 v)` function has been added to `utils.glslh`, to convert a vector into the suitable coordinate system for sampling a cubemap. The vector doesn't need to be normalized.