### PR TITLE
memory: use custom memory allocation wrappers

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -284,6 +284,10 @@ endif
 config.set('TAISEI_BUILDCONF_HAVE_BUILTIN_POPCOUNTLL', cc.has_function('__builtin_popcountll'))
 config.set('TAISEI_BUILDCONF_HAVE_BUILTIN_POPCOUNT', cc.has_function('__builtin_popcount'))
 config.set('TAISEI_BUILDCONF_HAVE_BUILTIN_AVAILABLE', cc.has_function('__builtin_available'))
+config.set('TAISEI_BUILDCONF_HAVE_ALIGNED_ALLOC', cc.has_function('aligned_alloc'))
+config.set('TAISEI_BUILDCONF_HAVE_POSIX_MEMALIGN', cc.has_function('posix_memalign'))
+config.set('TAISEI_BUILDCONF_HAVE_ALIGNED_MALLOC_FREE',
+    cc.has_function('_aligned_malloc') and cc.has_function('_aligned_free'))
 
 if dep_zip.found()
     if dep_zip.type_name() == 'internal'

--- a/src/aniplayer.c
+++ b/src/aniplayer.c
@@ -46,7 +46,7 @@ static void aniplayer_reset(AniPlayer *plr, bool hard) {
 }
 
 AniQueueEntry *aniplayer_queue(AniPlayer *plr, const char *seqname, int loops) {
-	AniQueueEntry *s = calloc(1, sizeof(AniQueueEntry));
+	auto s = ALLOC(AniQueueEntry);
 	alist_append(&plr->queue, s);
 	plr->queuesize++;
 
@@ -82,7 +82,7 @@ void aniplayer_update(AniPlayer *plr) {
 	s->clock++;
 	// The last condition assures that animations only switch at their end points
 	if(s->clock >= s->duration && plr->queuesize > 1 && s->clock%s->sequence->length == 0) {
-		free(alist_pop(&plr->queue));
+		mem_free(alist_pop(&plr->queue));
 		plr->queuesize--;
 	}
 }

--- a/src/audio/sdl/audio_sdl.c
+++ b/src/audio/sdl/audio_sdl.c
@@ -115,11 +115,11 @@ static bool audio_sdl_init(void) {
 
 	AudioStreamSpec mspec = astream_spec(aspec.format, aspec.channels, aspec.freq);
 
-	audio.mixer = calloc(1, sizeof(*audio.mixer));
+	audio.mixer = ALLOC(typeof(*audio.mixer));
 
 	if(!mixer_init(audio.mixer, &mspec)) {
 		mixer_shutdown(audio.mixer);
-		free(audio.mixer);
+		mem_free(audio.mixer);
 		SDL_CloseAudioDevice(audio.device);
 		SDL_QuitSubSystem(SDL_INIT_AUDIO);
 		return false;
@@ -136,7 +136,7 @@ static bool audio_sdl_shutdown(void) {
 	SDL_CloseAudioDevice(audio.device);
 	SDL_QuitSubSystem(SDL_INIT_AUDIO);
 	mixer_shutdown(audio.mixer);
-	free(audio.mixer);
+	mem_free(audio.mixer);
 
 	log_info("Audio subsystem deinitialized (SDL)");
 	return true;

--- a/src/audio/stream/mixer.c
+++ b/src/audio/stream/mixer.c
@@ -338,11 +338,11 @@ MixerBGMImpl *mixerbgm_load(const char *vfspath) {
 		return NULL;
 	}
 
-	MixerBGMImpl *bgm = calloc(1, sizeof(*bgm));
+	auto bgm = ALLOC(MixerBGMImpl);
 
 	if(!astream_open(&bgm->stream, rw, vfspath)) {
 		SDL_RWclose(rw);
-		free(bgm);
+		mem_free(bgm);
 		return NULL;
 	}
 
@@ -352,7 +352,7 @@ MixerBGMImpl *mixerbgm_load(const char *vfspath) {
 
 void mixerbgm_unload(MixerBGMImpl *bgm) {
 	astream_close(&bgm->stream);
-	free(bgm);
+	mem_free(bgm);
 }
 
 void mixer_notify_bgm_unload(Mixer *mx, MixerBGMImpl *bgm) {
@@ -398,13 +398,13 @@ MixerSFXImpl *mixersfx_load(const char *vfspath, const AudioStreamSpec *spec) {
 
 	assert(pcm_size <= INT32_MAX);
 
-	MixerSFXImpl *isnd = calloc(1, sizeof(*isnd) + pcm_size);
+	auto isnd = ALLOC_FLEX(MixerSFXImpl, pcm_size);
 
 	bool ok = astream_crystalize(&stream, spec, pcm_size, &isnd->pcm);
 	astream_close(&stream);
 
 	if(!ok) {
-		free(isnd);
+		mem_free(isnd);
 		return NULL;
 	}
 
@@ -415,7 +415,7 @@ MixerSFXImpl *mixersfx_load(const char *vfspath, const AudioStreamSpec *spec) {
 }
 
 void mixersfx_unload(MixerSFXImpl *sfx) {
-	free(sfx);
+	mem_free(sfx);
 }
 
 void mixer_notify_sfx_unload(Mixer *mx, MixerSFXImpl *sfx) {

--- a/src/audio/stream/player.c
+++ b/src/audio/stream/player.c
@@ -42,7 +42,7 @@ bool splayer_init(StreamPlayer *plr, int num_channels, const AudioStreamSpec *ds
 	assert(dst_spec->frame_size == sizeof(struct stereo_frame));
 
 	plr->num_channels = num_channels,
-	plr->channels = calloc(sizeof(*plr->channels), num_channels);
+	plr->channels = ALLOC_ARRAY(num_channels, typeof(*plr->channels));
 	plr->dst_spec = *dst_spec;
 
 	for(int i = 0; i < num_channels; ++i) {
@@ -80,7 +80,7 @@ void splayer_shutdown(StreamPlayer *plr) {
 		free_channel(plr->channels + i);
 	}
 
-	free(plr->channels);
+	mem_free(plr->channels);
 }
 
 static inline void splayer_stream_ended(StreamPlayer *plr, int chan) {

--- a/src/audio/stream/stream_pcm.c
+++ b/src/audio/stream/stream_pcm.c
@@ -54,7 +54,7 @@ static ssize_t astream_pcm_tell(AudioStream *stream) {
 
 static void astream_pcm_free(AudioStream *stream) {
 	PCMStreamContext *ctx = NOT_NULL(stream->opaque);
-	free(ctx);
+	mem_free(ctx);
 }
 
 static void astream_pcm_static_close(AudioStream *stream) {
@@ -80,10 +80,10 @@ static AudioStreamProcs astream_pcm_static_procs = {
 
 bool astream_pcm_open(AudioStream *stream, const AudioStreamSpec *spec, size_t pcm_buffer_size, void *pcm_buffer, int32_t loop_start) {
 	stream->procs = &astream_pcm_procs;
-	stream->opaque = calloc(1, sizeof(PCMStreamContext));
+	stream->opaque = ALLOC(PCMStreamContext);
 
 	if(!astream_pcm_reopen(stream, spec, pcm_buffer_size, pcm_buffer, loop_start)) {
-		free(stream->opaque);
+		mem_free(stream->opaque);
 		return false;
 	}
 

--- a/src/boss.c
+++ b/src/boss.c
@@ -1346,7 +1346,7 @@ void boss_death(Boss **boss) {
 
 static void free_attack(Attack *a) {
 	COEVENT_CANCEL_ARRAY(a->events);
-	free(a->name);
+	mem_free(a->name);
 }
 
 void free_boss(Boss *boss) {
@@ -1359,7 +1359,7 @@ void free_boss(Boss *boss) {
 	ent_unregister(&boss->ent);
 	boss_set_portrait(boss, NULL, NULL, NULL);
 	aniplayer_free(&boss->ani);
-	free(boss->name);
+	mem_free(boss->name);
 	objpool_release(stage_object_pools.bosses, boss);
 }
 

--- a/src/cli.c
+++ b/src/cli.c
@@ -289,8 +289,8 @@ int cli_args(int argc, char **argv, CLIAction *a) {
 }
 
 void free_cli_action(CLIAction *a) {
-	free(a->filename);
+	mem_free(a->filename);
 	a->filename = NULL;
-	free(a->out_replay);
+	mem_free(a->out_replay);
 	a->out_replay = NULL;
 }

--- a/src/credits.c
+++ b/src/credits.c
@@ -201,13 +201,12 @@ static void credits_add(char *data, int time) {
 
 	for(c = data; *c; ++c)
 		if(*c == '\n') e->lines++;
-	e->data = malloc(e->lines * sizeof(char*));
+	e->data = ALLOC_ARRAY(e->lines, typeof(*e->data));
 
 	for(c = data; *c; ++c) {
 		if(*c == '\n') {
 			buf[i] = 0;
-			e->data[l] = malloc(strlen(buf) + 1);
-			strcpy(e->data[l], buf);
+			e->data[l] = strdup(buf);
 			i = 0;
 			++l;
 		} else {
@@ -216,8 +215,7 @@ static void credits_add(char *data, int time) {
 	}
 
 	buf[i] = 0;
-	e->data[l] = malloc(strlen(buf) + 1);
-	strcpy(e->data[l], buf);
+	e->data[l] = strdup(buf);
 	credits.end += time;
 }
 
@@ -546,9 +544,9 @@ static void credits_free(void) {
 
 	dynarray_foreach_elem(&credits.entries, CreditsEntry *e, {
 		for(int i = 0; i < e->lines; ++i) {
-			free(e->data[i]);
+			mem_free(e->data[i]);
 		}
-		free(e->data);
+		mem_free(e->data);
 	});
 
 	dynarray_free_data(&credits.entries);

--- a/src/dynarray.c
+++ b/src/dynarray.c
@@ -21,7 +21,7 @@
 #endif
 
 void _dynarray_free_data(dynarray_size_t sizeof_element, DynamicArray *darr) {
-	free(darr->data);
+	mem_free(darr->data);
 	if(darr->capacity) {
 		DYNARRAY_DEBUG(darr, "%u/%u", darr->num_elements, darr->capacity);
 	}
@@ -33,7 +33,7 @@ INLINE void _dynarray_resize(dynarray_size_t sizeof_element, DynamicArray *darr,
 	assert(capacity > 0);
 	DYNARRAY_DEBUG(darr, "capacity change: %u --> %u", darr->capacity, capacity);
 	darr->capacity = capacity;
-	darr->data = realloc(darr->data, sizeof_element * capacity);
+	darr->data = mem_realloc(darr->data, sizeof_element * capacity);
 }
 
 void _dynarray_ensure_capacity(dynarray_size_t sizeof_element, DynamicArray *darr, dynarray_size_t capacity) {

--- a/src/entity.c
+++ b/src/entity.c
@@ -34,7 +34,7 @@ static struct {
 } entities;
 
 static void add_hook(EntityDrawHookList *list, EntityDrawHookCallback cb, void *arg) {
-	EntityDrawHook *hook = calloc(1, sizeof(*hook));
+	auto hook = ALLOC(EntityDrawHook);
 	hook->callback = cb;
 	hook->arg = arg;
 
@@ -45,7 +45,7 @@ static void remove_hook(EntityDrawHookList *list, EntityDrawHookCallback cb) {
 	for(EntityDrawHook *hook = list->first; hook; hook = hook->next) {
 		if(hook->callback == cb) {
 			alist_unlink(list, hook);
-			free(hook);
+			mem_free(hook);
 			return;
 		}
 	}

--- a/src/gamepad.c
+++ b/src/gamepad.c
@@ -79,8 +79,8 @@ cleanup:
 		log_info("Loaded %i mappings from '%s'", num_loaded, repr);
 	}
 
-	free(repr);
-	free(errstr);
+	mem_free(repr);
+	mem_free(errstr);
 	return num_loaded;
 }
 
@@ -292,8 +292,8 @@ void gamepad_init(void) {
 
 	gamepad.initialized = true;
 	gamepad.update_needed = true;
-	gamepad.axes = calloc(GAMEPAD_AXIS_MAX, sizeof(GamepadAxisState));
-	gamepad.buttons = calloc(GAMEPAD_BUTTON_MAX + GAMEPAD_EMULATED_BUTTON_MAX, sizeof(GamepadButtonState));
+	gamepad.axes = ALLOC_ARRAY(GAMEPAD_AXIS_MAX, typeof(*gamepad.axes));
+	gamepad.buttons = ALLOC_ARRAY(GAMEPAD_BUTTON_MAX + GAMEPAD_EMULATED_BUTTON_MAX, typeof(*gamepad.buttons));
 	gamepad.active_dev_num = GAMEPAD_DEVNUM_INVALID;
 	gamepad_load_all_mappings();
 
@@ -312,8 +312,8 @@ void gamepad_shutdown(void) {
 
 	log_info("Disabled the gamepad subsystem");
 
-	free(gamepad.axes);
-	free(gamepad.buttons);
+	mem_free(gamepad.axes);
+	mem_free(gamepad.buttons);
 
 	dynarray_foreach_elem(&gamepad.devices, auto dev, {
 		if(dev->controller) {

--- a/src/hashtable.inc.h
+++ b/src/hashtable.inc.h
@@ -386,14 +386,14 @@ HT_DECLARE_FUNC(void, destroy, (HT_BASETYPE *ht))
  * ht_XXX_t* ht_XXX_new(void);
  *
  * Convenience function; allocates and initializes a new hashtable structure.
- * You must free() it manually when you're done with it (but don't forget to
+ * You must mem_free() it manually when you're done with it (but don't forget to
  * ht_*_destroy() it as well).
  *
  * Returns the allocated hashtable structure.
  */
 INLINE attr_returns_allocated
 HT_DECLARE_FUNC(HT_BASETYPE*, new, (void))  {
-	HT_BASETYPE *ht = calloc(1, sizeof(HT_BASETYPE));
+	auto ht = ALLOC(HT_BASETYPE);
 	HT_FUNC(create)(ht);
 	return ht;
 }
@@ -804,7 +804,7 @@ HT_DECLARE_FUNC(void, write_unlock, (HT_BASETYPE *ht)) {
 HT_DECLARE_FUNC(void, create, (HT_BASETYPE *ht)) {
 	ht_size_t size = HT_MIN_SIZE;
 
-	ht->elements = calloc(size, sizeof(*ht->elements));
+	ht->elements = ALLOC_ARRAY(size, typeof(*ht->elements));
 	ht->num_elements_allocated = size;
 	ht->num_elements_occupied = 0;
 	ht->hash_mask = size - 1;
@@ -823,7 +823,7 @@ HT_DECLARE_FUNC(void, destroy, (HT_BASETYPE *ht)) {
 	SDL_DestroyCond(ht->sync.cond);
 	SDL_DestroyMutex(ht->sync.mutex);
 	#endif
-	free(ht->elements);
+	mem_free(ht->elements);
 }
 
 HT_DECLARE_PRIV_FUNC(HT_TYPE(element)*, find_element, (HT_BASETYPE *ht, HT_TYPE(const_key) key, hash_t hash)) {
@@ -1150,7 +1150,7 @@ HT_DECLARE_PRIV_FUNC(void, resize, (HT_BASETYPE *ht, size_t new_size)) {
 	ht_size_t old_size = ht->num_elements_allocated;
 	HT_PRIV_FUNC(check_elem_count)(ht);
 
-	HT_TYPE(element) *new_elements = calloc(new_size, sizeof(*ht->elements));
+	auto new_elements = ALLOC_ARRAY(new_size, typeof(*ht->elements));
 	ht->max_psl = 0;
 
 	for(ht_size_t i = 0; i < old_size; ++i) {
@@ -1164,7 +1164,7 @@ HT_DECLARE_PRIV_FUNC(void, resize, (HT_BASETYPE *ht, size_t new_size)) {
 	ht->num_elements_allocated = new_size;
 	ht->hash_mask = new_size - 1;
 
-	free(old_elements);
+	mem_free(old_elements);
 
 	/*
 	log_debug(

--- a/src/hashtable_predefs.inc.h
+++ b/src/hashtable_predefs.inc.h
@@ -18,7 +18,7 @@
 #define HT_SUFFIX                      str2ptr
 #define HT_KEY_TYPE                    char*
 #define HT_VALUE_TYPE                  void*
-#define HT_FUNC_FREE_KEY(key)          free(key)
+#define HT_FUNC_FREE_KEY(key)          mem_free(key)
 #define HT_FUNC_KEYS_EQUAL(key1, key2) (!strcmp(key1, key2))
 #define HT_FUNC_HASH_KEY(key)          htutil_hashfunc_string(key)
 #define HT_FUNC_COPY_KEY(dst, src)     (*(dst) = strdup(src))
@@ -38,7 +38,7 @@
 #define HT_SUFFIX                      str2ptr_ts
 #define HT_KEY_TYPE                    char*
 #define HT_VALUE_TYPE                  void*
-#define HT_FUNC_FREE_KEY(key)          free(key)
+#define HT_FUNC_FREE_KEY(key)          mem_free(key)
 #define HT_FUNC_KEYS_EQUAL(key1, key2) (!strcmp(key1, key2))
 #define HT_FUNC_HASH_KEY(key)          htutil_hashfunc_string(key)
 #define HT_FUNC_COPY_KEY(dst, src)     (*(dst) = strdup(src))
@@ -59,7 +59,7 @@
 #define HT_SUFFIX                      str2int
 #define HT_KEY_TYPE                    char*
 #define HT_VALUE_TYPE                  int64_t
-#define HT_FUNC_FREE_KEY(key)          free(key)
+#define HT_FUNC_FREE_KEY(key)          mem_free(key)
 #define HT_FUNC_KEYS_EQUAL(key1, key2) (!strcmp(key1, key2))
 #define HT_FUNC_HASH_KEY(key)          htutil_hashfunc_string(key)
 #define HT_FUNC_COPY_KEY(dst, src)     (*(dst) = strdup(src))
@@ -78,7 +78,7 @@
 #define HT_SUFFIX                      str2int_ts
 #define HT_KEY_TYPE                    char*
 #define HT_VALUE_TYPE                  int64_t
-#define HT_FUNC_FREE_KEY(key)          free(key)
+#define HT_FUNC_FREE_KEY(key)          mem_free(key)
 #define HT_FUNC_KEYS_EQUAL(key1, key2) (!strcmp(key1, key2))
 #define HT_FUNC_HASH_KEY(key)          htutil_hashfunc_string(key)
 #define HT_FUNC_COPY_KEY(dst, src)     (*(dst) = strdup(src))

--- a/src/list.c
+++ b/src/list.c
@@ -368,13 +368,13 @@ void* alist_foreach(ListAnchor *list, ListAnchorForeachCallback callback, void *
 
 void* list_callback_free_element(List **dest, List *elem, void *arg) {
 	list_unlink(dest, elem);
-	free(elem);
+	mem_free(elem);
 	return NULL;
 }
 
 void* alist_callback_free_element(ListAnchor *list, List *elem, void *arg) {
 	alist_unlink(list, elem);
-	free(elem);
+	mem_free(elem);
 	return NULL;
 }
 
@@ -389,7 +389,5 @@ void alist_free_all(ListAnchor *list) {
 }
 
 ListContainer* list_wrap_container(void *data) {
-	ListContainer *c = calloc(1, sizeof(ListContainer));
-	c->data = data;
-	return c;
+	return ALLOC(ListContainer, { .data = data });
 }

--- a/src/memory.c
+++ b/src/memory.c
@@ -1,0 +1,150 @@
+/*
+ * This software is licensed under the terms of the MIT License.
+ * See COPYING for further information.
+ * ---
+ * Copyright (c) 2011-2019, Lukas Weber <laochailan@web.de>.
+ * Copyright (c) 2012-2019, Andrei Alexeyev <akari@taisei-project.org>.
+*/
+
+#include "taisei.h"
+
+#include "memory.h"
+
+#include <stdlib.h>
+
+#define MEMALIGN_METHOD_C11   0
+#define MEMALIGN_METHOD_POSIX 1
+#define MEMALIGN_METHOD_WIN32 2
+
+#if defined(TAISEI_BUILDCONF_HAVE_POSIX_MEMALIGN)
+	#define MEMALIGN_METHOD MEMALIGN_METHOD_POSIX
+#elif defined(TAISEI_BUILDCONF_HAVE_ALIGNED_ALLOC)
+	#define MEMALIGN_METHOD MEMALIGN_METHOD_C11
+#elif defined(TAISEI_BUILDCONF_HAVE_ALIGNED_MALLOC_FREE)
+	#define MEMALIGN_METHOD MEMALIGN_METHOD_WIN32
+#else
+	#error No usable aligned malloc implementation
+#endif
+
+void mem_free(void *ptr) {
+#if MEMALIGN_METHOD == MEMALIGN_METHOD_WIN32
+	_aligned_free(ptr);
+#else
+	libc_free(ptr);
+#endif
+}
+
+static size_t mem_calc_array_size(size_t num_members, size_t size) {
+	size_t array_size;
+
+	if(__builtin_mul_overflow(num_members, size, &array_size)) {
+		assert(0 && "size_t overflow");
+		abort();
+	}
+
+	return array_size;
+}
+
+void *mem_alloc(size_t size) {
+#if MEMALIGN_METHOD == MEMALIGN_METHOD_WIN32
+	void *p = NOT_NULL(_aligned_malloc(size, alignof(max_align_t)));
+	memset(p, 0, size);
+	return p;
+#else
+	return NOT_NULL(libc_calloc(1, size));
+#endif
+}
+
+void *mem_alloc_array(size_t num_members, size_t size) {
+#if MEMALIGN_METHOD == MEMALIGN_METHOD_WIN32
+	size_t array_size = mem_calc_array_size(num_members, size);
+	void *p = NOT_NULL(_aligned_malloc(array_size, alignof(max_align_t)));
+	memset(p, 0, array_size);
+	return p;
+#else
+	return NOT_NULL(libc_calloc(num_members, size));
+#endif
+}
+
+void *mem_realloc(void *ptr, size_t size) {
+	if(ptr == NULL) {
+		return mem_alloc(size);
+	}
+
+	if(size == 0) {
+		libc_free(ptr);
+		return ptr;
+	}
+
+#if MEMALIGN_METHOD == MEMALIGN_METHOD_WIN32
+	return NOT_NULL(_aligned_realloc(ptr, size, alignof(max_align_t)));
+#else
+	return NOT_NULL(libc_realloc(ptr, size));
+#endif
+}
+
+void *mem_alloc_aligned(size_t size, size_t alignment) {
+	assert((alignment & (alignment - 1)) == 0);
+	assert((alignment / sizeof(void*)) * sizeof(void*) == alignment);
+
+#if MEMALIGN_METHOD == MEMALIGN_METHOD_C11
+	size_t nsize = ((size - 1) / alignment + 1) * alignment;
+	assert(nsize >= size);
+	void *p = NOT_NULL(aligned_alloc(alignment, nsize));
+	memset(p, 0, size);
+	return p;
+#elif MEMALIGN_METHOD == MEMALIGN_METHOD_POSIX
+	void *p;
+	attr_unused int r = posix_memalign(&p, alignment, size);
+	assert(r == 0);
+	assume(p != NULL);
+	memset(p, 0, size);
+	return p;
+#elif MEMALIGN_METHOD == MEMALIGN_METHOD_WIN32
+	void *p = NOT_NULL(_aligned_malloc(size, alignment));
+	memset(p, 0, size);
+	return p;
+#else
+	#error No usable aligned malloc implementation
+#endif
+}
+
+void *mem_alloc_array_aligned(size_t num_members, size_t size, size_t alignment) {
+	return mem_alloc_aligned(mem_calc_array_size(num_members, size), alignment);
+}
+
+void *mem_dup(const void *src, size_t size) {
+	return memcpy(mem_alloc(size), src, size);
+}
+
+// SDL's calling convention may differ from the default, so wrap when necessary.
+
+static void SDLCALL mem_sdlcall_free(void *ptr) {
+	mem_free(ptr);
+}
+
+static void *SDLCALL mem_sdlcall_malloc(size_t size) {
+	return mem_alloc(size);
+}
+
+static void *SDLCALL mem_sdlcall_calloc(size_t num_members, size_t size) {
+	return mem_alloc_array(num_members, size);
+}
+
+static void *SDLCALL mem_sdlcall_realloc(void *ptr, size_t size) {
+	return mem_realloc(ptr, size);
+}
+
+#define _mem_choose_compatible_func(orig, wrapper) \
+	__builtin_choose_expr( \
+		__builtin_types_compatible_p(typeof(orig), typeof(wrapper)), \
+		orig, wrapper)
+
+void mem_install_sdl_callbacks(void) {
+	SDL_SetMemoryFunctions(
+		_mem_choose_compatible_func(mem_alloc,       mem_sdlcall_malloc),
+		_mem_choose_compatible_func(mem_alloc_array, mem_sdlcall_calloc),
+		_mem_choose_compatible_func(mem_realloc,     mem_sdlcall_realloc),
+		_mem_choose_compatible_func(mem_free,        mem_sdlcall_free)
+	);
+}

--- a/src/memory.h
+++ b/src/memory.h
@@ -1,0 +1,122 @@
+/*
+ * This software is licensed under the terms of the MIT License.
+ * See COPYING for further information.
+ * ---
+ * Copyright (c) 2011-2019, Lukas Weber <laochailan@web.de>.
+ * Copyright (c) 2012-2019, Andrei Alexeyev <akari@taisei-project.org>.
+*/
+
+#pragma once
+#include "taisei.h"
+
+#include "util/macrohax.h"
+
+#include <SDL.h>
+
+/*
+ * NOTE: All allocation functions return zero-initialized memory (except realloc) and never NULL.
+ */
+
+void mem_free(void *ptr);
+
+void *mem_alloc(size_t size)
+	attr_malloc
+	attr_dealloc(mem_free, 1)
+	attr_alloc_size(1)
+	attr_returns_allocated;
+
+void *mem_alloc_array(size_t num_members, size_t size)
+	attr_malloc
+	attr_dealloc(mem_free, 1)
+	attr_alloc_size(1, 2)
+	attr_returns_allocated;
+
+void *mem_realloc(void *ptr, size_t size)
+	attr_dealloc(mem_free, 1)
+	attr_alloc_size(2)
+	attr_returns_allocated;
+
+void *mem_alloc_aligned(size_t size, size_t alignment)
+	attr_malloc
+	attr_dealloc(mem_free, 1)
+	attr_alloc_size(1)
+	attr_alloc_align(2)
+	attr_returns_allocated;
+
+void *mem_alloc_array_aligned(size_t num_members, size_t size, size_t alignment)
+	attr_malloc
+	attr_dealloc(mem_free, 1)
+	attr_alloc_size(1, 2)
+	attr_alloc_align(3)
+	attr_returns_allocated;
+
+void *mem_dup(const void *src, size_t size)
+	attr_malloc
+	attr_dealloc(mem_free, 1)
+	attr_alloc_size(2)
+	attr_returns_allocated;
+
+#define memdup mem_dup
+
+/*
+ * This macro transparently handles allocation of both normal and over-aligned types.
+ * The allocation must be free'd with mem_free().
+ *
+ * You should use it like this:
+ *
+ * 		auto x = ALLOC(MyType);  // x is a pointer to MyType
+ *
+ * This style is also allowed:
+ *
+ * 		MyType *x = ALLOC(typeof(*x));
+ *
+ * This style can also be used, but is not recommended:
+ *
+ * 		MyType *x = ALLOC(MyType);
+ *
+ * You can also provide an optional initializer as the second argument, like so:
+ *
+ * 		auto x = ALLOC(MyStructType, { .foo = 42, .bar = 69 });
+ */
+#define ALLOC(_type, ...)\
+	MACROHAX_OVERLOAD_HASARGS(ALLOC_, __VA_ARGS__)(_type, ##__VA_ARGS__)
+
+#define ALLOC_0(_type) \
+	(_type *)__builtin_choose_expr( \
+		alignof(_type) > alignof(max_align_t), \
+		mem_alloc_aligned(sizeof(_type), alignof(_type)), \
+		mem_alloc(sizeof(_type)))
+
+#define ALLOC_1(_type, ...) ({ \
+		auto _alloc_ptr = ALLOC_0(_type); \
+		*_alloc_ptr = (_type) __VA_ARGS__; \
+		_alloc_ptr; \
+	})
+
+/*
+ * Like ALLOC(), but for array allocations:
+ *
+ * 		auto x = ALLOC_ARRAY(10, int);  // x is an int*
+ *
+ * Unlike ALLOC(), this macro does not accept an optional initializer.
+ */
+#define ALLOC_ARRAY(_nmemb, _type) \
+	(_type *)__builtin_choose_expr( \
+		alignof(_type) > alignof(max_align_t), \
+		mem_alloc_array_aligned(_nmemb, sizeof(_type), alignof(_type)), \
+		mem_alloc_array(_nmemb, sizeof(_type)))
+
+/*
+ * Like ALLOC(), but for structs with flexible array members:
+ *
+ * 		auto x = ALLOC(MyFlexStruct, 42);  // allocates sizeof(MyFlexStruct)+42 bytes
+ *
+ * Unlike ALLOC(), this macro does not accept an optional initializer.
+ */
+#define ALLOC_FLEX(_type, _extra_size) \
+	(_type *)__builtin_choose_expr( \
+		alignof(_type) > alignof(max_align_t), \
+		mem_alloc_aligned(sizeof(_type) + (_extra_size), alignof(_type)), \
+		mem_alloc(sizeof(_type) + (_extra_size)))
+
+void mem_install_sdl_callbacks(void);

--- a/src/menu/charprofile.c
+++ b/src/menu/charprofile.c
@@ -320,7 +320,7 @@ static void add_character(MenuData *m, int i) {
 }
 
 static void charprofile_free(MenuData *m) {
-	free(m->context);
+	mem_free(m->context);
 }
 
 // TODO: add a better drawing animation for character selection
@@ -390,9 +390,7 @@ MenuData *create_charprofile_menu(void) {
 	m->end = charprofile_free;
 	m->transition = TransFadeBlack;
 	m->flags = MF_Abortable;
-
-	CharProfileContext *ctx = calloc(1, sizeof(*ctx));
-	m->context = ctx;
+	m->context = ALLOC(CharProfileContext);
 
 	for(int i = 0; i < NUM_PROFILES; i++) {
 		add_character(m, i);

--- a/src/menu/charselect.c
+++ b/src/menu/charselect.c
@@ -107,7 +107,7 @@ static void update_char_menu(MenuData *menu) {
 }
 
 static void end_char_menu(MenuData *m) {
-	free(m->context);
+	mem_free(m->context);
 }
 
 static void transition_to_game(double fade) {
@@ -124,9 +124,10 @@ MenuData* create_char_menu(void) {
 	m->transition = TransFadeBlack;
 	m->flags = MF_Abortable;
 
-	CharMenuContext *ctx = calloc(1, sizeof(*ctx));
-	ctx->subshot = progress.game_settings.shotmode;
-	ctx->prev_selected_char = -1;
+	auto ctx = ALLOC(CharMenuContext, {
+		.subshot = progress.game_settings.shotmode,
+		.prev_selected_char = -1,
+	});
 	m->context = ctx;
 
 	for(uintptr_t i = 0; i < NUM_CHARACTERS; ++i) {

--- a/src/menu/common.c
+++ b/src/menu/common.c
@@ -39,7 +39,7 @@ static void start_game_do_show_credits(CallChainResult ccr);
 static void start_game_do_cleanup(CallChainResult ccr);
 
 static void start_game_internal(MenuData *menu, StageInfo *info, bool difficulty_menu) {
-	StartGameContext *ctx = calloc(1, sizeof(*ctx));
+	auto ctx = ALLOC(StartGameContext);
 
 	if(info == NULL) {
 		global.is_practice_mode = false;
@@ -184,7 +184,7 @@ static void start_game_do_cleanup(CallChainResult ccr) {
 	StartGameContext *ctx = ccr.ctx;
 	replay_reset(&ctx->replay);
 	kill_aux_menus(ctx);
-	free(ctx);
+	mem_free(ctx);
 	free_resources(false);
 	global.gameover = GAMEOVER_NONE;
 	replay_state_deinit(&global.replay.output);

--- a/src/menu/menu.c
+++ b/src/menu/menu.c
@@ -33,22 +33,22 @@ void free_menu(MenuData *menu) {
 	}
 
 	dynarray_foreach_elem(&menu->entries, MenuEntry *e, {
-		free(e->name);
+		mem_free(e->name);
 	});
 
 	dynarray_free_data(&menu->entries);
-	free(menu);
+	mem_free(menu);
 }
 
 MenuData* alloc_menu(void) {
-	MenuData *menu = calloc(1, sizeof(*menu));
-	menu->selected = -1;
-	menu->transition = TransFadeBlack;
-	menu->transition_in_time = FADE_TIME;
-	menu->transition_out_time = FADE_TIME;
-	menu->fade = 1.0;
-	menu->input = menu_input;
-	return menu;
+	return ALLOC(MenuData, {
+		.selected = -1,
+		.transition = TransFadeBlack,
+		.transition_in_time = FADE_TIME,
+		.transition_out_time = FADE_TIME,
+		.fade = 1.0,
+		.input = menu_input,
+	});
 }
 
 void kill_menu(MenuData *menu) {

--- a/src/menu/musicroom.c
+++ b/src/menu/musicroom.c
@@ -228,9 +228,10 @@ static void add_bgm(MenuData *m, const char *bgm_name, bool preload) {
 		title = "Unknown track";
 	}
 
-	MusicEntryParam *p = calloc(1, sizeof(*p));
-	p->bgm = bgm;
-	p->text_shader = res_shader("text_default");
+	auto p = ALLOC(MusicEntryParam, {
+		.bgm = bgm,
+		.text_shader = res_shader("text_default"),
+	});
 
 	if(progress_is_bgm_unlocked(bgm_name)) {
 		p->state |= MSTATE_UNLOCKED;
@@ -242,7 +243,7 @@ static void add_bgm(MenuData *m, const char *bgm_name, bool preload) {
 
 static void musicroom_free(MenuData *m) {
 	dynarray_foreach_elem(&m->entries, MenuEntry *e, {
-		free(e->arg);
+		mem_free(e->arg);
 	});
 }
 

--- a/src/menu/savereplay.c
+++ b/src/menu/savereplay.c
@@ -43,7 +43,7 @@ static void do_save_replay(Replay *rpy) {
 		rpy->playername = NULL;
 	}
 
-	free(name);
+	mem_free(name);
 }
 
 static void save_rpy(MenuData *menu, void *a) {

--- a/src/meson.build
+++ b/src/meson.build
@@ -77,6 +77,7 @@ taisei_src = files(
     'list.c',
     'log.c',
     'main.c',
+    'memory.c',
     'move.c',
     'player.c',
     'plrmodes.c',

--- a/src/objectpool_fake.c
+++ b/src/objectpool_fake.c
@@ -16,21 +16,19 @@ struct ObjectPool {
 };
 
 ObjectPool *objpool_alloc(size_t obj_size, size_t max_objects, const char *tag) {
-	ObjectPool *pool = malloc(sizeof(ObjectPool));
-	pool->size_of_object = obj_size;
-	return pool;
+	return ALLOC(ObjectPool, { .size_of_object = obj_size });
 }
 
 void *objpool_acquire(ObjectPool *pool) {
-	return calloc(1, pool->size_of_object);
+	return mem_alloc(pool->size_of_object);
 }
 
 void objpool_release(ObjectPool *pool, void *object) {
-	free(object);
+	mem_free(object);
 }
 
 void objpool_free(ObjectPool *pool) {
-	free(pool);
+	mem_free(pool);
 }
 
 void objpool_get_stats(ObjectPool *pool, ObjectPoolStats *stats) {

--- a/src/pixmap/conversion.c
+++ b/src/pixmap/conversion.c
@@ -286,7 +286,7 @@ void pixmap_convert_inplace_realloc(Pixmap *src, PixmapFormat format) {
 	pixmap_copy_meta(src, &tmp);
 	pixmap_convert_alloc(src, &tmp, format);
 
-	free(src->data.untyped);
+	mem_free(src->data.untyped);
 	*src = tmp;
 }
 

--- a/src/pixmap/fileformats/internal.c
+++ b/src/pixmap/fileformats/internal.c
@@ -112,7 +112,7 @@ static bool px_internal_load(SDL_RWops *stream, Pixmap *pixmap, PixmapFormat pre
 		goto fail;
 	}
 
-	pixmap->data.untyped = NOT_NULL(malloc(pixmap->data_size));
+	pixmap->data.untyped = mem_alloc(pixmap->data_size);
 	size_t read = SDL_RWread(cstream, pixmap->data.untyped, 1, pixmap->data_size);
 
 	if(read != pixmap->data_size) {
@@ -134,7 +134,7 @@ static bool px_internal_load(SDL_RWops *stream, Pixmap *pixmap, PixmapFormat pre
 
 fail:
 	if(pixmap->data.untyped) {
-		free(pixmap->data.untyped);
+		mem_free(pixmap->data.untyped);
 		pixmap->data.untyped = NULL;
 	}
 

--- a/src/pixmap/fileformats/png.c
+++ b/src/pixmap/fileformats/png.c
@@ -135,7 +135,7 @@ done:
 
 	if(error) {
 		log_error("Failed to load image: %s", error);
-		free(pixmap->data.untyped);
+		mem_free(pixmap->data.untyped);
 		pixmap->data.untyped = NULL;
 		return false;
 	}
@@ -272,7 +272,7 @@ done:
 	}
 
 	if(px.data.untyped != src_pixmap->data.untyped) {
-		free(px.data.untyped);
+		mem_free(px.data.untyped);
 	}
 
 	if(png != NULL) {

--- a/src/pixmap/fileformats/webp.c
+++ b/src/pixmap/fileformats/webp.c
@@ -117,7 +117,7 @@ static bool px_webp_load(SDL_RWops *stream, Pixmap *pixmap, PixmapFormat preferr
 
 		if(status != VP8_STATUS_OK && status != VP8_STATUS_SUSPENDED) {
 			log_error("WebPIAppend() failed: %s", webp_error_str(status));
-			free(pixmap->data.untyped);
+			mem_free(pixmap->data.untyped);
 			pixmap->data.untyped = NULL;
 			break;
 		}

--- a/src/pixmap/pixmap.c
+++ b/src/pixmap/pixmap.c
@@ -35,7 +35,7 @@ void *pixmap_alloc_buffer(PixmapFormat format, uint32_t width, uint32_t height, 
 		*out_bufsize = s;
 	}
 
-	return calloc(1, s);
+	return mem_alloc(s);
 }
 
 void *pixmap_alloc_buffer_for_copy(const Pixmap *src, uint32_t *out_bufsize) {

--- a/src/player.c
+++ b/src/player.c
@@ -1287,7 +1287,7 @@ static void player_ani_moving(Player *plr, int dir) {
 	aniplayer_hard_switch(&plr->ani,transition,1);
 	aniplayer_queue(&plr->ani,seqname,0);
 	plr->lastmovesequence = dir;
-	free(transition);
+	mem_free(transition);
 }
 
 void player_applymovement(Player *plr) {

--- a/src/renderer/common/shaderlib/cache.c
+++ b/src/renderer/common/shaderlib/cache.c
@@ -176,13 +176,13 @@ static bool shader_cache_load_entry(SDL_RWops *stream, ShaderSource *out_src) {
 
 			if(nattrs > 0) {
 				out_src->meta.glsl.num_attributes = nattrs;
-				out_src->meta.glsl.attributes = calloc(nattrs, sizeof(*out_src->meta.glsl.attributes));
+				out_src->meta.glsl.attributes = ALLOC_ARRAY(nattrs, typeof(*out_src->meta.glsl.attributes));
 
 				for(uint i = 0; i < nattrs; ++i) {
 					GLSLAttribute *attr = out_src->meta.glsl.attributes + i;
 					attr->location = SDL_ReadLE32(s);
 					uint len = SDL_ReadU8(s);
-					attr->name = calloc(1, len + 1);
+					attr->name = mem_alloc(len + 1);
 					SDL_RWread(s, attr->name, len, 1);
 				}
 			}
@@ -201,7 +201,7 @@ static bool shader_cache_load_entry(SDL_RWops *stream, ShaderSource *out_src) {
 	}
 
 	out_src->content_size = SDL_ReadLE32(s);
-	out_src->content = calloc(1, out_src->content_size);
+	out_src->content = mem_alloc(out_src->content_size);
 
 	if(SDL_RWread(s, out_src->content, out_src->content_size, 1) != 1) {
 		log_error("Read error");
@@ -270,7 +270,7 @@ bool shader_cache_set(const char *hash, const char *key, const ShaderSource *src
 
 	if(entry != NULL) {
 		shader_cache_set_raw(hash, key, entry, entry_size);
-		free(entry);
+		mem_free(entry);
 		log_debug("Stored %s/%s in cache", hash, key);
 		return true;
 	}
@@ -295,6 +295,6 @@ bool shader_cache_hash(const ShaderSource *src, const ShaderMacro *macros, size_
 
 	// shader_cache_set_raw(out_buf, "orig", entry, entry_size);
 
-	free(entry);
+	mem_free(entry);
 	return true;
 }

--- a/src/renderer/common/shaderlib/lang_glsl.c
+++ b/src/renderer/common/shaderlib/lang_glsl.c
@@ -285,19 +285,19 @@ bool glsl_load_source(const char *path, ShaderSource *out, const GLSLSourceOptio
 	pstate.src = out;
 	pstate.options = options;
 	pstate.linebuf_size = 128;
-	pstate.linebuf = calloc(1, pstate.linebuf_size);
+	pstate.linebuf = mem_alloc(pstate.linebuf_size);
 
 	GLSLFileParseState fstate = { 0 };
 	fstate.global = &pstate;
 	fstate.path = path;
 
 	bool result = glsl_process_file(&fstate);
-	free(pstate.linebuf);
+	mem_free(pstate.linebuf);
 
 	if(result) {
 		SDL_WriteU8(out_buf, 0);
 		out->content_size = strlen(bufdata_ptr) + 1;
-		out->content = malloc(out->content_size);
+		out->content = mem_alloc(out->content_size);
 		memcpy(out->content, bufdata_ptr, out->content_size);
 	}
 
@@ -373,10 +373,10 @@ void glsl_free_source(ShaderSource *src) {
 	ShaderSourceMetaGLSL *m = &src->meta.glsl;
 
 	for(uint i = 0; i < m->num_attributes; ++i) {
-		free(m->attributes[i].name);
+		mem_free(m->attributes[i].name);
 	}
 
-	free(m->attributes);
+	mem_free(m->attributes);
 	m->attributes = NULL;
 }
 

--- a/src/renderer/common/shaderlib/lang_spirv.c
+++ b/src/renderer/common/shaderlib/lang_spirv.c
@@ -187,7 +187,7 @@ bool _spirv_compile(const ShaderSource *in, ShaderSource *out, const SPIRVCompil
 	out->lang.lang = SHLANG_SPIRV;
 	out->lang.spirv.target = options->target;
 	out->content_size = data_len + 1;
-	out->content = calloc(1, out->content_size);
+	out->content = mem_alloc(out->content_size);
 	memcpy(out->content, data, data_len);
 	shaderc_result_release(result);
 
@@ -209,7 +209,7 @@ static spvc_result write_glsl_attribs(spvc_compiler compiler, ShaderSource *out)
 	log_debug("%zu stage inputs", num_inputs);
 
 	// caller is expected to clean this up in case of error
-	GLSLAttribute *attrs = calloc(num_inputs, sizeof(*attrs));
+	auto attrs = ALLOC_ARRAY(num_inputs, GLSLAttribute);
 	out->meta.glsl.attributes = attrs;
 	out->meta.glsl.num_attributes = num_inputs;
 

--- a/src/renderer/common/shaderlib/lang_spirv_aux.c
+++ b/src/renderer/common/shaderlib/lang_spirv_aux.c
@@ -192,6 +192,6 @@ bool spirv_transpile(const ShaderSource *in, ShaderSource *out, const SPIRVTrans
 		}
 	}
 
-	free(spirv.content);
+	mem_free(spirv.content);
 	return result;
 }

--- a/src/renderer/common/shaderlib/shaderlib.c
+++ b/src/renderer/common/shaderlib/shaderlib.c
@@ -19,7 +19,7 @@ void shader_free_source(ShaderSource *src) {
 		default: break;
 	}
 
-	free(src->content);
+	mem_free(src->content);
 	src->content = NULL;
 	src->content_size = 0;
 }

--- a/src/renderer/gl33/common_buffer.c
+++ b/src/renderer/gl33/common_buffer.c
@@ -78,8 +78,7 @@ SDL_RWops *gl33_buffer_get_stream(CommonBuffer *cbuf) {
 }
 
 CommonBuffer *gl33_buffer_create(uint bindidx, size_t alloc_size) {
-	CommonBuffer *cbuf = calloc(1, alloc_size);
-
+	CommonBuffer *cbuf = mem_alloc(alloc_size);
 	cbuf->bindidx = bindidx;
 	cbuf->stream.type = SDL_RWOPS_UNKNOWN;
 	cbuf->stream.close = gl33_buffer_stream_close;
@@ -87,9 +86,7 @@ CommonBuffer *gl33_buffer_create(uint bindidx, size_t alloc_size) {
 	cbuf->stream.write = gl33_buffer_stream_write;
 	cbuf->stream.seek = gl33_buffer_stream_seek;
 	cbuf->stream.size = gl33_buffer_stream_size;
-
 	glGenBuffers(1, &cbuf->gl_handle);
-
 	return cbuf;
 }
 
@@ -97,7 +94,7 @@ void gl33_buffer_init_cache(CommonBuffer *cbuf, size_t capacity) {
 	capacity = topow2(capacity);
 
 	if(cbuf->size != capacity || !cbuf->cache.buffer) {
-		cbuf->cache.buffer = realloc(cbuf->cache.buffer, capacity);
+		cbuf->cache.buffer = mem_realloc(cbuf->cache.buffer, capacity);
 		cbuf->size = cbuf->commited_size = capacity;
 		cbuf->cache.update_begin = capacity;
 	}
@@ -122,10 +119,10 @@ void gl33_buffer_init(CommonBuffer *cbuf, size_t capacity, void *data, GLenum us
 }
 
 void gl33_buffer_destroy(CommonBuffer *cbuf) {
-	free(cbuf->cache.buffer);
+	mem_free(cbuf->cache.buffer);
 	gl33_buffer_deleted(cbuf);
 	glDeleteBuffers(1, &cbuf->gl_handle);
-	free(cbuf);
+	mem_free(cbuf);
 }
 
 void gl33_buffer_invalidate(CommonBuffer *cbuf) {
@@ -152,7 +149,7 @@ void gl33_buffer_resize(CommonBuffer *cbuf, size_t new_size) {
 	);
 
 	cbuf->size = new_size;
-	cbuf->cache.buffer = realloc(cbuf->cache.buffer, new_size);
+	cbuf->cache.buffer = mem_realloc(cbuf->cache.buffer, new_size);
 	cbuf->cache.update_begin = 0;
 	cbuf->cache.update_end = umin(old_size, new_size);
 

--- a/src/renderer/gl33/framebuffer.c
+++ b/src/renderer/gl33/framebuffer.c
@@ -23,7 +23,7 @@ static GLuint r_attachment_to_gl_attachment[] = {
 static_assert(sizeof(r_attachment_to_gl_attachment)/sizeof(GLuint) == FRAMEBUFFER_MAX_ATTACHMENTS, "");
 
 Framebuffer *gl33_framebuffer_create(void) {
-	Framebuffer *fb = calloc(1, sizeof(Framebuffer));
+	auto fb = ALLOC(Framebuffer);
 	glGenFramebuffers(1, &fb->gl_fbo);
 	snprintf(fb->debug_label, sizeof(fb->debug_label), "FBO #%i", fb->gl_fbo);
 
@@ -117,7 +117,7 @@ void gl33_framebuffer_outputs(
 void gl33_framebuffer_destroy(Framebuffer *framebuffer) {
 	gl33_framebuffer_deleted(framebuffer);
 	glDeleteFramebuffers(1, &framebuffer->gl_fbo);
-	free(framebuffer);
+	mem_free(framebuffer);
 }
 
 void gl33_framebuffer_taint(Framebuffer *framebuffer) {

--- a/src/renderer/gl33/gl33.c
+++ b/src/renderer/gl33/gl33.c
@@ -248,7 +248,7 @@ static void gl33_init_texunits(void) {
 		R.texunits.limit = iclamp(R.texunits.limit, texunits_min, texunits_available);
 	}
 
-	R.texunits.array = calloc(R.texunits.limit, sizeof(TextureUnit));
+	R.texunits.array = ALLOC_ARRAY(R.texunits.limit, typeof(*R.texunits.array));
 	R.texunits.active = R.texunits.array;
 
 	for(int i = 0; i < R.texunits.limit; ++i) {

--- a/src/renderer/gl33/shader_object.c
+++ b/src/renderer/gl33/shader_object.c
@@ -100,14 +100,15 @@ ShaderObject *gl33_shader_object_compile(ShaderSource *source) {
 	if(status) {
 		uint nattribs = source->meta.glsl.num_attributes;
 
-		shobj = calloc(1, sizeof(*shobj));
-		shobj->gl_handle = gl_handle;
-		shobj->stage = source->stage;
-		shobj->num_attribs = nattribs;
+		shobj = ALLOC(ShaderObject, {
+			.gl_handle = gl_handle,
+			.stage = source->stage,
+			.num_attribs = nattribs,
+		});
 		snprintf(shobj->debug_label, sizeof(shobj->debug_label), "Shader object #%i", gl_handle);
 
 		if(nattribs > 0) {
-			shobj->attribs = calloc(nattribs, sizeof(*shobj->attribs));
+			shobj->attribs = ALLOC_ARRAY(nattribs, typeof(*shobj->attribs));
 		}
 
 		for(uint i = 0; i < nattribs; ++i) {
@@ -128,11 +129,11 @@ void gl33_shader_object_destroy(ShaderObject *shobj) {
 	uint nattribs = shobj->num_attribs;
 
 	for(uint i = 0; i < nattribs; ++i) {
-		free(shobj->attribs[i].name);
+		mem_free(shobj->attribs[i].name);
 	}
 
-	free(shobj->attribs);
-	free(shobj);
+	mem_free(shobj->attribs);
+	mem_free(shobj);
 }
 
 void gl33_shader_object_set_debug_label(ShaderObject *shobj, const char *label) {
@@ -154,12 +155,12 @@ bool gl33_shader_object_transfer(ShaderObject *dst, ShaderObject *src) {
 	uint nattribs = dst->num_attribs;
 
 	for(uint i = 0; i < nattribs; ++i) {
-		free(dst->attribs[i].name);
+		mem_free(dst->attribs[i].name);
 	}
 
-	free(dst->attribs);
+	mem_free(dst->attribs);
 	*dst = *src;
-	free(src);
+	mem_free(src);
 
 	return true;
 }

--- a/src/renderer/gl33/texture.c
+++ b/src/renderer/gl33/texture.c
@@ -302,8 +302,7 @@ static void apply_swizzle_mask(GLenum gl_target, SwizzleMask *mask) {
 }
 
 Texture *gl33_texture_create(const TextureParams *params) {
-	Texture *tex = calloc(1, sizeof(Texture));
-	memcpy(&tex->params, params, sizeof(*params));
+	auto tex = ALLOC(Texture, { .params = *params });
 	TextureParams *p = &tex->params;
 
 	TextureClass cls = p->class;
@@ -551,7 +550,7 @@ void gl33_texture_destroy(Texture *tex) {
 		glDeleteBuffers(1, &tex->pbo);
 	}
 
-	free(tex);
+	mem_free(tex);
 }
 
 void gl33_texture_taint(Texture *tex) {
@@ -628,6 +627,6 @@ bool gl33_texture_transfer(Texture *dst, Texture *src) {
 	glDeleteTextures(1, &dst->gl_handle);
 	*dst = *src;
 	gl33_texture_pointer_renamed(src, dst);
-	free(src);
+	mem_free(src);
 	return true;
 }

--- a/src/renderer/gl33/vertex_array.c
+++ b/src/renderer/gl33/vertex_array.c
@@ -25,7 +25,7 @@ static GLenum va_type_to_gl_type[] = {
 };
 
 VertexArray* gl33_vertex_array_create(void) {
-	VertexArray *varr = calloc(1, sizeof(VertexArray));
+	auto varr = ALLOC(VertexArray);
 	glGenVertexArrays(1, &varr->gl_handle);
 	// A VAO must be bound before it's considered valid.
 	// https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glIsVertexArray.xhtml
@@ -40,9 +40,9 @@ VertexArray* gl33_vertex_array_create(void) {
 void gl33_vertex_array_destroy(VertexArray *varr) {
 	gl33_vertex_array_deleted(varr);
 	glDeleteVertexArrays(1, &varr->gl_handle);
-	free(varr->attachments);
-	free(varr->attribute_layout);
-	free(varr);
+	mem_free(varr->attachments);
+	mem_free(varr->attribute_layout);
+	mem_free(varr);
 }
 
 static void gl33_vertex_array_update_layout(VertexArray *varr) {
@@ -135,7 +135,7 @@ void gl33_vertex_array_attach_vertex_buffer(VertexArray *varr, VertexBuffer *vbu
 
 	// TODO: more efficient way of handling this?
 	if(attachment >= varr->num_attachments) {
-		varr->attachments = realloc(varr->attachments, (attachment + 1) * sizeof(VertexBuffer*));
+		varr->attachments = mem_realloc(varr->attachments, (attachment + 1) * sizeof(VertexBuffer*));
 		varr->num_attachments = attachment + 1;
 	}
 
@@ -162,7 +162,7 @@ IndexBuffer* gl33_vertex_array_get_index_attachment(VertexArray *varr) {
 
 void gl33_vertex_array_layout(VertexArray *varr, uint nattribs, VertexAttribFormat attribs[nattribs]) {
 	if(varr->num_attributes != nattribs) {
-		varr->attribute_layout = realloc(varr->attribute_layout, sizeof(VertexAttribFormat) * nattribs);
+		varr->attribute_layout = mem_realloc(varr->attribute_layout, sizeof(VertexAttribFormat) * nattribs);
 		varr->num_attributes = nattribs;
 	}
 

--- a/src/renderer/glcommon/opengl.c
+++ b/src/renderer/glcommon/opengl.c
@@ -692,15 +692,11 @@ static void detect_broken_intel_driver(void) {
 
 	mbdata.flags = SDL_MESSAGEBOX_WARNING;
 	mbdata.title = "Taisei Project";
-
-	char *msg = strfmt(
+	mbdata.message =
 		"Looks like you have a broken OpenGL driver.\n"
 		"Taisei will probably not work correctly, if at all.\n\n"
 		"Starting the game in ANGLE mode should fix the problem, but may introduce slowdown.\n\n"
-		"Restart in ANGLE mode now? (If unsure, press YES)"
-	);
-
-	mbdata.message = msg;
+		"Restart in ANGLE mode now? (If unsure, press YES)";
 	mbdata.numbuttons = 3;
 	mbdata.buttons = (SDL_MessageBoxButtonData[]) {
 		{ SDL_MESSAGEBOX_BUTTON_ESCAPEKEY_DEFAULT, 2, "Abort" },
@@ -709,7 +705,6 @@ static void detect_broken_intel_driver(void) {
 	};
 
 	int mbresult = SDL_ShowMessageBox(&mbdata, &button);
-	free(msg);
 
 	if(mbresult < 0) {
 		log_sdl_error(LOG_ERROR, "SDL_ShowMessageBox");

--- a/src/renderer/gles20/index_buffer.c
+++ b/src/renderer/gles20/index_buffer.c
@@ -12,7 +12,7 @@
 
 IndexBuffer *gles20_index_buffer_create(uint index_size, size_t max_elements) {
 	assert(index_size == sizeof(gles20_ibo_index_t));
-	IndexBuffer *ibuf = calloc(1, sizeof(*ibuf) + max_elements * sizeof(gles20_ibo_index_t));
+	auto ibuf = ALLOC_FLEX(IndexBuffer, max_elements * sizeof(gles20_ibo_index_t));
 	snprintf(ibuf->debug_label, sizeof(ibuf->debug_label), "Fake IBO at %p", (void*)ibuf);
 	ibuf->num_elements = max_elements;
 	return ibuf;
@@ -55,7 +55,7 @@ void gles20_index_buffer_add_indices(IndexBuffer *ibuf, size_t data_size, void *
 }
 
 void gles20_index_buffer_destroy(IndexBuffer *ibuf) {
-	free(ibuf);
+	mem_free(ibuf);
 }
 
 void gles20_index_buffer_flush(IndexBuffer *ibuf) {

--- a/src/replay/play.c
+++ b/src/replay/play.c
@@ -33,12 +33,11 @@ void replay_play(Replay *rpy, int firstidx, CallChain next) {
 		return;
 	}
 
-	ReplayContext *ctx = calloc(1, sizeof(*ctx));
-	ctx->cc = next;
-	ctx->rpy = rpy;
-	ctx->stage_idx = firstidx;
-
-	replay_do_play(CALLCHAIN_RESULT(ctx, NULL));
+	replay_do_play(CALLCHAIN_RESULT(ALLOC(ReplayContext, {
+		.cc = next,
+		.rpy = rpy,
+		.stage_idx = firstidx,
+	}), NULL));
 }
 
 static void replay_do_play(CallChainResult ccr) {
@@ -94,6 +93,6 @@ static void replay_do_cleanup(CallChainResult ccr) {
 	free_resources(false);
 
 	CallChain cc = ctx->cc;
-	free(ctx);
+	mem_free(ctx);
 	run_call_chain(&cc, NULL);
 }

--- a/src/replay/read.c
+++ b/src/replay/read.c
@@ -40,9 +40,7 @@ static void replay_read_string(SDL_RWops *file, char **ptr, uint16_t version) {
 		len = SDL_ReadLE16(file);
 	}
 
-	*ptr = malloc(len + 1);
-	memset(*ptr, 0, len + 1);
-
+	*ptr = mem_alloc(len + 1);
 	SDL_RWread(file, *ptr, 1, len);
 }
 
@@ -99,7 +97,7 @@ static bool replay_read_header(Replay *rpy, SDL_RWops *file, int64_t filesize, s
 	char *gamev = taisei_version_tostring(&rpy->game_version);
 	log_info("Struct version %u (%scompressed), game version %s%s",
 		base_version, compression ? "" : "un", gamev, gamev_assumed ? " (assumed)" : "");
-	free(gamev);
+	mem_free(gamev);
 
 	if(compression) {
 		CHECKPROP(rpy->fileoffset = SDL_ReadLE32(file), u);
@@ -216,7 +214,7 @@ static bool replay_read_meta(Replay *rpy, SDL_RWops *file, int64_t filesize, con
 	return true;
 
 error:
-	free(rpy->playername);
+	mem_free(rpy->playername);
 	rpy->playername = NULL;
 	dynarray_free_data(&rpy->stages);
 	return false;

--- a/src/replay/replay.c
+++ b/src/replay/replay.c
@@ -22,7 +22,7 @@ void replay_destroy_events(Replay *rpy) {
 void replay_reset(Replay *rpy) {
 	replay_destroy_events(rpy);
 	dynarray_free_data(&rpy->stages);
-	free(rpy->playername);
+	mem_free(rpy->playername);
 	memset(rpy, 0, sizeof(Replay));
 }
 
@@ -36,10 +36,10 @@ bool replay_save(Replay *rpy, const char *name) {
 	char *p = replay_getpath(name, !strendswith(name, REPLAY_EXTENSION));
 	char *sp = vfs_repr(p, true);
 	log_info("Saving %s", sp);
-	free(sp);
+	mem_free(sp);
 
 	SDL_RWops *file = vfs_open(p, VFS_MODE_WRITE);
-	free(p);
+	mem_free(p);
 
 	if(!file) {
 		log_error("VFS error: %s", vfs_get_error());
@@ -74,17 +74,17 @@ bool replay_load(Replay *rpy, const char *name, ReplayReadMode mode) {
 	log_info("Loading %s (%s)", sp, replay_mode_string(mode));
 
 	SDL_RWops *file = vfs_open(p, VFS_MODE_READ);
-	free(p);
+	mem_free(p);
 
 	if(!file) {
 		log_error("VFS error: %s", vfs_get_error());
-		free(sp);
+		mem_free(sp);
 		return false;
 	}
 
 	bool result = replay_read(rpy, file, mode, sp);
 
-	free(sp);
+	mem_free(sp);
 	SDL_RWclose(file);
 	return result;
 }

--- a/src/resource/shader_object.c
+++ b/src/resource/shader_object.c
@@ -76,7 +76,7 @@ static void load_shader_object_stage1(ResourceLoadState *st) {
 		return;
 	}
 
-	struct shobj_load_data *ldata = calloc(1, sizeof(struct shobj_load_data));
+	auto ldata = ALLOC(struct shobj_load_data);
 
 	char backend_macro[32] = "BACKEND_";
 	{
@@ -146,7 +146,7 @@ static void load_shader_object_stage1(ResourceLoadState *st) {
 
 fail:
 	shader_free_source(&ldata->source);
-	free(ldata);
+	mem_free(ldata);
 	res_load_failed(st);
 }
 
@@ -155,7 +155,7 @@ static void load_shader_object_stage2(ResourceLoadState *st) {
 
 	ShaderObject *shobj = r_shader_object_compile(&ldata->source);
 	shader_free_source(&ldata->source);
-	free(ldata);
+	mem_free(ldata);
 
 	if(shobj) {
 		r_shader_object_set_debug_label(shobj, st->name);

--- a/src/resource/shader_program.c
+++ b/src/resource/shader_program.c
@@ -48,7 +48,7 @@ static void load_shader_program_stage1(ResourceLoadState *st) {
 		{ NULL }
 	})) {
 		SDL_RWclose(rw);
-		free(strobjects);
+		mem_free(strobjects);
 		res_load_failed(st);
 		return;
 	}
@@ -56,7 +56,7 @@ static void load_shader_program_stage1(ResourceLoadState *st) {
 	SDL_RWclose(rw);
 
 	if(strobjects) {
-		ldata.objlist = calloc(1, strlen(strobjects) + 1);
+		ldata.objlist = mem_alloc(strlen(strobjects) + 1);
 		char *listptr = ldata.objlist;
 		char *objname, *srcptr = strobjects;
 
@@ -69,21 +69,21 @@ static void load_shader_program_stage1(ResourceLoadState *st) {
 			}
 		}
 
-		free(strobjects);
+		mem_free(strobjects);
 	}
 
 	if(ldata.num_objects) {
 		res_load_continue_on_main(st, load_shader_program_stage2, memdup(&ldata, sizeof(ldata)));
 	} else {
 		log_error("%s: no shader objects to link", st->path);
-		free(ldata.objlist);
+		mem_free(ldata.objlist);
 		res_load_failed(st);
 	}
 }
 
 static void load_shader_program_stage2(ResourceLoadState *st) {
 	struct shprog_load_data ldata = *(struct shprog_load_data*)NOT_NULL(st->opaque);
-	free(st->opaque);
+	mem_free(st->opaque);
 
 	ShaderObject *objs[ldata.num_objects];
 	char *objname = ldata.objlist;
@@ -91,7 +91,7 @@ static void load_shader_program_stage2(ResourceLoadState *st) {
 	for(int i = 0; i < ldata.num_objects; ++i) {
 		if(!(objs[i] = get_resource_data(RES_SHADER_OBJECT, objname, st->flags & ~RESF_RELOAD))) {
 			log_error("%s: couldn't load shader object '%s'", st->path, objname);
-			free(ldata.objlist);
+			mem_free(ldata.objlist);
 			res_load_failed(st);
 			return;
 		}
@@ -99,7 +99,7 @@ static void load_shader_program_stage2(ResourceLoadState *st) {
 		objname += strlen(objname) + 1;
 	}
 
-	free(ldata.objlist);
+	mem_free(ldata.objlist);
 	ShaderProgram *prog = r_shader_program_link(ldata.num_objects, objs);
 
 	if(prog) {

--- a/src/resource/texture_loader/basisu.c
+++ b/src/resource/texture_loader/basisu.c
@@ -390,7 +390,7 @@ static void texture_loader_basisu_cleanup(struct basisu_load_data *bld) {
 		basist_transcoder_set_data(bld->tc, (basist_data) { 0 });
 	}
 
-	free(bld->filebuf);
+	mem_free(bld->filebuf);
 	bld->filebuf = NULL;
 }
 
@@ -638,12 +638,12 @@ static bool texture_loader_basisu_init_mipmaps(
 
 	switch(ld->params.class) {
 		case TEXTURE_CLASS_2D:
-			ld->pixmaps = calloc(ld->params.mipmaps, sizeof(*ld->pixmaps));
+			ld->pixmaps = ALLOC_ARRAY(ld->params.mipmaps, typeof(*ld->pixmaps));
 			ld->num_pixmaps = ld->params.mipmaps;
 			break;
 
 		case TEXTURE_CLASS_CUBEMAP:
-			ld->cubemaps = calloc(ld->params.mipmaps, sizeof(*ld->cubemaps));
+			ld->cubemaps = ALLOC_ARRAY(ld->params.mipmaps, typeof(*ld->cubemaps));
 			ld->num_pixmaps = ld->params.mipmaps * 6;
 			break;
 
@@ -701,7 +701,7 @@ static bool texture_loader_basisu_load_pixmap(
 		}
 
 		out_pixmap->data_size = data_size;
-		out_pixmap->data.untyped = calloc(1, out_pixmap->data_size);
+		out_pixmap->data.untyped = mem_alloc(out_pixmap->data_size);
 		parm->output_blocks = out_pixmap->data.untyped;
 		parm->output_blocks_size = size_info.num_blocks;
 

--- a/src/resource/texture_loader/basisu_cache.c
+++ b/src/resource/texture_loader/basisu_cache.c
@@ -147,7 +147,7 @@ bool texture_loader_basisu_load_cached(
 	return true;
 
 bad_entry:
-	free(out_pixmap->data.untyped);
+	mem_free(out_pixmap->data.untyped);
 	out_pixmap->data.untyped = NULL;
 	return false;
 }

--- a/src/rwops/rwops_autobuf.c
+++ b/src/rwops/rwops_autobuf.c
@@ -25,7 +25,7 @@ static void auto_realloc(Buffer *b, size_t newsize) {
 	SDL_RWclose(b->memrw);
 
 	b->size = newsize;
-	b->data = realloc(b->data, b->size);
+	b->data = mem_realloc(b->data, b->size);
 	b->memrw = SDL_RWFromMem(b->data, b->size);
 
 	if(b->ptr) {
@@ -41,8 +41,8 @@ static int auto_close(SDL_RWops *rw) {
 	if(rw) {
 		Buffer *b = BUFFER(rw);
 		SDL_RWclose(b->memrw);
-		free(b->data);
-		free(b);
+		mem_free(b->data);
+		mem_free(b);
 		SDL_FreeRW(rw);
 	}
 
@@ -91,11 +91,12 @@ SDL_RWops *SDL_RWAutoBuffer(void **ptr, size_t initsize) {
 	rw->write = auto_write;
 	rw->close = auto_close;
 
-	Buffer *b = calloc(1, sizeof(Buffer));
+	auto b = ALLOC(Buffer, {
+		.size = initsize,
+		.data = mem_alloc(initsize),
+		.ptr = ptr,
+	});
 
-	b->size = initsize;
-	b->data = malloc(b->size);
-	b->ptr = ptr;
 	b->memrw = SDL_RWFromMem(b->data, b->size);
 
 	if(ptr) {

--- a/src/rwops/rwops_crc32.c
+++ b/src/rwops/rwops_crc32.c
@@ -36,7 +36,7 @@ static int rwcrc32_close(SDL_RWops *rw) {
 		SDL_RWclose(DATA(rw)->src);
 	}
 
-	free(DATA(rw));
+	mem_free(DATA(rw));
 	SDL_FreeRW(rw);
 	return 0;
 }
@@ -84,7 +84,7 @@ SDL_RWops *SDL_RWWrapCRC32(SDL_RWops *src, uint32_t *crc32_ptr, bool autoclose) 
 	memset(rw, 0, sizeof(SDL_RWops));
 
 	rw->type = SDL_RWOPS_UNKNOWN;
-	rw->hidden.unknown.data1 = calloc(1, sizeof(struct crc32_data));
+	rw->hidden.unknown.data1 = ALLOC(struct crc32_data);
 	DATA(rw)->src = src;
 	DATA(rw)->crc32_ptr = crc32_ptr;
 	DATA(rw)->autoclose = autoclose;

--- a/src/rwops/rwops_segment.c
+++ b/src/rwops/rwops_segment.c
@@ -164,7 +164,7 @@ static int segment_close(SDL_RWops *rw) {
 			SDL_RWclose(s->wrapped);
 		}
 
-		free(s);
+		mem_free(s);
 		SDL_FreeRW(rw);
 	}
 
@@ -192,17 +192,15 @@ SDL_RWops *SDL_RWWrapSegment(SDL_RWops *src, size_t start, size_t end, bool auto
 	rw->read = segment_read;
 	rw->write = segment_write;
 	rw->close = segment_close;
+	rw->hidden.unknown.data1 = ALLOC(Segment, {
+		.wrapped = src,
+		.start = start,
+		.end = end,
+		.autoclose = autoclose,
 
-	Segment *s = malloc(sizeof(Segment));
-	s->wrapped = src;
-	s->start = start;
-	s->end = end;
-	s->autoclose = autoclose;
-
-	// fallback for non-seekable streams
-	s->pos = start;
-
-	rw->hidden.unknown.data1 = s;
+		// fallback for non-seekable streams
+		.pos = start,
+	});
 
 	return rw;
 }

--- a/src/rwops/rwops_sha256.c
+++ b/src/rwops/rwops_sha256.c
@@ -24,7 +24,7 @@ static int rwsha256_close(SDL_RWops *rw) {
 		SDL_RWclose(DATA(rw)->src);
 	}
 
-	free(DATA(rw));
+	mem_free(DATA(rw));
 	SDL_FreeRW(rw);
 	return 0;
 }
@@ -74,7 +74,7 @@ SDL_RWops *SDL_RWWrapSHA256(SDL_RWops *src, SHA256State *sha256, bool autoclose)
 	memset(rw, 0, sizeof(SDL_RWops));
 
 	rw->type = SDL_RWOPS_UNKNOWN;
-	rw->hidden.unknown.data1 = calloc(1, sizeof(struct sha256_data));
+	rw->hidden.unknown.data1 = ALLOC(struct sha256_data);
 	DATA(rw)->src = src;
 	DATA(rw)->sha256 = sha256;
 	DATA(rw)->autoclose = autoclose;

--- a/src/rwops/rwops_trace.c
+++ b/src/rwops/rwops_trace.c
@@ -40,7 +40,7 @@ static int trace_close(SDL_RWops *rw) {
 	}
 
 	TRACE(rw, "closed %i", ret);
-	free(rw->hidden.unknown.data2);
+	mem_free(rw->hidden.unknown.data2);
 	SDL_FreeRW(rw);
 	return ret;
 }
@@ -99,7 +99,7 @@ SDL_RWops *SDL_RWWrapTrace(SDL_RWops *src, const char *tag, bool autoclose) {
 
 	memset(rw, 0, sizeof(SDL_RWops));
 
-	TData *tdata = calloc(1, sizeof(*tdata) + strlen(tag) + 1);
+	auto tdata = ALLOC_FLEX(TData, strlen(tag) + 1);
 	tdata->autoclose = autoclose;
 	strcpy(tdata->tag, tag);
 

--- a/src/rwops/rwops_zipfile.c
+++ b/src/rwops/rwops_zipfile.c
@@ -73,7 +73,7 @@ static int ziprw_close(SDL_RWops *rw) {
 		}
 
 		vfs_decref(rwdata->node);
-		free(rwdata);
+		mem_free(rwdata);
 		SDL_FreeRW(rw);
 	}
 
@@ -173,9 +173,10 @@ SDL_RWops *SDL_RWFromZipFile(VFSNode *znode, VFSZipPathData *pdata) {
 
 	memset(rw, 0, sizeof(SDL_RWops));
 
-	ZipRWData *rwdata = calloc(1, sizeof(*rwdata));
-	rwdata->node = znode;
-	rwdata->size = pdata->size;
+	auto rwdata = ALLOC(ZipRWData, {
+		.node = znode,
+		.size = pdata->size,
+	});
 
 	vfs_incref(znode);
 

--- a/src/stagedraw.c
+++ b/src/stagedraw.c
@@ -137,7 +137,7 @@ static void stage_framebuffer_resize_strategy(void *userdata, IntExtent *out_dim
 static void stage_framebuffer_resize_strategy_cleanup(void *userdata) {
 	StageFramebufferResizeParams *rp = userdata;
 	if(--rp->refs <= 0) {
-		free(rp);
+		mem_free(rp);
 	}
 }
 

--- a/src/stageinfo.c
+++ b/src/stageinfo.c
@@ -51,8 +51,8 @@ static void add_spellpractice_stage(
 
 	add_stage(id, s->procs->spellpractice_procs, STAGE_SPELL, title, subtitle, a, diff);
 
-	free(title);
-	free(subtitle);
+	mem_free(title);
+	mem_free(subtitle);
 }
 
 static void add_spellpractice_stages(
@@ -97,7 +97,8 @@ static void stageinfo_fill(StagesExports *e);
 void stageinfo_init(void) {
 	dynstage_init();
 	stageinfo_fill(dynstage_get_exports());
-	stageinfo.stages_progress = calloc(stageinfo.stages.num_elements, sizeof(*stageinfo.stages_progress));
+	stageinfo.stages_progress = ALLOC_ARRAY(
+		stageinfo.stages.num_elements, typeof(*stageinfo.stages_progress));
 }
 
 void stageinfo_reload(void) {
@@ -110,8 +111,8 @@ void stageinfo_reload(void) {
 	attr_unused uint prev_count = stageinfo.stages.num_elements;
 
 	dynarray_foreach_elem(&stageinfo.stages, StageInfo *stg, {
-		free(stg->title);
-		free(stg->subtitle);
+		mem_free(stg->title);
+		mem_free(stg->subtitle);
 	});
 
 	stageinfo.stages.num_elements = 0;
@@ -176,13 +177,13 @@ static void stageinfo_fill(StagesExports *e) {
 
 void stageinfo_shutdown(void) {
 	dynarray_foreach(&stageinfo.stages, int i, StageInfo *stg, {
-		free(stg->title);
-		free(stg->subtitle);
-		free(stageinfo.stages_progress[i]);
+		mem_free(stg->title);
+		mem_free(stg->subtitle);
+		mem_free(stageinfo.stages_progress[i]);
 	});
 
 	dynarray_free_data(&stageinfo.stages);
-	free(stageinfo.stages_progress);
+	mem_free(stageinfo.stages_progress);
 	dynstage_shutdown();
 }
 
@@ -240,7 +241,7 @@ StageProgress *stageinfo_get_progress(StageInfo *stage, Difficulty diff, bool al
 			return NULL;
 		}
 
-		*prog = calloc(fixed_diff ? 1 : NUM_SELECTABLE_DIFFICULTIES, sizeof(**prog));
+		*prog = ALLOC_ARRAY(fixed_diff ? 1 : NUM_SELECTABLE_DIFFICULTIES, typeof(**prog));
 	}
 
 	return *prog + (fixed_diff ? 0 : diff - D_Easy);

--- a/src/stages/stage1/draw.c
+++ b/src/stages/stage1/draw.c
@@ -22,7 +22,7 @@ Stage1DrawData *stage1_get_draw_data(void) {
 }
 
 void stage1_drawsys_init(void) {
-	stage1_draw_data = calloc(1, sizeof(*stage1_draw_data));
+	stage1_draw_data = ALLOC(typeof(*stage1_draw_data));
 	stage3d_init(&stage_3d_context, 64);
 
 	FBAttachmentConfig cfg = { 0 };
@@ -41,7 +41,7 @@ void stage1_drawsys_init(void) {
 
 void stage1_drawsys_shutdown(void) {
 	stage3d_shutdown(&stage_3d_context);
-	free(stage1_draw_data);
+	mem_free(stage1_draw_data);
 	stage1_draw_data = NULL;
 }
 

--- a/src/stages/stage2/draw.c
+++ b/src/stages/stage2/draw.c
@@ -16,8 +16,6 @@
 #include "stageutils.h"
 #include "util/glm.h"
 
-#include <stdlib.h>
-
 static Stage2DrawData *stage2_draw_data;
 
 Stage2DrawData *stage2_get_draw_data(void) {
@@ -460,8 +458,8 @@ void stage2_drawsys_init(void) {
 	stage3d_init(&stage_3d_context, 16);
 	stage_3d_context.cam.near = 1;
 	stage_3d_context.cam.far = 60;
-	stage2_draw_data = aligned_alloc(alignof(*stage2_draw_data), sizeof(*stage2_draw_data));
-	memset(stage2_draw_data, 0, sizeof(*stage2_draw_data));
+
+	stage2_draw_data = ALLOC(typeof(*stage2_draw_data));
 
 	pbr_load_model(&stage2_draw_data->models.branch, "stage2/branch", "stage2/branch");
 	pbr_load_model(&stage2_draw_data->models.grass,  "stage2/grass",  "stage2/ground");
@@ -484,7 +482,7 @@ void stage2_drawsys_init(void) {
 
 void stage2_drawsys_shutdown(void) {
 	stage3d_shutdown(&stage_3d_context);
-	free(stage2_draw_data);
+	mem_free(stage2_draw_data);
 }
 
 ShaderRule stage2_bg_effects[] = {

--- a/src/stages/stage3/draw.c
+++ b/src/stages/stage3/draw.c
@@ -109,7 +109,7 @@ void stage3_drawsys_init(void) {
 	stage_3d_context.cam.vel[1] = 0.1;
 	stage_3d_context.cam.vel[2] = 0.05;
 
-	stage3_draw_data = calloc(1, sizeof(*stage3_draw_data));
+	stage3_draw_data = ALLOC(typeof(*stage3_draw_data));
 
 	pbr_load_model(&stage3_draw_data->models.ground, "stage3/ground", "stage3/ground");	pbr_load_model(&stage3_draw_data->models.leaves, "stage3/leaves", "stage3/leaves");
 	pbr_load_model(&stage3_draw_data->models.rocks,  "stage3/rocks",  "stage3/rocks");
@@ -118,7 +118,7 @@ void stage3_drawsys_init(void) {
 
 void stage3_drawsys_shutdown(void) {
 	stage3d_shutdown(&stage_3d_context);
-	free(stage3_draw_data);
+	mem_free(stage3_draw_data);
 }
 
 static bool stage3_fog(Framebuffer *fb) {

--- a/src/stages/stage4/draw.c
+++ b/src/stages/stage4/draw.c
@@ -329,7 +329,7 @@ void stage4_draw(void) {
 }
 
 void stage4_drawsys_init(void) {
-	stage4_draw_data = calloc(1, sizeof(*stage4_draw_data));
+	stage4_draw_data = ALLOC(typeof(*stage4_draw_data));
 	stage3d_init(&stage_3d_context, 16);
 
 	pbr_load_model(&stage4_draw_data->models.corridor, "stage4/corridor", "stage4/corridor");
@@ -345,7 +345,7 @@ void stage4_drawsys_init(void) {
 
 void stage4_drawsys_shutdown(void) {
 	stage3d_shutdown(&stage_3d_context);
-	free(stage4_draw_data);
+	mem_free(stage4_draw_data);
 	stage4_draw_data = NULL;
 }
 

--- a/src/stages/stage5/draw.c
+++ b/src/stages/stage5/draw.c
@@ -22,7 +22,7 @@ Stage5DrawData *stage5_get_draw_data(void) {
 }
 
 void stage5_drawsys_init(void) {
-	stage5_draw_data = calloc(1, sizeof(*stage5_draw_data));
+	stage5_draw_data = ALLOC(typeof(*stage5_draw_data));
 	stage3d_init(&stage_3d_context, 16);
 
 	stage5_draw_data->stairs.light_pos = -200;
@@ -40,7 +40,7 @@ void stage5_drawsys_init(void) {
 
 void stage5_drawsys_shutdown(void) {
 	stage3d_shutdown(&stage_3d_context);
-	free(stage5_draw_data);
+	mem_free(stage5_draw_data);
 	stage5_draw_data = NULL;
 }
 

--- a/src/taisei.h
+++ b/src/taisei.h
@@ -11,6 +11,8 @@
 
 #include "build_config.h"
 #include "util/compat.h"
+#include "util/consideredharmful.h"
+#include "memory.h"
 
 #ifdef TAISEI_BUILDCONF_DEVELOPER
 	// TODO: maybe rename this

--- a/src/util/consideredharmful.h
+++ b/src/util/consideredharmful.h
@@ -73,4 +73,25 @@ int rand(void);
 attr_deprecated("Use tsrand_seed instead")
 void srand(uint);
 
+
+INLINE void *libc_malloc(size_t size) { return malloc(size); }
+#undef malloc
+attr_deprecated("Use the memory.h API instead")
+void *malloc(size_t size);
+
+INLINE void libc_free(void *ptr) { free(ptr); }
+#undef free
+attr_deprecated("Use the memory.h API instead, or libc_free if this is a foreign allocation")
+void free(void *ptr);
+
+INLINE void *libc_calloc(size_t nmemb, size_t size) { return calloc(nmemb, size); }
+#undef calloc
+attr_deprecated("Use the memory.h API instead")
+void *calloc(size_t nmemb, size_t size);
+
+INLINE void *libc_realloc(void *ptr, size_t size) { return realloc(ptr, size); }
+#undef realloc
+attr_deprecated("Use the memory.h API instead")
+void *realloc(void *ptr, size_t size);
+
 PRAGMA(GCC diagnostic pop)

--- a/src/util/crap.c
+++ b/src/util/crap.c
@@ -13,12 +13,6 @@
 
 #include <SDL_thread.h>
 
-void* memdup(const void *src, size_t size) {
-	void *data = malloc(size);
-	memcpy(data, src, size);
-	return data;
-}
-
 static_assert(sizeof(void*) == sizeof(void (*)(void)), "Can't store function pointers in void* :(");
 
 void inherit_missing_pointers(uint num, void *dest[num], void *const base[num]) {

--- a/src/util/crap.h
+++ b/src/util/crap.h
@@ -11,7 +11,6 @@
 
 #include <SDL.h>
 
-void* memdup(const void *src, size_t size) attr_returns_allocated attr_nonnull(1);
 void inherit_missing_pointers(uint num, void *dest[num], void *const base[num]) attr_nonnull(2, 3);
 bool is_main_thread(void);
 

--- a/src/util/fbmgr.c
+++ b/src/util/fbmgr.c
@@ -65,7 +65,7 @@ ManagedFramebuffer *fbmgr_framebuffer_create(const char *name, const Framebuffer
 	assert(cfg->attachments != NULL);
 	assert(cfg->num_attachments >= 1);
 
-	ManagedFramebuffer *mfb = calloc(1, sizeof(*mfb) + sizeof(ManagedFramebufferData));
+	auto mfb = ALLOC_FLEX(ManagedFramebuffer, sizeof(ManagedFramebufferData));
 	ManagedFramebufferData *data = GET_DATA(mfb);
 	data->resize_strategy = cfg->resize_strategy;
 	mfb->fb = r_framebuffer_create();
@@ -113,7 +113,7 @@ Framebuffer *fbmgr_framebuffer_disown(ManagedFramebuffer *mfb) {
 
 			Framebuffer *fb = m->fb;
 			list_unlink(&framebuffers, d);
-			free(m);
+			mem_free(m);
 			return fb;
 		}
 	}
@@ -161,7 +161,7 @@ void fbmgr_shutdown(void) {
 }
 
 ManagedFramebufferGroup *fbmgr_group_create(void) {
-	return calloc(1, sizeof(ManagedFramebufferGroup));
+	return ALLOC(ManagedFramebufferGroup);
 }
 
 void fbmgr_group_destroy(ManagedFramebufferGroup *group) {
@@ -171,7 +171,7 @@ void fbmgr_group_destroy(ManagedFramebufferGroup *group) {
 		fbmgr_framebuffer_destroy(mfb);
 	}
 
-	free(group);
+	mem_free(group);
 }
 
 Framebuffer *fbmgr_group_framebuffer_create(ManagedFramebufferGroup *group, const char *name, const FramebufferConfig *cfg) {

--- a/src/util/kvparser.c
+++ b/src/util/kvparser.c
@@ -18,7 +18,7 @@ bool parse_keyvalue_stream_cb(SDL_RWops *strm, KVCallback callback, void *data) 
 	static const char separator[] = "= ";
 
 	size_t bufsize = 256;
-	char *buffer = malloc(bufsize);
+	char *buffer = mem_alloc(bufsize);
 	int lineno = 0;
 	int errors = 0;
 
@@ -69,7 +69,7 @@ bool parse_keyvalue_stream_cb(SDL_RWops *strm, KVCallback callback, void *data) 
 		}
 	}
 
-	free(buffer);
+	mem_free(buffer);
 	return !errors;
 }
 

--- a/src/util/pngcruft.c
+++ b/src/util/pngcruft.c
@@ -46,10 +46,24 @@ void pngutil_setup_error_handlers(png_structp png) {
 	png_set_error_fn(png, NULL, pngutil_error_handler, pngutil_warning_handler);
 }
 
+static PNG_CALLBACK(png_voidp, pngutil_malloc, (png_structp png, png_alloc_size_t size)) {
+	return mem_alloc(size);
+}
+
+static PNG_CALLBACK(void, pngutil_free, (png_structp png, png_voidp ptr)) {
+	mem_free(ptr);
+}
+
 png_structp pngutil_create_read_struct(void) {
-	return png_create_read_struct(PNG_LIBPNG_VER_STRING, NULL, pngutil_error_handler, pngutil_warning_handler);
+	return png_create_read_struct_2(
+		PNG_LIBPNG_VER_STRING,
+		NULL, pngutil_error_handler, pngutil_warning_handler,
+		NULL, pngutil_malloc, pngutil_free);
 }
 
 png_structp pngutil_create_write_struct(void) {
-	return png_create_write_struct(PNG_LIBPNG_VER_STRING, NULL, pngutil_error_handler, pngutil_warning_handler);
+	return png_create_write_struct_2(
+		PNG_LIBPNG_VER_STRING,
+		NULL, pngutil_error_handler, pngutil_warning_handler,
+		NULL, pngutil_malloc, pngutil_free);
 }

--- a/src/util/sha256.c
+++ b/src/util/sha256.c
@@ -120,13 +120,13 @@ static void sha256_init(SHA256State *ctx)
 }
 
 SHA256State *sha256_new(void) {
-	SHA256State *ctx = calloc(1, sizeof(*ctx));
+	auto ctx = ALLOC(SHA256State);
 	sha256_init(ctx);
 	return ctx;
 }
 
 void sha256_free(SHA256State *ctx) {
-	free(ctx);
+	mem_free(ctx);
 }
 
 void sha256_update(SHA256State *ctx, const sha256_byte_t data[], size_t len) {

--- a/src/util/strbuf.c
+++ b/src/util/strbuf.c
@@ -37,7 +37,7 @@ static size_t strbuf_reserve(StringBuffer *strbuf, size_t size_required) {
 	if(size_required >= size_available) {
 		ptrdiff_t offset = strbuf->pos - strbuf->start;
 		size_t new_size = topow2_u64(strbuf->buf_size + (size_required - size_available + 1));
-		strbuf->start = realloc(strbuf->start, new_size);
+		strbuf->start = mem_realloc(strbuf->start, new_size);
 		strbuf->pos = strbuf->start + offset;
 		strbuf->buf_size = new_size;
 		size_available = new_size - offset;
@@ -89,6 +89,6 @@ void strbuf_clear(StringBuffer *strbuf) {
 }
 
 void strbuf_free(StringBuffer *strbuf) {
-	free(strbuf->start);
+	mem_free(strbuf->start);
 	memset(strbuf, 0, sizeof(*strbuf));
 }

--- a/src/util/stringops.c
+++ b/src/util/stringops.c
@@ -57,20 +57,14 @@ bool strstartswith_any(const char *s, const char **earray) {
 }
 
 void stralloc(char **dest, const char *src) {
-	free(*dest);
-
-	if(src) {
-		*dest = malloc(strlen(src)+1);
-		strcpy(*dest, src);
-	} else {
-		*dest = NULL;
-	}
+	mem_free(*dest);
+	*dest = src ? strdup(src) : NULL;
 }
 
 char* strjoin(const char *first, ...) {
 	va_list args;
 	size_t size = strlen(first) + 1;
-	char *str = malloc(size);
+	char *str = mem_alloc(size);
 
 	strcpy(str, first);
 	va_start(args, first);
@@ -83,7 +77,7 @@ char* strjoin(const char *first, ...) {
 		}
 
 		size += strlen(next);
-		str = realloc(str, size);
+		str = mem_realloc(str, size);
 		strcat(str, next);
 	}
 
@@ -101,7 +95,7 @@ char* vstrfmt(const char *fmt, va_list args) {
 		asize *= 2;
 
 	for(;;) {
-		out = realloc(out, asize);
+		out = mem_realloc(out, asize);
 
 		va_list nargs;
 		va_copy(nargs, args);
@@ -116,7 +110,7 @@ char* vstrfmt(const char *fmt, va_list args) {
 	}
 
 	if(asize > strlen(out) + 1) {
-		out = realloc(out, strlen(out) + 1);
+		out = mem_realloc(out, strlen(out) + 1);
 	}
 
 	return out;
@@ -149,7 +143,7 @@ char* strappend(char **dst, char *src) {
 		return *dst = strdup(src);
 	}
 
-	*dst = realloc(*dst, strlen(*dst) + strlen(src) + 1);
+	*dst = mem_realloc(*dst, strlen(*dst) + strlen(src) + 1);
 	strcat(*dst, src);
 	return *dst;
 }
@@ -199,7 +193,7 @@ void ucs4_to_utf8(const uint32_t *ucs4, size_t bufsize, char buf[bufsize]) {
 	assert(bufsize > ucs4len(ucs4));
 	char *temp = ucs4_to_utf8_alloc(ucs4);
 	memcpy(buf, temp, bufsize);
-	free(temp);
+	SDL_free(temp);
 }
 
 char* ucs4_to_utf8_alloc(const uint32_t *ucs4) {

--- a/src/util/stringops.h
+++ b/src/util/stringops.h
@@ -13,6 +13,7 @@
 #include <SDL.h>
 
 #include "systime.h"
+#include "memory.h"
 
 #define UNICODE_UNKNOWN 0xFFFD
 #define UNICODE_BOM_NATIVE  0xFEFF
@@ -29,7 +30,7 @@
 #define strdup _ts_strdup
 INLINE attr_returns_allocated attr_nonnull(1) char *strdup(const char *str) {
 	size_t sz = strlen(str) + 1;
-	return memcpy(malloc(sz), str, sz);
+	return memcpy(mem_alloc(sz), str, sz);
 }
 
 #ifndef TAISEI_BUILDCONF_HAVE_STRTOK_R
@@ -66,7 +67,7 @@ char* strappend(char **dst, char *src);
 char* strftimealloc(const char *fmt, const struct tm *timeinfo) attr_returns_allocated;
 void expand_escape_sequences(char *str);
 
-uint32_t* ucs4chr(const uint32_t *ucs4, uint32_t chr);
+uint32_t* ucs4chr(const uint32_t *ucs4, uint32_t chr) attr_dealloc(SDL_free, 1);
 size_t ucs4len(const uint32_t *ucs4);
 
 void utf8_to_ucs4(const char *utf8, size_t bufsize, uint32_t buf[bufsize]) attr_nonnull(1, 3);

--- a/src/vfs/decompress_wrapper.c
+++ b/src/vfs/decompress_wrapper.c
@@ -28,7 +28,7 @@ static_assert_nomsg(sizeof(struct decomp_data) <= sizeof(void*));
 static char *vfs_decomp_repr(VFSNode *node) {
 	char *wrapped_repr = vfs_node_repr(WRAPPED(node), false);
 	char *repr = strjoin("decompress view of ", wrapped_repr, NULL);
-	free(wrapped_repr);
+	mem_free(wrapped_repr);
 	return repr;
 }
 
@@ -171,7 +171,7 @@ static const char *vfs_decomp_iter(VFSNode *node, void **opaque) {
 	struct decomp_iter_data *i = *opaque;
 
 	if(!i) {
-		i = calloc(1, sizeof(*i));
+		i = ALLOC(typeof(*i));
 		ht_create(&i->visited);
 		*opaque = i;
 	}
@@ -198,7 +198,7 @@ static void vfs_decomp_iter_stop(VFSNode *node, void **opaque) {
 		vfs_node_iter_stop(wrapped, &i->opaque);
 		ht_destroy(&i->visited);
 		strbuf_free(&i->temp_buf);
-		free(i);
+		mem_free(i);
 		*opaque = NULL;
 	}
 }

--- a/src/vfs/loadpacks.c
+++ b/src/vfs/loadpacks.c
@@ -83,7 +83,7 @@ void vfs_load_packages(const char *dir, const char *unionmp) {
 			log_error("VFS error: %s", vfs_get_error());
 		}
 
-		free(tmp);
+		mem_free(tmp);
 	}
 
 	vfs_dir_list_free(paklist, numpaks);

--- a/src/vfs/nodeapi.c
+++ b/src/vfs/nodeapi.c
@@ -85,7 +85,7 @@ char* vfs_node_repr(VFSNode *node, bool try_syspath) {
 		i.error, i.exists, i.is_dir
 	);
 
-	free(o);
+	mem_free(o);
 	return r;
 }
 

--- a/src/vfs/public.c
+++ b/src/vfs/public.c
@@ -205,9 +205,7 @@ VFSDir* vfs_dir_open(const char *path) {
 
 	if(node) {
 		if(node->funcs->iter && vfs_node_query(node).is_dir) {
-			VFSDir *d = calloc(1, sizeof(VFSDir));
-			d->node = node;
-			return d;
+			return ALLOC(VFSDir, { .node = node });
 		}
 
 		vfs_set_error("Node '%s' is not a directory", path);
@@ -223,7 +221,7 @@ void vfs_dir_close(VFSDir *dir) {
 	if(dir) {
 		vfs_node_iter_stop(dir->node, &dir->opaque);
 		vfs_decref(dir->node);
-		free(dir);
+		mem_free(dir);
 	}
 }
 
@@ -265,10 +263,10 @@ void vfs_dir_list_free(char **list, size_t size) {
 	}
 
 	for(size_t i = 0; i < size; ++i) {
-		free(list[i]);
+		mem_free(list[i]);
 	}
 
-	free(list);
+	mem_free(list);
 }
 
 int vfs_dir_list_order_ascending(const void *a, const void *b) {

--- a/src/vfs/readonly_wrapper.c
+++ b/src/vfs/readonly_wrapper.c
@@ -17,7 +17,7 @@
 static char* vfs_ro_repr(VFSNode *node) {
 	char *wrapped_repr = vfs_node_repr(WRAPPED(node), false);
 	char *repr = strjoin("read-only view of ", wrapped_repr, NULL);
-	free(wrapped_repr);
+	mem_free(wrapped_repr);
 	return repr;
 }
 

--- a/src/vfs/setup.h
+++ b/src/vfs/setup.h
@@ -25,7 +25,7 @@ void vfs_setup(CallChain onready);
 static inline void vfs_setup_onsync_done(CallChainResult ccr) {
 	CallChain *next = ccr.ctx;
 	run_call_chain(next, NULL);
-	free(next);
+	mem_free(next);
 }
 
 static inline void vfs_setup_res_syspath(const char *res_path) {

--- a/src/vfs/setup_generic.c
+++ b/src/vfs/setup_generic.c
@@ -108,8 +108,8 @@ void vfs_setup(CallChain next) {
 		log_warn("%s", vfs_get_error());
 	}
 
-	free(local_res_path);
-	free(cache_path_allocated);
+	mem_free(local_res_path);
+	mem_free(cache_path_allocated);
 
 	// set up the final "res" union and get rid of the temporaries
 

--- a/src/vfs/syspath_posix.c
+++ b/src/vfs/syspath_posix.c
@@ -23,7 +23,7 @@ char *vfs_syspath_separators = "/";
 static void vfs_syspath_init_internal(VFSNode *node, char *path);
 
 static void vfs_syspath_free(VFSNode *node) {
-	free(node->_path_);
+	mem_free(node->_path_);
 }
 
 static VFSInfo vfs_syspath_query(VFSNode *node) {
@@ -121,7 +121,7 @@ static bool vfs_syspath_mkdir(VFSNode *node, const char *subdir) {
 		vfs_set_error("Can't create directory %s (errno: %i)", p, errno);
 	}
 
-	free(p);
+	mem_free(p);
 	return ok;
 }
 

--- a/src/vfs/union.c
+++ b/src/vfs/union.c
@@ -19,7 +19,7 @@ static void* vfs_union_delete_callback(List **list, List *elem, void *arg) {
 	ListContainer *c = (ListContainer*)elem;
 	VFSNode *n = c->data;
 	vfs_decref(n);
-	free(list_unlink(list, elem));
+	mem_free(list_unlink(list, elem));
 	return NULL;
 }
 
@@ -90,7 +90,7 @@ static const char* vfs_union_iter(VFSNode *node, void **opaque) {
 	const char *r = NULL;
 
 	if(!i) {
-		i = malloc(sizeof(VFSUnionIterData));
+		i = ALLOC(typeof(*i));
 		i->current = node->_members_;
 		i->opaque = NULL;
 		ht_create(&i->visited);
@@ -124,7 +124,7 @@ static void vfs_union_iter_stop(VFSNode *node, void **opaque) {
 
 	if(i) {
 		ht_destroy(&i->visited);
-		free(i);
+		mem_free(i);
 	}
 
 	*opaque = NULL;
@@ -147,7 +147,7 @@ static bool vfs_union_mount_internal(VFSNode *unode, const char *mountpoint, VFS
 		if(seterror) {
 			char *r = vfs_node_repr(mountee, true);
 			vfs_set_error("Mountee doesn't represent a usable resource: %s", r);
-			free(r);
+			mem_free(r);
 		}
 
 		return false;
@@ -156,7 +156,7 @@ static bool vfs_union_mount_internal(VFSNode *unode, const char *mountpoint, VFS
 	if(seterror && !info.is_dir) {
 		char *r = vfs_node_repr(mountee, true);
 		vfs_set_error("Mountee is not a directory: %s", r);
-		free(r);
+		mem_free(r);
 		return false;
 	}
 
@@ -194,7 +194,7 @@ static char* vfs_union_repr(VFSNode *node) {
 		VFSNode *n = c->data;
 
 		strappend(&mlist, r = vfs_node_repr(n, false));
-		free(r);
+		mem_free(r);
 
 		if(c->next) {
 			strappend(&mlist, ", ");

--- a/src/vfs/vdir.c
+++ b/src/vfs/vdir.c
@@ -41,7 +41,7 @@ static const char* vfs_vdir_iter(VFSNode *vdir, void **opaque) {
 	ht_str2ptr_iter_t *iter = *opaque;
 
 	if(!iter) {
-		iter = *opaque = calloc(1, sizeof(*iter));
+		iter = *opaque = ALLOC(typeof(*iter));
 		ht_iter_begin(VDIR_TABLE(vdir), iter);
 	} else {
 		ht_iter_next(iter);
@@ -53,7 +53,7 @@ static const char* vfs_vdir_iter(VFSNode *vdir, void **opaque) {
 static void vfs_vdir_iter_stop(VFSNode *vdir, void **opaque) {
 	if(*opaque) {
 		ht_iter_end((ht_str2ptr_iter_t*)*opaque);
-		free(*opaque);
+		mem_free(*opaque);
 		*opaque = NULL;
 	}
 }
@@ -77,7 +77,7 @@ static void vfs_vdir_free(VFSNode *vdir) {
 
 	ht_iter_end(&iter);
 	ht_destroy(ht);
-	free(ht);
+	mem_free(ht);
 }
 
 static bool vfs_vdir_mount(VFSNode *vdir, const char *mountpoint, VFSNode *subtree) {

--- a/src/video.c
+++ b/src/video.c
@@ -560,7 +560,7 @@ static void *video_screenshot_task(void *arg) {
 	if(LIKELY(ok)) {
 		char *syspath = vfs_repr(tdata->dest_path, true);
 		log_info("Saved screenshot as %s", syspath);
-		free(syspath);
+		mem_free(syspath);
 	}
 
 	return NULL;
@@ -568,9 +568,9 @@ static void *video_screenshot_task(void *arg) {
 
 static void video_screenshot_free_task_data(void *arg) {
 	ScreenshotTaskData *tdata = arg;
-	free(tdata->image.data.untyped);
-	free(tdata->dest_path);
-	free(tdata);
+	mem_free(tdata->image.data.untyped);
+	mem_free(tdata->dest_path);
+	mem_free(tdata);
 }
 
 void video_take_screenshot(void) {

--- a/src/video_postprocess.c
+++ b/src/video_postprocess.c
@@ -29,9 +29,10 @@ VideoPostProcess *video_postprocess_init(void) {
 		return NULL;
 	}
 
-	VideoPostProcess *vpp = calloc(1, sizeof(*vpp));
-	vpp->pp_pipeline = pps;
-	vpp->mfb_group = fbmgr_group_create();
+	auto vpp = ALLOC(VideoPostProcess, {
+		.pp_pipeline = pps,
+		.mfb_group = fbmgr_group_create(),
+	});
 
 	FBAttachmentConfig a = { 0 };
 	a.attachment = FRAMEBUFFER_ATTACH_COLOR0;
@@ -56,7 +57,7 @@ VideoPostProcess *video_postprocess_init(void) {
 void video_postprocess_shutdown(VideoPostProcess *vpp) {
 	if(vpp) {
 		fbmgr_group_destroy(vpp->mfb_group);
-		free(vpp);
+		mem_free(vpp);
 	}
 }
 


### PR DESCRIPTION
Introduces wrappers around memory allocation functions in `memory.h` that should be used instead of the standard C ones.

These never return NULL and, with the exception of `mem_realloc()`, zero-initialize the allocated memory like `calloc()` does.

All allocations made with the memory.h API must be deallocated with `mem_free()`. Although standard `free()` will work on some platforms, it's not portable (currently it won't work on Windows). Likewise, `mem_free()` must not be used to free foreign allocations.

The standard C allocation functions are now diagnosed as deprecated. They are, however, available with the `libc_` prefix in case interfacing with foreign APIs is required. So far they are only used to implement `memory.h`.

Perhaps the most important change is the introduction of the `ALLOC()`, `ALLOC_ARRAY()`, and `ALLOC_FLEX()` macros. They take a type as a parameter, and allocate enough memory with the correct alignment for that type. That includes overaligned types as well. In most circumstances you should prefer to use these macros. See the `memory.h` header for some usage examples.