### PR TITLE
Fix OpenSSL 3.0 deprecation error for SHA256 functions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,6 +62,7 @@ jobs:
         libwebp-dev
         libfreetype6-dev
         libzstd-dev
+        libssl-dev
 
         pip install
         meson==${{ env.MESON_VERSION }}

--- a/doc/BUILD.rst
+++ b/doc/BUILD.rst
@@ -64,7 +64,7 @@ Optional
    flaky/non-existent OpenGL support, such as Windows)
 -  GameMode headers (Linux only; for automatic
    `GameMode <https://github.com/FeralInteractive/gamemode>`__ integration)
--  OpenSSL/LibreSSL (for a better SHA-256 implementation)
+-  OpenSSL >= 1.1.0 or LibreSSL >= 2.7.0 (for a better SHA-256 implementation)
 
 
 Built-In vs. System Dependencies

--- a/src/util/sha256_openssl.c
+++ b/src/util/sha256_openssl.c
@@ -11,38 +11,34 @@
 #include "sha256.h"
 #include "util.h"
 
-#include <openssl/sha.h>
-
-struct SHA256State {
-	SHA256_CTX context;
-};
+#include <openssl/evp.h>
 
 SHA256State *sha256_new(void) {
-	SHA256State *st = calloc(1, sizeof(*st));
-	SHA256_Init(&st->context);
-	return st;
+	EVP_MD_CTX *ctx = EVP_MD_CTX_new();
+	EVP_DigestInit(ctx, EVP_sha256());
+	return (SHA256State*)ctx;
 }
 
-void sha256_free(SHA256State *ctx) {
-	free(ctx);
+void sha256_free(SHA256State *st) {
+	EVP_MD_CTX_free((EVP_MD_CTX*)st);
 }
 
-void sha256_update(SHA256State *ctx, const uint8_t *data, size_t len) {
-    SHA256_Update(&ctx->context, data, len);
+void sha256_update(SHA256State *st, const uint8_t *data, size_t len) {
+	EVP_DigestUpdate((EVP_MD_CTX*)st, data, len);
 }
 
-void sha256_final(SHA256State *ctx, uint8_t hash[SHA256_BLOCK_SIZE], size_t hashlen) {
+void sha256_final(SHA256State *st, uint8_t hash[SHA256_BLOCK_SIZE], size_t hashlen) {
 	assert(hashlen >= SHA256_BLOCK_SIZE);
-	SHA256_Final(hash, &ctx->context);
+	EVP_DigestFinalXOF((EVP_MD_CTX*)st, hash, hashlen);
 }
 
 void sha256_digest(const uint8_t *data, size_t len, uint8_t hash[SHA256_BLOCK_SIZE], size_t hashlen) {
 	assert(hashlen >= SHA256_BLOCK_SIZE);
 
-	SHA256_CTX ctx;
-	SHA256_Init(&ctx);
-	SHA256_Update(&ctx, data, len);
-	SHA256_Final(hash, &ctx);
+	SHA256State *st = sha256_new();
+	sha256_update(st, data, len);
+	sha256_final(st, hash, hashlen);
+	sha256_free(st);
 }
 
 void sha256_hexdigest(const uint8_t *data, size_t len, char hash[SHA256_HEXDIGEST_SIZE], size_t hashlen) {


### PR DESCRIPTION
This is a small fix for compiling with OpenSSL 3.0. As of 3.0, the `SHA256_*` functions are deprecated in favour of `EVP_*` functions, which then triggers an error when `-Werror` is enabled.

Functionality is the same, and I streamlined things slightly. There's also a single-line change for eliminating an unused variable error.