### PR TITLE
Live reloading for resources

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -58,6 +58,7 @@
 	CONFIGDEF_KEYBINDING(KEY_RESTART,           "key_restart",          SDL_SCANCODE_F2) \
 	CONFIGDEF_KEYBINDING(KEY_HITAREAS,          "key_hitareas",         SDL_SCANCODE_H) \
 	CONFIGDEF_KEYBINDING(KEY_TOGGLE_AUDIO,      "key_toggle_audio",     SDL_SCANCODE_M) \
+	CONFIGDEF_KEYBINDING(KEY_RELOAD_RESOURCES,  "key_reload_resources", SDL_SCANCODE_F5) \
 
 
 #define GPKEYDEFS \

--- a/src/events.c
+++ b/src/events.c
@@ -526,5 +526,10 @@ static bool events_handler_hotkeys(SDL_Event *event, void *arg) {
 		return true;
 	}
 
+	if(scan == config_get_int(CONFIG_KEY_RELOAD_RESOURCES)) {
+		reload_all_resources();
+		return true;
+	}
+
 	return false;
 }

--- a/src/events.h
+++ b/src/events.h
@@ -47,6 +47,8 @@ typedef enum {
 
 	TE_AUDIO_BGM_STARTED,
 
+	TE_FILEWATCH,
+
 	NUM_TAISEI_EVENTS
 } TaiseiEvent;
 

--- a/src/filewatch/filewatch.h
+++ b/src/filewatch/filewatch.h
@@ -1,0 +1,23 @@
+/*
+ * This software is licensed under the terms of the MIT License.
+ * See COPYING for further information.
+ * ---
+ * Copyright (c) 2011-2019, Lukas Weber <laochailan@web.de>.
+ * Copyright (c) 2012-2019, Andrei Alexeyev <akari@taisei-project.org>.
+*/
+
+#pragma once
+#include "taisei.h"
+
+typedef enum FileWatchEvent {
+	FILEWATCH_FILE_UPDATED,
+	FILEWATCH_FILE_DELETED,
+} FileWatchEvent;
+
+typedef struct FileWatch FileWatch;
+
+void filewatch_init(void);
+void filewatch_shutdown(void);
+
+FileWatch *filewatch_watch(const char *syspath);
+void filewatch_unwatch(FileWatch *watch);

