### PR TITLE
use strncmp for strendswith

### DIFF
--- a/src/util/stringops.c
+++ b/src/util/stringops.c
@@ -19,11 +19,7 @@ bool strendswith(const char *s, const char *e) {
 	if(le > ls)
 		return false;
 
-	int i; for(i = 0; i < le; ++i)
-	if(s[ls-i-1] != e[le-i-1])
-		return false;
-
-	return true;
+	return !strncmp(s+ls-le, e, le);
 }
 
 bool strstartswith(const char *s, const char *p) {


### PR DESCRIPTION
Minor change, doesn't really fix anything.

Similar to strstartswith, it may be better to use strncmp instead of looping through every char in a string.