### PR TITLE
filewatch: rewrite inotify backend

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -256,9 +256,16 @@ config.set('TAISEI_BUILDCONF_HAVE_LONG_DOUBLE', cc.sizeof('long double') > 8)
 config.set('TAISEI_BUILDCONF_HAVE_POSIX', have_posix)
 config.set('TAISEI_BUILDCONF_HAVE_SINCOS', cc.has_function('sincos', dependencies : dep_m))
 
-if config.get('TAISEI_BUILDCONF_HAVE_SINCOS')
-    config.set('_GNU_SOURCE', true)
-endif
+use_gnu_funcs = false
+gnu_funcs = ['sincos', 'strtok_r']
+
+foreach f : gnu_funcs
+    have = cc.has_function(f, dependencies : dep_m)
+    config.set('TAISEI_BUILDCONF_HAVE_@0@'.format(f.to_upper()), have)
+    use_gnu_funcs = have or use_gnu_funcs
+endforeach
+
+config.set('_GNU_SOURCE', use_gnu_funcs)
 
 if host_machine.system() == 'emscripten'
     # Emscripten bug: https://github.com/emscripten-core/emscripten/issues/10072

--- a/meson.build
+++ b/meson.build
@@ -257,7 +257,7 @@ config.set('TAISEI_BUILDCONF_HAVE_POSIX', have_posix)
 config.set('TAISEI_BUILDCONF_HAVE_SINCOS', cc.has_function('sincos', dependencies : dep_m))
 
 use_gnu_funcs = false
-gnu_funcs = ['sincos', 'strtok_r']
+gnu_funcs = ['sincos', 'strtok_r', 'memrchr']
 
 foreach f : gnu_funcs
     have = cc.has_function(f, dependencies : dep_m)

--- a/src/filewatch/filewatch_inotify.c
+++ b/src/filewatch/filewatch_inotify.c
@@ -11,58 +11,238 @@
 #include "filewatch.h"
 #include "util.h"
 #include "events.h"
+#include "vfs/syspath_public.h"
 
-#include <sys/inotify.h>
-#include <unistd.h>
-#include <stdio.h>
 #include <errno.h>
+#include <stdio.h>
+#include <sys/inotify.h>
+#include <sys/resource.h>
+#include <unistd.h>
+
+// #define FW_DEBUG
+
+#ifdef FW_DEBUG
+	#undef FW_DEBUG
+	#define FW_DEBUG(...) log_debug(__VA_ARGS__)
+	#define IF_FW_DEBUG(...) __VA_ARGS__
+#else
+	#define FW_DEBUG(...) ((void)0)
+	#define IF_FW_DEBUG(...)
+#endif
+
+#define WATCH_FLAGS ( \
+	IN_CLOSE_WRITE      | \
+	IN_CREATE           | \
+	IN_DELETE           | \
+	IN_DELETE_SELF      | \
+	IN_MODIFY           | \
+	IN_MOVED_FROM       | \
+	IN_MOVED_TO         | \
+	IN_MOVE_SELF        | \
+	                      \
+	IN_EXCL_UNLINK      | \
+	IN_ONLYDIR          | \
+0)
 
 #define INVALID_WD (-1)
-
-#define WATCHED_EVENTS ( \
-	IN_CLOSE_WRITE     | \
-	IN_DELETE_SELF     | \
-	IN_MODIFY          | \
-	IN_MOVE_SELF       | \
-0)
-
-// FIXME: This doesn't detect removals of files with more than 1 hard link.
-// IM_DELETE_SELF is only emitted when the link count drops to 0.
-// Otherwise, IN_ATTRIB is emitted, indicating that the number of hard links has changed.
-// Unfortunately, IN_ATTRIB is also emitted for *any* attribute change on the file, such as
-// permissions or even access time, and there is no good way to distinguish a hard link removal from
-// anything else. In principle, we could test if the path we're interested in monitoring is still
-// accessible after an IN_ATTRIB event. However, that would require us to actually track the paths // here, complicating the code. Note that it is possible for multiple watched paths to resolve to
-// the same file/watch descriptor. In the current implementation, FileWatch instances correspond
-// 1-to-1 to watch descriptors, not paths.
-#define DELETION_EVENTS ( \
-	IN_DELETE_SELF      | \
-	IN_IGNORED          | \
-	IN_MOVE_SELF        | \
-0)
 
 #define FW (*_fw_globals)
 
 #define EVENTS_BUF_SIZE 4096
 