--- a/src/filewatch/filewatch_inotify.c
+++ b/src/filewatch/filewatch_inotify.c
@@ -1,0 +1,230 @@
+/*
+ * This software is licensed under the terms of the MIT License.
+ * See COPYING for further information.
+ * ---
+ * Copyright (c) 2011-2019, Lukas Weber <laochailan@web.de>.
+ * Copyright (c) 2012-2019, Andrei Alexeyev <akari@taisei-project.org>.
+*/
+
+#include "taisei.h"
+
+#include "filewatch.h"
+#include "util.h"
+#include "events.h"
+
+#include <sys/inotify.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <errno.h>
+
+#define INVALID_WD (-1)
+
+#define WATCHED_EVENTS ( \
+	IN_ATTRIB          | \
+	IN_CLOSE_WRITE     | \
+	IN_DELETE_SELF     | \
+	IN_MODIFY          | \
+	IN_MOVE_SELF       | \
+0)
+
+#define DELETION_EVENTS ( \
+	IN_ATTRIB           | /* could be an inode refcount update… */ \
+	IN_DELETE_SELF      | \
+	IN_IGNORED          | \
+	IN_MOVE_SELF        | \
+0)
+
+#define FW (*_fw_globals)
+
+#define EVENTS_BUF_SIZE 4096
+
+struct FileWatch {
+	int wd;
+	SDL_atomic_t refs;
+	bool updated;
+	bool deleted;
+};
+
+struct {
+	int inotify;
+	ht_int2ptr_ts_t wd_to_watch;
+	SDL_mutex *modify_mtx;
+	DYNAMIC_ARRAY(FileWatch*) deactivate_list;
+} *_fw_globals;
+
+static bool filewatch_frame_event(SDL_Event *e, void *a);
+
+void filewatch_init(void) {
+	assert(_fw_globals == NULL);
+
+	int inotify = inotify_init1(IN_NONBLOCK | IN_CLOEXEC);
+
+	if(UNLIKELY(inotify < 0)) {
+		log_error("Failed to initialize inotify: %s", strerror(errno));
+		return;
+	}
+
+	_fw_globals = calloc(1, sizeof(*_fw_globals));
+	FW.inotify = inotify;
+	ht_create(&FW.wd_to_watch);
+
+	FW.modify_mtx = SDL_CreateMutex();
+
+	if(UNLIKELY(FW.modify_mtx == NULL)) {
+		log_sdl_error(LOG_WARN, "SDL_CreateMutex");
+	}
+
+	events_register_handler(&(EventHandler) {
+		.proc = filewatch_frame_event,
+		.priority = EPRIO_SYSTEM,
+		.event_type = MAKE_TAISEI_EVENT(TE_FRAME),
+	});
+}
+
+void filewatch_shutdown(void) {
+	if(_fw_globals) {
+		events_unregister_handler(filewatch_frame_event);
+
+		close(FW.inotify);
+		ht_destroy(&FW.wd_to_watch);
+		dynarray_free_data(&FW.deactivate_list);
+		SDL_DestroyMutex(FW.modify_mtx);
+
+		free(_fw_globals);
+		_fw_globals = NULL;
+	}
+}
+
+FileWatch *filewatch_watch(const char *syspath) {
+	if(!&FW) {
+		log_error("Subsystem not initialized");
+		return NULL;
+	}
+
+	SDL_LockMutex(FW.modify_mtx);
+	int wd = inotify_add_watch(FW.inotify, syspath, WATCHED_EVENTS);
+
+	if(UNLIKELY(wd == INVALID_WD)) {
+		SDL_UnlockMutex(FW.modify_mtx);
+		log_error("Failed to watch '%s': %s", syspath, strerror(errno));
+		return NULL;
+	}
+
+	FileWatch *w;
+
+	if(ht_lookup(&FW.wd_to_watch, wd, (void**)&w)) {
+		assert(w->wd == wd);
+	} else {
+		w = calloc(1, sizeof(*w));
+		w->wd = wd;
+		ht_set(&FW.wd_to_watch, wd, w);
+	}
+
+	SDL_AtomicIncRef(&w->refs);
+	SDL_UnlockMutex(FW.modify_mtx);
+
+	log_debug("Watching '%s'; wd = %i", syspath, w->wd);
+	return NOT_NULL(w);
+}
+
+static void filewatch_deactivate(FileWatch *watch) {
+	SDL_LockMutex(FW.modify_mtx);
+
+	if(watch->wd != INVALID_WD) {
+		assert(ht_get(&FW.wd_to_watch, watch->wd, NULL) == watch);
+
+		if(UNLIKELY(inotify_rm_watch(FW.inotify, watch->wd) == -1)) {
+			log_warn("Failed to remove inotify watch: %s", strerror(errno));
+		}
+
+		ht_unset(&FW.wd_to_watch, watch->wd);
+		watch->wd = INVALID_WD;
+	}
+
+	SDL_UnlockMutex(FW.modify_mtx);
+}
+
+void filewatch_unwatch(FileWatch *watch) {
+	if(SDL_AtomicDecRef(&watch->refs)) {
+		filewatch_deactivate(watch);
+		free(watch);
+	}
+}
+
+static void filewatch_process_events(ssize_t bufsize, char buf[bufsize]) {
+	struct inotify_event *e;
+
+	for(ssize_t i = 0; i < bufsize;) {
+		e = CASTPTR_ASSUME_ALIGNED(buf + i, struct inotify_event);
+		FileWatch *w = ht_get(&FW.wd_to_watch, e->wd, NULL);
+
+		if(w == NULL) {
+			log_debug("inotify event wd=%i mask=0x%08x (ignore)", e->wd, e->mask);
+			goto skip;
+		}
+
+		if(e->mask & DELETION_EVENTS) {
+			log_debug("inotify event wd=%i mask=0x%08x (delete)", e->wd, e->mask);
+			w->deleted = true;
+		} else {
+			log_debug("inotify event wd=%i mask=0x%08x (update)", e->wd, e->mask);
+			w->updated = true;
+		}
+	skip:
+		i += sizeof(*e) + e->len;
+	}
+}
+
+static void filewatch_process(void) {
+	SDL_LockMutex(FW.modify_mtx);
+	alignas(alignof(struct inotify_event)) char buf[EVENTS_BUF_SIZE];
+
+	for(;;) {
+		ssize_t r = read(FW.inotify, buf, sizeof(buf));
+
+		if(r == -1) {
+			if(errno != EAGAIN) {
+				log_error("%s", strerror(errno));
+			}
+
+			break;
+		}
+
+		filewatch_process_events(r, buf);
+	}
+
+	ht_lock(&FW.wd_to_watch);
+	ht_int2ptr_ts_iter_t iter;
+	ht_iter_begin(&FW.wd_to_watch, &iter);
+
+	for(;iter.has_data; ht_iter_next(&iter)) {
+		FileWatch *w = NOT_NULL(iter.value);
+
+		if(w->deleted) {
+			log_debug("Emitting delete event for wd %i", w->wd);
+			events_emit(TE_FILEWATCH, FILEWATCH_FILE_DELETED, w, NULL);
+			w->deleted = w->updated = false;
+			// defer filewatch_deactivate(w) because it modifies this hashtable
+			*dynarray_append(&FW.deactivate_list) = w;
+		} else if(w->updated) {
+			log_debug("Emitting update event for wd %i", w->wd);
+			events_emit(TE_FILEWATCH, FILEWATCH_FILE_UPDATED, w, NULL);
+			w->updated = false;
+		}
+	}
+
+	ht_iter_end(&iter);
+	ht_unlock(&FW.wd_to_watch);
+
+	dynarray_foreach_elem(&FW.deactivate_list, FileWatch **w, {
+		filewatch_deactivate(*w);
+	});
+
+	FW.deactivate_list.num_elements = 0;
+	SDL_UnlockMutex(FW.modify_mtx);
+}
+
+static bool filewatch_frame_event(SDL_Event *e, void *a) {
+	filewatch_process();
+	return false;
+}

--- a/src/filewatch/filewatch_null.c
+++ b/src/filewatch/filewatch_null.c
@@ -1,0 +1,24 @@
+/*
+ * This software is licensed under the terms of the MIT License.
+ * See COPYING for further information.
+ * ---
+ * Copyright (c) 2011-2019, Lukas Weber <laochailan@web.de>.
+ * Copyright (c) 2012-2019, Andrei Alexeyev <akari@taisei-project.org>.
+*/
+
+#include "taisei.h"
+
+#include "filewatch.h"
+
+void filewatch_init(void) {
+}
+
+void filewatch_shutdown(void) {
+}
+
+FileWatch *filewatch_watch(const char *syspath) {
+	return NULL;
+}
+
+void filewatch_unwatch(FileWatch *watch) {
+}