+typedef struct DirWatch DirWatch;
+
 struct FileWatch {
-	int wd;
-	SDL_atomic_t refs;
+	LIST_INTERFACE(FileWatch);
+	char *filename;
+	DirWatch *dw;
 	bool updated;
 	bool deleted;
 };
 
+struct DirWatch {
+	LIST_INTERFACE(DirWatch);
+	FileWatch *filewatch_list;
+	char *path;
+	int wd;
+};
+
+typedef struct WDRecord {
+	DirWatch *dirwatch_list;
+	int32_t refs;
+} WDRecord;
+
+#define HT_SUFFIX                      int2wdrecord
+#define HT_KEY_TYPE                    int32_t
+#define HT_VALUE_TYPE                  WDRecord
+#define HT_FUNC_HASH_KEY(key)          htutil_hashfunc_uint32((uint32_t)(key))
+#define HT_KEY_FMT                     PRIi32
+#define HT_KEY_PRINTABLE(key)          (key)
+#define HT_VALUE_FMT                   "i"
+#define HT_VALUE_PRINTABLE(val)        ((val).wd)
+#define HT_DECL
+#define HT_IMPL
+#include "hashtable_incproxy.inc.h"
+
+#define HT_SUFFIX                      filewatchset
+#define HT_KEY_TYPE                    FileWatch*
+#define HT_VALUE_TYPE                  struct ht_empty
+#define HT_FUNC_HASH_KEY(key)          htutil_hashfunc_uint64((uint64_t)(key))
+#define HT_KEY_FMT                     "p"
+#define HT_KEY_PRINTABLE(key)          ((void*)(key))
+#define HT_VALUE_FMT                   "s"
+#define HT_VALUE_PRINTABLE(val)        "(empty)"
+#define HT_DECL
+#define HT_IMPL
+#include "hashtable_incproxy.inc.h"
+
 struct {
 	int inotify;
-	ht_int2ptr_ts_t wd_to_watch;
+	ht_int2wdrecord_t wd_records;
+	ht_str2ptr_t dirpath_to_dirwatch;
+	ht_filewatchset_t updated_watches;
 	SDL_mutex *modify_mtx;
-	DYNAMIC_ARRAY(FileWatch*) deactivate_list;
 } *_fw_globals;
+
+static WDRecord *wdrecord_get(int wd, bool create) {
+	WDRecord *r = NULL;
+
+	if(!ht_int2wdrecord_get_ptr_unsafe(&FW.wd_records, wd, &r, create)) {
+		if(create) {
+			*r = (WDRecord) { 0 };
+		}
+	}
+
+	return r;
+}
+
+static void wdrecord_delete(int wd) {
+	ht_int2wdrecord_unset(&FW.wd_records, wd);
+}
+
+static int wdrecord_incref(WDRecord *r) {
+	return r->refs++;
+}
+
+static int wdrecord_decref(WDRecord *r) {
+	int32_t rc = --r->refs;
+	assert(rc >= 0);
+	return rc;
+}
+
+static DirWatch *dirwatch_get(const char *path, bool create) {
+	DirWatch *dw = ht_get(&FW.dirpath_to_dirwatch, path, NULL);
+
+	if(dw || !create) {
+		if(dw) {
+			assert(dw->path != NULL);
+			assert(!strcmp(dw->path, path));
+		}
+
+		return dw;
+	}
+
+	int wd = inotify_add_watch(FW.inotify, path, WATCH_FLAGS);
+
+	if(UNLIKELY(wd == INVALID_WD)) {
+		log_error("%s: %s", path, strerror(errno));
+		return NULL;
+	}
+
+	dw = calloc(1, sizeof(*dw));
+	dw->path = strdup(path);
+	dw->wd = wd;
+
+	WDRecord *wdrec = NOT_NULL(wdrecord_get(wd, true));
+	list_push(&wdrec->dirwatch_list, dw);
+	wdrecord_incref(wdrec);
+
+	ht_set(&FW.dirpath_to_dirwatch, path, dw);
+
+	return dw;
+}
+
+static void dirwatch_delete(DirWatch *dw) {
+	assert(dw->filewatch_list == NULL);
+
+	WDRecord *wdrec = NOT_NULL(wdrecord_get(dw->wd, false));
+	list_unlink(&wdrec->dirwatch_list, dw);
+	ht_unset(&FW.dirpath_to_dirwatch, dw->path);
+	free(dw->path);
+
+	if(wdrecord_decref(wdrec) == 0) {
+		inotify_rm_watch(FW.inotify, dw->wd);
+		wdrecord_delete(dw->wd);
+	}
+
+	free(dw);
+}
+
+static void dirwatch_invalidate(DirWatch *dw) {
+	log_warn("%s: Unimplemented (FIXME)", dw->path);
+}
 
 static bool filewatch_frame_event(SDL_Event *e, void *a);
 