--- a/src/filewatch/meson.build
+++ b/src/filewatch/meson.build
@@ -1,5 +1,5 @@
 
-filewatch_enabled = true
+filewatch_enabled = is_developer_build
 filewatch_src = []
 
 if filewatch_enabled

--- a/src/filewatch/meson.build
+++ b/src/filewatch/meson.build
@@ -1,0 +1,28 @@
+
+filewatch_enabled = true
+filewatch_src = []
+
+if filewatch_enabled
+    # For shims like inotify-kqueue
+    inotify_dep = dependency('libinotify', required : false)
+    if not inotify_dep.found()
+        inotify_dep = cc.find_library('inotify', required : false)
+    endif
+
+    filewatch_enabled = (
+        have_posix and
+        cc.has_function('inotify_init1', dependencies : inotify_dep) and
+        cc.has_header_symbol('sys/inotify.h', 'struct inotify_event', dependencies : inotify_dep)
+    )
+
+    if not filewatch_enabled
+        warning('No inotify support; live file monitoring not available')
+    endif
+endif
+
+if filewatch_enabled
+    taisei_deps += inotify_dep
+    filewatch_src += files('filewatch_inotify.c')
+else
+    filewatch_src += files('filewatch_null.c')
+endif

--- a/src/main.c
+++ b/src/main.c
@@ -45,7 +45,7 @@ static void taisei_shutdown(void) {
 
 	gamemode_shutdown();
 	free_all_refs();
-	free_resources(true);
+	shutdown_resources();
 	filewatch_shutdown();
 	taskmgr_global_shutdown();
 	audio_shutdown();

--- a/src/main.c
+++ b/src/main.c
@@ -30,6 +30,7 @@
 #include "util/gamemode.h"
 #include "cutscenes/cutscene.h"
 #include "replay/struct.h"
+#include "filewatch/filewatch.h"
 
 attr_unused
 static void taisei_shutdown(void) {
@@ -45,6 +46,7 @@ static void taisei_shutdown(void) {
 	gamemode_shutdown();
 	free_all_refs();
 	free_resources(true);
+	filewatch_shutdown();
 	taskmgr_global_shutdown();
 	audio_shutdown();
 	video_shutdown();
@@ -337,6 +339,7 @@ static void main_post_vfsinit(CallChainResult ccr) {
 	init_global(&ctx->cli);
 	events_init();
 	video_init();
+	filewatch_init();
 	init_resources();
 	r_post_init();
 	draw_loading_screen();

--- a/src/meson.build
+++ b/src/meson.build
@@ -127,6 +127,7 @@ subdir('audio')
 subdir('cutscenes')
 subdir('dialog')
 subdir('eventloop')
+subdir('filewatch')
 subdir('lasers')
 subdir('menu')
 subdir('pixmap')
@@ -146,6 +147,7 @@ taisei_src += [
     cutscenes_src,
     dialog_src,
     eventloop_src,
+    filewatch_src,
     lasers_src,
     menu_src,
     pixmap_src,

--- a/src/renderer/api.c
+++ b/src/renderer/api.c
@@ -356,6 +356,10 @@ const char* r_shader_object_get_debug_label(ShaderObject *shobj) {
 	return B.shader_object_get_debug_label(shobj);
 }
 
+bool r_shader_object_transfer(ShaderObject *dst, ShaderObject *src) {
+	return B.shader_object_transfer(dst, src);
+}
+
 ShaderProgram* r_shader_program_link(uint num_objects, ShaderObject *shobjs[num_objects]) {
 	return B.shader_program_link(num_objects, shobjs);
 }
@@ -370,6 +374,10 @@ void r_shader_program_set_debug_label(ShaderProgram *prog, const char *label) {
 
 const char* r_shader_program_get_debug_label(ShaderProgram *prog) {
 	return B.shader_program_get_debug_label(prog);
+}
+
+bool r_shader_program_transfer(ShaderProgram *dst, ShaderProgram *src) {
+	return B.shader_program_transfer(dst, src);
 }
 
 void r_shader_ptr(ShaderProgram *prog) {
@@ -460,6 +468,10 @@ void r_texture_clear(Texture *tex, const Color *clr) {
 
 void r_texture_destroy(Texture *tex) {
 	B.texture_destroy(tex);
+}
+
+bool r_texture_transfer(Texture *dst, Texture *src) {
+	return B.texture_transfer(dst, src);
 }
 
 bool r_texture_type_query(TextureType type, TextureFlags flags, PixmapFormat pxfmt, PixmapOrigin pxorigin, TextureTypeQueryResult *result) {

--- a/src/renderer/api.h
+++ b/src/renderer/api.h
@@ -539,11 +539,13 @@ ShaderObject* r_shader_object_compile(ShaderSource *source) attr_nonnull(1);
 void r_shader_object_destroy(ShaderObject *shobj) attr_nonnull(1);
 void r_shader_object_set_debug_label(ShaderObject *shobj, const char *label) attr_nonnull(1);
 const char* r_shader_object_get_debug_label(ShaderObject *shobj) attr_nonnull(1);
+bool r_shader_object_transfer(ShaderObject *dst, ShaderObject *src) attr_nonnull_all;
 
 ShaderProgram* r_shader_program_link(uint num_objects, ShaderObject *shobjs[num_objects]) attr_nonnull(2);
 void r_shader_program_destroy(ShaderProgram *prog);
 void r_shader_program_set_debug_label(ShaderProgram *prog, const char *label) attr_nonnull(1);
 const char* r_shader_program_get_debug_label(ShaderProgram *prog) attr_nonnull(1);
+bool r_shader_program_transfer(ShaderProgram *dst, ShaderProgram *src) attr_nonnull_all;
 
 void r_shader_ptr(ShaderProgram *prog) attr_nonnull(1);
 ShaderProgram* r_shader_current(void) attr_returns_nonnull;
@@ -737,6 +739,7 @@ bool r_texture_dump(Texture *tex, uint mipmap, uint layer, Pixmap *dst) attr_non
 void r_texture_invalidate(Texture *tex) attr_nonnull(1);
 void r_texture_clear(Texture *tex, const Color *clr) attr_nonnull(1, 2);
 void r_texture_destroy(Texture *tex) attr_nonnull(1);
+bool r_texture_transfer(Texture *dst, Texture *src) attr_nonnull(1);
 
 bool r_texture_type_query(TextureType type, TextureFlags flags, PixmapFormat pxfmt, PixmapOrigin pxorigin, TextureTypeQueryResult *result) attr_nodiscard;
 const char *r_texture_type_name(TextureType type);

--- a/src/renderer/common/backend.h
+++ b/src/renderer/common/backend.h
@@ -49,11 +49,13 @@ typedef struct RendererFuncs {
 	void (*shader_object_destroy)(ShaderObject *shobj);
 	void (*shader_object_set_debug_label)(ShaderObject *shobj, const char *label);
 	const char* (*shader_object_get_debug_label)(ShaderObject *shobj);
+	bool (*shader_object_transfer)(ShaderObject *dst, ShaderObject *src);
 
 	ShaderProgram* (*shader_program_link)(uint num_objects, ShaderObject *shobjs[num_objects]);
 	void (*shader_program_destroy)(ShaderProgram *prog);
 	void (*shader_program_set_debug_label)(ShaderProgram *prog, const char *label);
 	const char* (*shader_program_get_debug_label)(ShaderProgram *prog);
+	bool (*shader_program_transfer)(ShaderProgram *dst, ShaderProgram *src);
 
 	void (*shader)(ShaderProgram *prog);
 	ShaderProgram* (*shader_current)(void);
@@ -76,6 +78,7 @@ typedef struct RendererFuncs {
 	bool (*texture_dump)(Texture *tex, uint mipmap, uint layer, Pixmap *dst);
 	void (*texture_clear)(Texture *tex, const Color *clr);
 	bool (*texture_type_query)(TextureType type, TextureFlags flags, PixmapFormat pxfmt, PixmapOrigin pxorigin, TextureTypeQueryResult *result);
+	bool (*texture_transfer)(Texture *dst, Texture *src);
 
 	Framebuffer* (*framebuffer_create)(void);
 	const char* (*framebuffer_get_debug_label)(Framebuffer *framebuffer);

--- a/src/renderer/gl33/gl33.c
+++ b/src/renderer/gl33/gl33.c
@@ -1035,6 +1035,21 @@ void gl33_texture_deleted(Texture *tex) {
 	}
 }
 
+void gl33_texture_pointer_renamed(Texture *pold, Texture *pnew) {
+	_r_sprite_batch_texture_deleted(pold);
+	gl33_uniforms_handle_texture_pointer_renamed(pold, pnew);
+
+	for(TextureUnit *unit = R.texunits.array; unit < R.texunits.array + R.texunits.limit; ++unit) {
+		if(unit->pending == pold) {
+			unit->pending = pnew;
+		}
+
+		if(unit->active == pold) {
+			unit->active = pnew;
+		}
+	}
+}
+
 void gl33_framebuffer_deleted(Framebuffer *fb) {
 	if(R.framebuffer.pending == fb) {
 		R.framebuffer.pending = NULL;
@@ -1390,10 +1405,12 @@ RendererBackend _r_backend_gl33 = {
 		.shader_object_destroy = gl33_shader_object_destroy,
 		.shader_object_set_debug_label = gl33_shader_object_set_debug_label,
 		.shader_object_get_debug_label = gl33_shader_object_get_debug_label,
+		.shader_object_transfer = gl33_shader_object_transfer,
 		.shader_program_link = gl33_shader_program_link,
 		.shader_program_destroy = gl33_shader_program_destroy,
 		.shader_program_set_debug_label = gl33_shader_program_set_debug_label,
 		.shader_program_get_debug_label = gl33_shader_program_get_debug_label,
+		.shader_program_transfer = gl33_shader_program_transfer,
 		.shader = gl33_shader,
 		.shader_current = gl33_shader_current,
 		.shader_uniform = gl33_shader_uniform,
@@ -1413,6 +1430,7 @@ RendererBackend _r_backend_gl33 = {
 		.texture_clear = gl33_texture_clear,
 		.texture_type_query = gl33_texture_type_query,
 		.texture_dump = gl33_texture_dump,
+		.texture_transfer = gl33_texture_transfer,
 		.framebuffer_create = gl33_framebuffer_create,
 		.framebuffer_destroy = gl33_framebuffer_destroy,
 		.framebuffer_attach = gl33_framebuffer_attach,

--- a/src/renderer/gl33/gl33.h
+++ b/src/renderer/gl33/gl33.h
@@ -83,4 +83,6 @@ void gl33_texture_deleted(Texture *tex);
 void gl33_framebuffer_deleted(Framebuffer *fb);
 void gl33_shader_deleted(ShaderProgram *prog);
 
+void gl33_texture_pointer_renamed(Texture *pold, Texture *pnew);
+
 extern RendererBackend _r_backend_gl33;

--- a/src/renderer/gl33/shader_object.h
+++ b/src/renderer/gl33/shader_object.h
@@ -17,12 +17,13 @@ struct ShaderObject {
 	ShaderStage stage;
 	char debug_label[R_DEBUG_LABEL_SIZE];
 	uint num_attribs;
-	GLSLAttribute attribs[];
+	GLSLAttribute *attribs;
 };
 
 bool gl33_shader_language_supported(const ShaderLangInfo *lang, ShaderLangInfo *out_alternative);
 
-ShaderObject* gl33_shader_object_compile(ShaderSource *source);
+ShaderObject *gl33_shader_object_compile(ShaderSource *source);
 void gl33_shader_object_destroy(ShaderObject *shobj);
 void gl33_shader_object_set_debug_label(ShaderObject *shobj, const char *label);
-const char* gl33_shader_object_get_debug_label(ShaderObject *shobj);
+const char *gl33_shader_object_get_debug_label(ShaderObject *shobj);
+bool gl33_shader_object_transfer(ShaderObject *dst, ShaderObject *src);

--- a/src/renderer/gl33/shader_program.h
+++ b/src/renderer/gl33/shader_program.h
@@ -36,6 +36,8 @@ struct ShaderProgram {
 	char debug_label[R_DEBUG_LABEL_SIZE];
 };
 
+#define INVALID_UNIFORM_LOCATION 0xffffffff
+
 struct Uniform {
 	// these are for sampler uniforms
 	LIST_INTERFACE(Uniform);
@@ -71,3 +73,5 @@ Uniform *gl33_shader_uniform(ShaderProgram *prog, const char *uniform_name, hash
 UniformType gl33_uniform_type(Uniform *uniform);
 void gl33_uniform(Uniform *uniform, uint offset, uint count, const void *data);
 void gl33_unref_texture_from_samplers(Texture *tex);
+void gl33_uniforms_handle_texture_pointer_renamed(Texture *pold, Texture *pnew);
+bool gl33_shader_program_transfer(ShaderProgram *dst, ShaderProgram *src);

--- a/src/renderer/gl33/texture.c
+++ b/src/renderer/gl33/texture.c
@@ -622,3 +622,12 @@ bool gl33_texture_dump(Texture *tex, uint mipmap, uint layer, Pixmap *dst) {
 	return true;
 #endif
 }
+
+bool gl33_texture_transfer(Texture *dst, Texture *src) {
+	gl33_texture_deleted(dst);
+	glDeleteTextures(1, &dst->gl_handle);
+	*dst = *src;
+	gl33_texture_pointer_renamed(src, dst);
+	free(src);
+	return true;
+}

--- a/src/renderer/gl33/texture.h
+++ b/src/renderer/gl33/texture.h
@@ -44,3 +44,4 @@ void gl33_texture_destroy(Texture *tex);
 bool gl33_texture_type_query(TextureType type, TextureFlags flags, PixmapFormat pxfmt, PixmapOrigin pxorigin, TextureTypeQueryResult *result);
 bool gl33_texture_sampler_compatible(Texture *tex, UniformType sampler_type) attr_nonnull(1);
 bool gl33_texture_dump(Texture *tex, uint mipmap, uint layer, Pixmap *dst);
+bool gl33_texture_transfer(Texture *dst, Texture *src);

--- a/src/renderer/null/null.c
+++ b/src/renderer/null/null.c
@@ -46,11 +46,13 @@ static ShaderObject* null_shader_object_compile(ShaderSource *source) { return (
 static void null_shader_object_destroy(ShaderObject *shobj) { }
 static void null_shader_object_set_debug_label(ShaderObject *shobj, const char *label) { }
 static const char* null_shader_object_get_debug_label(ShaderObject *shobj) { return "Null shader object"; }
+static bool null_shader_object_transfer(ShaderObject *dst, ShaderObject *src) { return true; }
 
 static ShaderProgram* null_shader_program_link(uint num_objects, ShaderObject *shobjs[num_objects]) { return (void*)&placeholder; }
 static void null_shader_program_destroy(ShaderProgram *prog) { }
 static void null_shader_program_set_debug_label(ShaderProgram *prog, const char *label) { }
 static const char* null_shader_program_get_debug_label(ShaderProgram *prog) { return "Null shader program"; }
+static bool null_shader_program_transfer(ShaderProgram *dst, ShaderProgram *src) { return true; }
 
 static void null_shader(ShaderProgram *prog) { }
 static ShaderProgram* null_shader_current(void) { return (void*)&placeholder; }
@@ -101,6 +103,7 @@ static bool null_texture_type_query(TextureType type, TextureFlags flags, Pixmap
 
 	return true;
 }
+static bool null_texture_transfer(Texture *dst, Texture *src) { return true; }
 
 static FloatRect default_fb_viewport = { 0, 0, 800, 600 };
 
@@ -208,10 +211,12 @@ RendererBackend _r_backend_null = {
 		.shader_object_destroy = null_shader_object_destroy,
 		.shader_object_set_debug_label = null_shader_object_set_debug_label,
 		.shader_object_get_debug_label = null_shader_object_get_debug_label,
+		.shader_object_transfer = null_shader_object_transfer,
 		.shader_program_link = null_shader_program_link,
 		.shader_program_destroy = null_shader_program_destroy,
 		.shader_program_set_debug_label = null_shader_program_set_debug_label,
 		.shader_program_get_debug_label = null_shader_program_get_debug_label,
+		.shader_program_transfer = null_shader_program_transfer,
 		.shader = null_shader,
 		.shader_current = null_shader_current,
 		.shader_uniform = null_shader_uniform,
@@ -231,6 +236,7 @@ RendererBackend _r_backend_null = {
 		.texture_dump = null_texture_dump,
 		.texture_clear = null_texture_clear,
 		.texture_type_query = null_texture_type_query,
+		.texture_transfer = null_texture_transfer,
 		.framebuffer_create = null_framebuffer_create,
 		.framebuffer_get_debug_label = null_framebuffer_get_debug_label,
 		.framebuffer_set_debug_label = null_framebuffer_set_debug_label,

--- a/src/resource/resource.h
+++ b/src/resource/resource.h
@@ -10,6 +10,7 @@
 #include "taisei.h"
 
 #include "hashtable.h"
+#include "vfs/public.h"
 
 typedef enum ResourceType {
 	RES_TEXTURE,
@@ -84,6 +85,12 @@ void res_load_continue_after_dependencies(ResourceLoadState *st, ResourceLoadPro
 // Use with res_load_continue_after_dependencies/res_load_continue_on_main to wait for dependencies.
 void res_load_dependency(ResourceLoadState *st, ResourceType type, const char *name);
 
+// Like vfs_open(), but registers the path to monitor the file for changes.
+// When a change is detected, the resource will be reloaded.
+// This only works if the transfer proc is implemented; otherwise it's equivalent to vfs_open().
+// Note that file monitoring support is not guaranteed.
+SDL_RWops *res_open_file(ResourceLoadState *st, const char *path, VFSOpenMode mode);
+
 // Unloads a resource, freeing all allocated to it memory.
 typedef void (*ResourceUnloadProc)(void *res);
 
@@ -126,6 +133,7 @@ typedef struct Resource {
 
 void init_resources(void);
 void load_resources(void);
+void shutdown_resources(void);
 void free_resources(bool all);
 void reload_all_resources(void);
 

--- a/src/resource/shader_object.c
+++ b/src/resource/shader_object.c
@@ -33,7 +33,7 @@ static struct shobj_type shobj_type_table[] = {
 	{ NULL }
 };
 
-static struct shobj_type* get_shobj_type(const char *name) {
+static struct shobj_type *get_shobj_type(const char *name) {
 	for(struct shobj_type *type = shobj_type_table; type->ext; ++type) {
 		if(strendswith(name, type->ext)) {
 			return type;
@@ -43,7 +43,7 @@ static struct shobj_type* get_shobj_type(const char *name) {
 	return NULL;
 }
 
-static char* shader_object_path(const char *name) {
+static char *shader_object_path(const char *name) {
 	char *path = NULL;
 
 	for(const char *const *ext = shobj_exts; *ext; ++ext) {
@@ -163,6 +163,10 @@ static void unload_shader_object(void *vsha) {
 	r_shader_object_destroy(vsha);
 }
 
+static bool transfer_shader_object(void *dst, void *src) {
+	return r_shader_object_transfer(dst, src);
+}
+
 ResourceHandler shader_object_res_handler = {
 	.type = RES_SHADER_OBJECT,
 	.typename = "shader object",
@@ -175,5 +179,6 @@ ResourceHandler shader_object_res_handler = {
 		.check = check_shader_object_path,
 		.load = load_shader_object_stage1,
 		.unload = unload_shader_object,
+		.transfer = transfer_shader_object,
 	},
 };

--- a/src/resource/shader_object.c
+++ b/src/resource/shader_object.c
@@ -62,6 +62,11 @@ static bool check_shader_object_path(const char *path) {
 static void load_shader_object_stage1(ResourceLoadState *st);
 static void load_shader_object_stage2(ResourceLoadState *st);
 
+static SDL_RWops *glsl_open_callback(const char *path, void *userdata) {
+	ResourceLoadState *st = userdata;
+	return res_open_file(st, path, VFS_MODE_READ);
+}
+
 static void load_shader_object_stage1(ResourceLoadState *st) {
 	struct shobj_type *type = get_shobj_type(st->path);
 
@@ -94,6 +99,8 @@ static void load_shader_object_stage1(ResourceLoadState *st) {
 				.version = { 330, GLSL_PROFILE_CORE },
 				.stage = type->stage,
 				.macros = macros,
+				.file_open_callback = glsl_open_callback,
+				.file_open_callback_userdata = st,
 			};
 
 			if(!glsl_load_source(st->path, &ldata->source, &opts)) {

--- a/src/resource/shader_program.c
+++ b/src/resource/shader_program.c
@@ -78,7 +78,7 @@ static void load_shader_program_stage2(ResourceLoadState *st) {
 	char *objname = ldata.objlist;
 
 	for(int i = 0; i < ldata.num_objects; ++i) {
-		if(!(objs[i] = get_resource_data(RES_SHADER_OBJECT, objname, st->flags))) {
+		if(!(objs[i] = get_resource_data(RES_SHADER_OBJECT, objname, st->flags & ~RESF_RELOAD))) {
 			log_error("%s: couldn't load shader object '%s'", st->path, objname);
 			free(ldata.objlist);
 			res_load_failed(st);
@@ -104,6 +104,10 @@ static void unload_shader_program(void *vprog) {
 	r_shader_program_destroy(vprog);
 }
 
+static bool transfer_shader_program(void *dst, void *src) {
+	return r_shader_program_transfer(dst, src);
+}
+
 ResourceHandler shader_program_res_handler = {
 	.type = RES_SHADER_PROGRAM,
 	.typename = "shader program",
@@ -114,5 +118,6 @@ ResourceHandler shader_program_res_handler = {
 		.check = check_shader_program_path,
 		.load = load_shader_program_stage1,
 		.unload = unload_shader_program,
+		.transfer = transfer_shader_program,
 	},
 };

--- a/src/resource/shader_program.c
+++ b/src/resource/shader_program.c
@@ -34,15 +34,25 @@ static void load_shader_program_stage1(ResourceLoadState *st) {
 
 	char *strobjects = NULL;
 
-	if(!parse_keyvalue_file_with_spec(st->path, (KVSpec[]){
+	SDL_RWops *rw = res_open_file(st, st->path, VFS_MODE_READ);
+
+	if(UNLIKELY(!rw)) {
+		log_error("VFS error: %s", vfs_get_error());
+		res_load_failed(st);
+	}
+
+	if(!parse_keyvalue_stream_with_spec(rw, (KVSpec[]){
 		{ "glsl_objects", .out_str = &strobjects, KVSPEC_DEPRECATED("objects") },
 		{ "objects",      .out_str = &strobjects },
 		{ NULL }
 	})) {
+		SDL_RWclose(rw);
 		free(strobjects);
 		res_load_failed(st);
 		return;
 	}
+
+	SDL_RWclose(rw);
 
 	if(strobjects) {
 		ldata.objlist = calloc(1, strlen(strobjects) + 1);

--- a/src/resource/sprite.c
+++ b/src/resource/sprite.c
@@ -45,7 +45,6 @@ static void load_sprite_stage1(ResourceLoadState *st) {
 
 	if(texture_res_handler.procs.check(st->path)) {
 		state->texture_name = strdup(st->name);
-		// preload_resource(RES_TEXTURE, state->texture_name, st->flags);
 		res_load_dependency(st, RES_TEXTURE, state->texture_name);
 		res_load_continue_after_dependencies(st, load_sprite_stage2, state);
 		return;
@@ -97,7 +96,7 @@ static void load_sprite_stage2(ResourceLoadState *st) {
 	struct sprite_load_state *state = NOT_NULL(st->opaque);
 	Sprite *spr = NOT_NULL(state->spr);
 
-	spr->tex = get_resource_data(RES_TEXTURE, state->texture_name, st->flags);
+	spr->tex = get_resource_data(RES_TEXTURE, state->texture_name, st->flags & ~RESF_RELOAD);
 
 	free(state->texture_name);
 	free(state);
@@ -200,6 +199,12 @@ void sprite_set_denormalized_tex_coords(Sprite *restrict spr, FloatRect tc) {
 	spr->tex_area.h = tc.h / tex_h;
 }
 
+static bool transfer_sprite(void *dst, void *src) {
+	*(Sprite*)dst = *(Sprite*)src;
+	free(src);
+	return true;
+}
+
 ResourceHandler sprite_res_handler = {
 	.type = RES_SPRITE,
 	.typename = "sprite",
@@ -210,5 +215,6 @@ ResourceHandler sprite_res_handler = {
 		.check = check_sprite_path,
 		.load = load_sprite_stage1,
 		.unload = free,
+		.transfer = transfer_sprite,
 	},
 };

--- a/src/resource/texture.c
+++ b/src/resource/texture.c
@@ -12,6 +12,11 @@
 
 #include "global.h"
 #include "video.h"
+#include "renderer/api.h"
+
+static bool texture_transfer(void *dst, void *src) {
+	return r_texture_transfer(dst, src);
+}
 
 ResourceHandler texture_res_handler = {
 	.type = RES_TEXTURE,
@@ -23,6 +28,7 @@ ResourceHandler texture_res_handler = {
 		.check = texture_loader_check_path,
 		.load = texture_loader_stage1,
 		.unload = texture_loader_unload,
+		.transfer = texture_transfer,
 	},
 };
 

--- a/src/resource/texture_loader/basisu.c
+++ b/src/resource/texture_loader/basisu.c
@@ -745,7 +745,8 @@ void texture_loader_basisu(TextureLoadData *ld) {
 	const char *ctx = ld->st->name;
 	const char *basis_file = ld->src_paths.main;
 
-	SDL_RWops *rw_in = vfs_open(basis_file, VFS_MODE_READ);
+	SDL_RWops *rw_in = res_open_file(ld->st, basis_file, VFS_MODE_READ);
+
 	if(!UNLIKELY(rw_in)) {
 		log_error("%s: VFS error: %s", ctx, vfs_get_error());
 		texture_loader_basisu_failed(ld, &bld);


### PR DESCRIPTION
This PR implements mainly two things:

* A system that makes it possible to reload resources at runtime
* Automatic and dependency-aware reloading of resources triggered by file system events — i.e. reload stuff when it changes on disk.

## Reloading mechanism

Reloading itself presents a minor challenge. Since Taisei refers to all resources with raw pointers to the resource data, we can't just unload the resource and load it again. The old pointer must remain a valid reference to the new resource; this way the user code doesn't need to know anything about the reload mechanism. To implement this in a minimally invasive manner, a new (optional) "transfer" callback has been added to the `ResourceHandler` struct. The transfer function is responsible for moving data from one instance of a resource into another (previously loaded) instance. Resource types that do not implement this function are not reloadable at runtime.

A high-level overview of the resource reload flow:
* A new temporary resource slot (an `InternalResource`) is allocated for the resource to be reloaded.
* The resource is loaded into that slot as normal. This allocates a new instance of the resource.
* If the load fails, the transient `InternalResource` is destroyed and the original resource remains unmodified.
* Otherwise, the transfer function is called to move data from the newly loaded resource (source) into the original resource (destination).
    * The source pointer becomes invalid after this destination. The transfer function must ensure that no references to it remain anywhere after its completion.
    * The transfer function may fail. In that case, it must return false, and *not* modify the destination. The source will be destroyed/invalidated.
* After a successful transfer, the temporary slot is destroyed and the reload is complete. All of this happens transparently to the user code.

Because of the varying difficulty of implementing the transfer function and practicality of supporting reloads across resource types, not all of them currently support reloading.

|   | Resouce type   | Difficulty | Comment                                                                                                                       |
| - |--------------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------- |
| ❌ | Animation      | Hard?      | External pointers to `AniSequence` make it complicated.                                                                       |
| ❌ | BGM            | Normal?    | Dubious usefulness.                                                                                                           |
| ❌ | Font           | Normal?    | Dubious usefulness.                                                                                                           | 
| ✔️ | Material       | Easy       | Trivial memory copy.                                                                                                          | 
| ❌ | Model          | Lunatic    | Transfer is easy. Unload is not fully implemented and would require a memory manager for the static vertex and index buffers. | 
| ❌ | Postprocess    | Normal+    | Obscure niche feature; the linked list structure would probably have to be revisited.                                         | 
| ❌ | SFX            | Normal?    | May need special handling for currently playing instances.                                                                    | 
| ✔️ | Shader object  | Normal     | Transfer is rejected if the shader stage changes.                                                                             | 
| ✔️ | Shader program | Hard       | Uniform objects require complicated logic to handle. Transfer is rejected if a uniform changes type.                          | 
| ✔️ | Sprite         | Easy       | Trivial memory copy.                                                                                                          | 
| ✔️ | Texture        | Normal     | Requires updating a bunch of pointers in the gl33 state tracker.                                                              |

### Triggering reloads manually

A hotkey has been added (default: F5) to reload all currently loaded resources.

Passing a new `RESF_RELOAD` flag to `preload_resource`, `preload_resources`, `get_resource`, or `get_resource_data` will cause a reload. The later two functions will block until the reload is complete.

## Live reloading

Live reloading refers to automatically reloading resources when their files change on disk. This feature currently relies on inotify, a Linux-specific API (though there is a [shim](https://github.com/libinotify-kqueue/libinotify-kqueue) for BSDs). The inotify usage is abstracted away into a new `filewatch` module, with possibility of adding new backends, though I have no plans for that for now.

### Knowing what to track

Because one resource can fetch data from arbitrarily many files (think of shader `#include`s for example), the loaders are required to tell the system which files need to be tracked. A new API is provided for that purpose:
```c
SDL_RWops *res_open_file(ResourceLoadState *st, const char *path, VFSOpenMode mode);
```
This function is a wrapper for `vfs_open` that remembers the path and sets up file monitoring for this resource. Loaders should always use it to read data from files.

### Dependencies

A previous resource code refactor already put a basic dependency system in place, so no changes to the loaders were needed in that regard. The most substantial changes are internal, in that dependency information is no longer discarded after a load, and reverse-dependencies (dependents) are now also tracked for each resource to propagate reloads efficiently.

A limitation of the dependency system is that it does not distinguish between load-time and run-time dependencies. For example, a shader program has a load-time dependency on the shader objects it comprises, but it doesn't use them after the program has been linked. Therefore, if a shader object gets reloaded, we must also reload all shader programs that were linked with it in order to update them. On the other hand, a sprite object has a run-time dependency on the texture that it's mapping. Since sprites refer to their textures via simple pointers, it is not necessary to reload them if the texture content changes.

It is currently assumed that all dependencies apply at both load-time and run-time, so some unnecessary reload propagation can happen.

### Limitations

Monitoring a specific filesystem path for changes correctly is very complicated and requires a special degree of masochism, so some corners were cut. The system assumes you are not actively trying to confuse it e.g. with symlinks or by moving entire directory trees around. It was made with the use case of editing some shaders and getting instant feedback, and it should work fine for that.

Only plain files can be monitored, not those inside `.zip` packages. It's recommended to run Taisei with `TAISEI_RES_PATH` set to `/path/to/taisei-git/resources` to make best use of this feature.

Only real filesystem paths that were accessed at resource load time are monitored, not all potential paths that their corresponding VFS paths could be resolved to. For example, if resource Foo was loaded from `/path/to/taisei-git/resources/foo.bar`, then creating a `~/.local/share/taisei/resources/foo.bar` will not trigger an automatic reload, even though the later has a higher priority in the VFS search path. A manual reload will be needed to pick up the new location and start monitoring it.

## Bugs

Unloading resources (e.g. when quitting the game) while reloads are in progress is not robust and suffers from a race condition. There may be other race conditions involved in waiting for reloads to finish. That code is very miserable.