+attr_unused
+static void dump_events(StringBuffer *sbuf, uint events) {
+	#define DELIM() do { \
+		if(sbuf->pos != sbuf->start) { \
+			strbuf_cat(sbuf, " | "); \
+		} \
+	} while(0)
+
+	#define HANDLE(evt) do { \
+		if(events & evt) { \
+			DELIM(); \
+			strbuf_cat(sbuf, #evt); \
+			events &= ~evt; \
+		} \
+	} while(0)
+
+	HANDLE(IN_ACCESS);
+	HANDLE(IN_MODIFY);
+	HANDLE(IN_ATTRIB);
+	HANDLE(IN_CLOSE_WRITE);
+	HANDLE(IN_CLOSE_NOWRITE);
+	HANDLE(IN_OPEN);
+	HANDLE(IN_MOVED_FROM);
+	HANDLE(IN_MOVED_TO);
+	HANDLE(IN_CREATE);
+	HANDLE(IN_DELETE);
+	HANDLE(IN_DELETE_SELF);
+	HANDLE(IN_MOVE_SELF);
+
+	HANDLE(IN_UNMOUNT);
+	HANDLE(IN_Q_OVERFLOW);
+	HANDLE(IN_IGNORED);
+
+	HANDLE(IN_ONLYDIR);
+	HANDLE(IN_DONT_FOLLOW);
+	HANDLE(IN_EXCL_UNLINK);
+	HANDLE(IN_MASK_CREATE);
+	HANDLE(IN_MASK_ADD);
+	HANDLE(IN_ISDIR);
+	HANDLE(IN_ONESHOT);
+
+	if(events) {
+		DELIM();
+		strbuf_printf(sbuf, "0x%08x", events);
+	}
+
+	#undef DELIM
+	#undef HANDLE
+}
+
 void filewatch_init(void) {
 	assert(_fw_globals == NULL);
+
+	// NOTE: This is for libinotify-kqueue (macOS/*BSD), since it will possibly have to open a file
+	// descriptor for every file inside a monitored directory. Linux is unaffected by this.
+	struct rlimit lim;
+	getrlimit(RLIMIT_NOFILE, &lim);
+	lim.rlim_cur = lim.rlim_max;
+	setrlimit(RLIMIT_NOFILE, &lim);
 
 	int inotify = inotify_init1(IN_NONBLOCK | IN_CLOEXEC);
 
@@ -73,7 +253,9 @@ void filewatch_init(void) {
 
 	_fw_globals = calloc(1, sizeof(*_fw_globals));
 	FW.inotify = inotify;
-	ht_create(&FW.wd_to_watch);
+	ht_filewatchset_create(&FW.updated_watches);
+	ht_int2wdrecord_create(&FW.wd_records);
+	ht_create(&FW.dirpath_to_dirwatch);
 
 	FW.modify_mtx = SDL_CreateMutex();
 
@@ -93,13 +275,45 @@ void filewatch_shutdown(void) {
 		events_unregister_handler(filewatch_frame_event);
 
 		close(FW.inotify);
-		ht_destroy(&FW.wd_to_watch);
-		dynarray_free_data(&FW.deactivate_list);
+		ht_filewatchset_destroy(&FW.updated_watches);
+		ht_int2wdrecord_destroy(&FW.wd_records);
+		ht_destroy(&FW.dirpath_to_dirwatch);
 		SDL_DestroyMutex(FW.modify_mtx);
 
 		free(_fw_globals);
 		_fw_globals = NULL;
 	}
+}
+
+static bool split_path(char *pathbuf, const char **dirpath, const char **filename) {
+	char *sep;
+	size_t plen = strlen(pathbuf);
+
+	// Strip trailing slash
+	// TODO: maybe guarantee this in vfs_syspath_normalize?
+	while(pathbuf[plen - 1] == '/') {
+		pathbuf[plen - 1] = 0;
+
+		if(--plen == 0) {
+			return false;
+		}
+	}
+
+	sep = memrchr(pathbuf, '/', plen);
+	if(UNLIKELY(sep == NULL)) {
+		return false;
+	}
+
+	*filename = sep + 1;
+
+	if(UNLIKELY(sep == pathbuf)) {  // file in root directory?
+		*dirpath = "/";
+	} else {
+		*sep = 0;
+		*dirpath = pathbuf;
+	}
+
+	return true;
 }
 
 FileWatch *filewatch_watch(const char *syspath) {
@@ -108,74 +322,122 @@ FileWatch *filewatch_watch(const char *syspath) {
 		return NULL;
 	}
 
-	SDL_LockMutex(FW.modify_mtx);
-	int wd = inotify_add_watch(FW.inotify, syspath, WATCHED_EVENTS);
-
-	if(UNLIKELY(wd == INVALID_WD)) {
-		SDL_UnlockMutex(FW.modify_mtx);
-		log_error("Failed to watch '%s': %s", syspath, strerror(errno));
+	if(*syspath != '/') {
+		log_error("%s: relative paths are not supported", syspath);
 		return NULL;
 	}
 
-	FileWatch *w;
+	// NOTE: we want to normalize the path, but not resolve symlinks,
+	// so realpath(2) is not appropriate.
+	char pathbuf[strlen(syspath) + 1];
+	vfs_syspath_normalize(pathbuf, sizeof(pathbuf), syspath);
 
-	if(ht_lookup(&FW.wd_to_watch, wd, (void**)&w)) {
-		assert(w->wd == wd);
-	} else {
-		w = calloc(1, sizeof(*w));
-		w->wd = wd;
-		ht_set(&FW.wd_to_watch, wd, w);
+	const char *dirpath, *filename;
+	if(UNLIKELY(!split_path(pathbuf, &dirpath, &filename))) {
+		log_error("%s: can't split path", syspath);
+		return NULL;
 	}
 
-	SDL_AtomicIncRef(&w->refs);
-	SDL_UnlockMutex(FW.modify_mtx);
-
-	return NOT_NULL(w);
-}
-
-static void filewatch_deactivate(FileWatch *watch) {
 	SDL_LockMutex(FW.modify_mtx);
 
-	if(watch->wd != INVALID_WD) {
-		assert(ht_get(&FW.wd_to_watch, watch->wd, NULL) == watch);
+	DirWatch *dw = dirwatch_get(dirpath, true);
+	if(UNLIKELY(dw == NULL)) {
+		SDL_UnlockMutex(FW.modify_mtx);
+		log_error("%s: failed to watch parent directory", syspath);
+		return NULL;
+	}
 
-		if(UNLIKELY(inotify_rm_watch(FW.inotify, watch->wd) == -1)) {
-			log_warn("Failed to remove inotify watch: %s", strerror(errno));
-		}
+	FileWatch *fw = calloc(1, sizeof(*fw));
+	fw->dw = dw;
+	fw->filename = strdup(filename);
+	list_push(&dw->filewatch_list, fw);
 
-		ht_unset(&FW.wd_to_watch, watch->wd);
-		watch->wd = INVALID_WD;
+	SDL_UnlockMutex(FW.modify_mtx);
+
+	return fw;
+}
+
+void filewatch_unwatch(FileWatch *fw) {
+	SDL_LockMutex(FW.modify_mtx);
+
+	DirWatch *dw = NOT_NULL(fw->dw);
+	list_unlink(&dw->filewatch_list, fw);
+
+	free(fw->filename);
+	free(fw);
+
+	if(dw->filewatch_list == NULL) {
+		dirwatch_delete(dw);
 	}
 
 	SDL_UnlockMutex(FW.modify_mtx);
-}
-
-void filewatch_unwatch(FileWatch *watch) {
-	if(SDL_AtomicDecRef(&watch->refs)) {
-		filewatch_deactivate(watch);
-		free(watch);
-	}
 }
 
 static void filewatch_process_events(ssize_t bufsize, char buf[bufsize]) {
 	struct inotify_event *e;
 
+	IF_FW_DEBUG(
+		StringBuffer sbuf = {};
+	)
+
 	for(ssize_t i = 0; i < bufsize;) {
 		e = CASTPTR_ASSUME_ALIGNED(buf + i, struct inotify_event);
-		FileWatch *w = ht_get(&FW.wd_to_watch, e->wd, NULL);
+		WDRecord *rec = wdrecord_get(e->wd, false);
 
-		if(w == NULL) {
+		IF_FW_DEBUG(
+			strbuf_clear(&sbuf);
+			dump_events(&sbuf, e->mask);
+			FW_DEBUG("wd %i :: %s :: %s", e->wd, e->name, sbuf.start);
+		)
+
+		if(!rec) {
 			goto skip;
 		}
 
-		if(e->mask & DELETION_EVENTS) {
-			w->deleted = true;
-		} else {
-			w->updated = true;
+		for(DirWatch *dw = rec->dirwatch_list; dw; dw = dw->next) {
+			if(dw->wd != e->wd) {
+				continue;
+			}
+
+			FW_DEBUG("Match dir %s", dw->path);
+
+			if(e->mask & IN_ISDIR) {
+				if(e->mask & (IN_MOVE_SELF | IN_DELETE_SELF | IN_IGNORED)) {
+					dirwatch_invalidate(dw);
+				}
+
+				continue;
+			}
+
+			for(FileWatch *fw = dw->filewatch_list; fw; fw = fw->next) {
+				if(strcmp(fw->filename, e->name)) {
+					FW_DEBUG("* %p %s != %s", fw, fw->filename, e->name);
+					continue;
+				}
+
+				FW_DEBUG("Match file %s/%s", dw->path, fw->filename);
+
+				if(e->mask & (IN_DELETE | IN_MOVED_FROM)) {
+					fw->deleted = true;
+					ht_filewatchset_set(&FW.updated_watches, fw, HT_EMPTY);
+				} else if(e->mask & (IN_CREATE | IN_MOVED_TO)) {
+					fw->deleted = false;
+					fw->updated = true;
+					ht_filewatchset_set(&FW.updated_watches, fw, HT_EMPTY);
+				} else if(e->mask & (IN_CLOSE_WRITE | IN_MODIFY)) {
+					fw->updated = true;
+					ht_filewatchset_set(&FW.updated_watches, fw, HT_EMPTY);
+				}
+			}
 		}
+
 	skip:
 		i += sizeof(*e) + e->len;
 	}
+
+	IF_FW_DEBUG(
+		strbuf_free(&sbuf);
+	)
 }
 
 static void filewatch_process(void) {
@@ -193,35 +455,33 @@ static void filewatch_process(void) {
 			break;
 		}
 
+		FW_DEBUG("READ %ji", r);
 		filewatch_process_events(r, buf);
 	}
 
-	ht_lock(&FW.wd_to_watch);
-	ht_int2ptr_ts_iter_t iter;
-	ht_iter_begin(&FW.wd_to_watch, &iter);
-
-	for(;iter.has_data; ht_iter_next(&iter)) {
-		FileWatch *w = NOT_NULL(iter.value);
-
-		if(w->deleted) {
-			events_emit(TE_FILEWATCH, FILEWATCH_FILE_DELETED, w, NULL);
-			w->deleted = w->updated = false;
-			// defer filewatch_deactivate(w) because it modifies this hashtable
-			*dynarray_append(&FW.deactivate_list) = w;
-		} else if(w->updated) {
-			events_emit(TE_FILEWATCH, FILEWATCH_FILE_UPDATED, w, NULL);
-			w->updated = false;
-		}
+	if(FW.updated_watches.num_elements_occupied == 0) {
+		SDL_UnlockMutex(FW.modify_mtx);
+		return;
 	}
 
-	ht_iter_end(&iter);
-	ht_unlock(&FW.wd_to_watch);
+	ht_filewatchset_iter_t iter;
+	ht_filewatchset_iter_begin(&FW.updated_watches, &iter);
 
-	dynarray_foreach_elem(&FW.deactivate_list, FileWatch **w, {
-		filewatch_deactivate(*w);
-	});
+	for(;iter.has_data; ht_filewatchset_iter_next(&iter)) {
+		FileWatch *fw = NOT_NULL(iter.key);
 
-	FW.deactivate_list.num_elements = 0;
+		if(fw->deleted) {
+			events_emit(TE_FILEWATCH, FILEWATCH_FILE_DELETED, fw, NULL);
+		} else if(fw->updated) {
+			events_emit(TE_FILEWATCH, FILEWATCH_FILE_UPDATED, fw, NULL);
+		}
+
+		fw->deleted = fw->updated = false;
+	}
+
+	ht_filewatchset_iter_end(&iter);
+	ht_filewatchset_unset_all(&FW.updated_watches);
+
 	SDL_UnlockMutex(FW.modify_mtx);
 }
 

--- a/src/filewatch/filewatch_inotify.c
+++ b/src/filewatch/filewatch_inotify.c
@@ -30,6 +30,11 @@
 	#define IF_FW_DEBUG(...)
 #endif
 
+#ifndef IN_MASK_CREATE
+// libinotify-kqueue doesn't have this
+#define IN_MASK_CREATE (0)
+#endif
+
 #define WATCH_FLAGS ( \
 	IN_CLOSE_WRITE      | \
 	IN_CREATE           | \

--- a/src/filewatch/filewatch_inotify.c
+++ b/src/filewatch/filewatch_inotify.c
@@ -383,6 +383,11 @@ static uint32_t filewatch_process_event(
 	struct inotify_event *e
 	IF_FW_DEBUG(, StringBuffer *sbuf)
 ) {
+	if(UNLIKELY(e->wd == INVALID_WD)) {
+		log_error("inotify queue overflow");
+		return e->len;
+	}
+
 	WDRecord *rec = wdrecord_get(e->wd, false);
 
 	IF_FW_DEBUG(

--- a/src/util/io.c
+++ b/src/util/io.c
@@ -16,6 +16,10 @@
 #include "rwops/rwops_autobuf.h"
 #include "util/crap.h"
 
+#ifdef TAISEI_BUILDCONF_HAVE_POSIX
+#include <unistd.h>
+#endif
+
 char *SDL_RWgets(SDL_RWops *rwops, char *buf, size_t bufsize) {
 	char c, *ptr = buf, *end = buf + bufsize - 1;
 	assert(end > ptr);
@@ -176,4 +180,22 @@ void *SDL_RWreadAll(SDL_RWops *rwops, size_t *out_size, size_t max_size) {
 			return NULL;
 		}
 	}
+}
+
+void SDL_RWsync(SDL_RWops *rwops) {
+	#if HAVE_STDIO_H
+	if(rwops->type == SDL_RWOPS_STDFILE) {
+		FILE *fp = rwops->hidden.stdio.fp;
+
+		if(UNLIKELY(!fp)) {
+			return;
+		}
+
+		fflush(fp);
+
+		#ifdef TAISEI_BUILDCONF_HAVE_POSIX
+		fsync(fileno(fp));
+		#endif
+	}
+	#endif
 }

--- a/src/util/io.h
+++ b/src/util/io.h
@@ -16,6 +16,7 @@ char *SDL_RWgets(SDL_RWops *rwops, char *buf, size_t bufsize) attr_nonnull_all;
 char *SDL_RWgets_realloc(SDL_RWops *rwops, char **buf, size_t *bufsize) attr_nonnull_all;
 size_t SDL_RWprintf(SDL_RWops *rwops, const char* fmt, ...) attr_printf(2, 3) attr_nonnull_all;
 void *SDL_RWreadAll(SDL_RWops *rwops, size_t *out_size, size_t max_size) attr_nonnull_all;
+void SDL_RWsync(SDL_RWops *rwops);
 
 // This is for the very few legitimate uses for printf/fprintf that shouldn't be replaced with log_*
 void tsfprintf(FILE *out, const char *restrict fmt, ...) attr_printf(2, 3);

--- a/src/util/stringops.c
+++ b/src/util/stringops.c
@@ -208,6 +208,7 @@ char* ucs4_to_utf8_alloc(const uint32_t *ucs4) {
 	return utf8;
 }
 
+#ifndef TAISEI_BUILDCONF_HAVE_STRTOK_R
 /*
  * public domain strtok_r() by Charlie Gordon
  *
@@ -218,7 +219,7 @@ char* ucs4_to_utf8_alloc(const uint32_t *ucs4) {
  *     (Declaration that it's public domain):
  *      http://groups.google.com/group/comp.lang.c/msg/7c7b39328fefab9c
  */
-char* strtok_r(char *str, const char *delim, char **nextp) {
+char *strtok_r(char *str, const char *delim, char **nextp) {
 	char *ret;
 
 	if(str == NULL) {
@@ -241,6 +242,7 @@ char* strtok_r(char *str, const char *delim, char **nextp) {
 	*nextp = str;
 	return ret;
 }
+#endif
 
 size_t filename_timestamp(char *buf, size_t buf_size, SystemTime systime) {
 	assert(buf_size >= FILENAME_TIMESTAMP_MIN_BUF_SIZE);

--- a/src/util/stringops.c
+++ b/src/util/stringops.c
@@ -417,3 +417,17 @@ void expand_escape_sequences(char *str) {
 		p[-1] = 0;
 	}
 }
+
+#ifndef TAISEI_BUILDCONF_HAVE_MEMRCHR
+void *memrchr(const void *s, int c, size_t n) {
+	const char *mem = s;
+
+	for(const char *p = mem + n - 1; p >= mem; --p) {
+		if(*p == c) {
+			return (void*)p;
+		}
+	}
+
+	return NULL;
+}
+#endif

--- a/src/util/stringops.h
+++ b/src/util/stringops.h
@@ -32,8 +32,11 @@ INLINE attr_returns_allocated attr_nonnull(1) char *strdup(const char *str) {
 	return memcpy(malloc(sz), str, sz);
 }
 
+#ifndef TAISEI_BUILDCONF_HAVE_STRTOK_R
 #undef strtok_r
 #define strtok_r _ts_strtok_r
+char *strtok_r(char *str, const char *delim, char **nextp);
+#endif
 
 #undef strcasecmp
 #define strcasecmp SDL_strcasecmp
@@ -46,7 +49,6 @@ void stralloc(char **dest, const char *src);
 char* strjoin(const char *first, ...) attr_sentinel attr_returns_allocated;
 char* vstrfmt(const char *fmt, va_list args) attr_returns_allocated;
 char* strfmt(const char *fmt, ...) attr_printf(1,  2) attr_returns_allocated;
-char* strtok_r(char *str, const char *delim, char **nextp);
 char* strappend(char **dst, char *src);
 char* strftimealloc(const char *fmt, const struct tm *timeinfo) attr_returns_allocated;
 void expand_escape_sequences(char *str);

--- a/src/util/stringops.h
+++ b/src/util/stringops.h
@@ -38,6 +38,12 @@ INLINE attr_returns_allocated attr_nonnull(1) char *strdup(const char *str) {
 char *strtok_r(char *str, const char *delim, char **nextp);
 #endif
 
+#ifndef TAISEI_BUILDCONF_HAVE_MEMRCHR
+#undef memrchr
+#define memrchr _ts_memrchr
+void *memrchr(const void *s, int c, size_t n);
+#endif
+
 #undef strcasecmp
 #define strcasecmp SDL_strcasecmp
 


### PR DESCRIPTION
It's now based on directory monitoring, which is more complicated, but also much more reliable, especially when dealing with move events and hard links. It is also closer to the semantics we actually want (monitoring fs paths for changes, not inodes). It will still get confused if the directory itself gets moved (directly or indirectly), though, but handling that correctly is absurdly difficult and not important for our use-case.

Importantly, `FileWatch` no longer becomes useless after reporting a `FILEWATCH_FILE_DELETED` event: if another file is placed onto the same path later, the `FileWatch` will report `FILEWATCH_FILE_UPDATED`. Some client logic can be simplified because of that.