### PR TITLE
Resource system partial refactor

### DIFF
--- a/src/audio/audio.c
+++ b/src/audio/audio.c
@@ -392,12 +392,12 @@ static void *update_sounds_callback(const char *name, Resource *res, void *arg) 
 }
 
 void reset_all_sfx(void) {
-	resource_for_each(RES_SFX, update_sounds_callback, (void*)true);
+	res_for_each(RES_SFX, update_sounds_callback, (void*)true);
 	list_foreach(&audio.sound_queue, discard_enqueued_sound, NULL);
 }
 
 void update_all_sfx(void) {
-	resource_for_each(RES_SFX, update_sounds_callback, (void*)false);
+	res_for_each(RES_SFX, update_sounds_callback, (void*)false);
 
 	for(struct enqueued_sound *s = audio.sound_queue, *next; s; s = next) {
 		next = (struct enqueued_sound*)s->next;

--- a/src/boss.c
+++ b/src/boss.c
@@ -1617,7 +1617,7 @@ void _begin_boss_attack_task(const BossAttackTaskArgs *args) {
 }
 
 void boss_preload(void) {
-	preload_resources(RES_SFX, RESF_OPTIONAL,
+	res_preload_multi(RES_SFX, RESF_OPTIONAL,
 		"charge_generic",
 		"charge_extra",
 		"spellend",
@@ -1627,7 +1627,7 @@ void boss_preload(void) {
 		"bossdeath",
 	NULL);
 
-	preload_resources(RES_SPRITE, RESF_DEFAULT,
+	res_preload_multi(RES_SPRITE, RESF_DEFAULT,
 		"boss_circle",
 		"boss_indicator",
 		"boss_spellcircle0",
@@ -1636,7 +1636,7 @@ void boss_preload(void) {
 		"spell",
 	NULL);
 
-	preload_resources(RES_SHADER_PROGRAM, RESF_DEFAULT,
+	res_preload_multi(RES_SHADER_PROGRAM, RESF_DEFAULT,
 		"boss_zoom",
 		"boss_death",
 		"spellcard_intro",
@@ -1650,7 +1650,7 @@ void boss_preload(void) {
 	StageInfo *s = global.stage;
 
 	if(s->type != STAGE_SPELL || s->spell->type == AT_ExtraSpell) {
-		preload_resources(RES_TEXTURE, RESF_DEFAULT,
+		res_preload_multi(RES_TEXTURE, RESF_DEFAULT,
 			"stage3/wspellclouds",
 			"stage4/kurumibg2",
 		NULL);

--- a/src/boss.c
+++ b/src/boss.c
@@ -1616,8 +1616,8 @@ void _begin_boss_attack_task(const BossAttackTaskArgs *args) {
 	WAIT_EVENT_OR_DIE(&args->attack->events.started);
 }
 
-void boss_preload(void) {
-	res_preload_multi(RES_SFX, RESF_OPTIONAL,
+void boss_preload(ResourceGroup *rg) {
+	res_group_preload(rg, RES_SFX, RESF_OPTIONAL,
 		"charge_generic",
 		"charge_extra",
 		"spellend",
@@ -1627,7 +1627,7 @@ void boss_preload(void) {
 		"bossdeath",
 	NULL);
 
-	res_preload_multi(RES_SPRITE, RESF_DEFAULT,
+	res_group_preload(rg, RES_SPRITE, RESF_DEFAULT,
 		"boss_circle",
 		"boss_indicator",
 		"boss_spellcircle0",
@@ -1636,7 +1636,7 @@ void boss_preload(void) {
 		"spell",
 	NULL);
 
-	res_preload_multi(RES_SHADER_PROGRAM, RESF_DEFAULT,
+	res_group_preload(rg, RES_SHADER_PROGRAM, RESF_DEFAULT,
 		"boss_zoom",
 		"boss_death",
 		"spellcard_intro",
@@ -1650,7 +1650,7 @@ void boss_preload(void) {
 	StageInfo *s = global.stage;
 
 	if(s->type != STAGE_SPELL || s->spell->type == AT_ExtraSpell) {
-		res_preload_multi(RES_TEXTURE, RESF_DEFAULT,
+		res_group_preload(rg, RES_TEXTURE, RESF_DEFAULT,
 			"stage3/wspellclouds",
 			"stage4/kurumibg2",
 		NULL);

--- a/src/boss.h
+++ b/src/boss.h
@@ -16,6 +16,7 @@
 #include "projectile.h"
 #include "entity.h"
 #include "coroutine.h"
+#include "resource/resource.h"
 
 #define BOSS_HURT_RADIUS 16
 #define BOSS_MAX_ATTACKS 24
@@ -226,7 +227,7 @@ void boss_death(Boss **boss) attr_nonnull(1);
 
 void boss_reset_motion(Boss *boss) attr_nonnull(1);
 
-void boss_preload(void);
+void boss_preload(ResourceGroup *rg);
 
 #define BOSS_DEFAULT_SPAWN_POS (VIEWPORT_W * 0.5 - I * VIEWPORT_H * 0.5)
 #define BOSS_DEFAULT_GO_POS (VIEWPORT_W * 0.5 + 200.0*I)

--- a/src/credits.c
+++ b/src/credits.c
@@ -554,22 +554,22 @@ static void credits_free(void) {
 	stage3d_shutdown(&stage_3d_context);
 }
 
-void credits_preload(void) {
-	res_preload(RES_BGM, "credits", RESF_OPTIONAL);
-	res_preload_multi(RES_SHADER_PROGRAM, RESF_DEFAULT,
+void credits_preload(ResourceGroup *rg) {
+	res_group_preload(rg, RES_BGM, RESF_OPTIONAL, "credits", NULL);
+	res_group_preload(rg, RES_SHADER_PROGRAM, RESF_DEFAULT,
 		"pbr",
 		"envmap_reflect",
 		"stage6_sky",
 	NULL);
-	res_preload(RES_SPRITE, "kyoukkuri", RESF_DEFAULT);
-	res_preload_multi(RES_TEXTURE, RESF_DEFAULT,
+	res_group_preload(rg, RES_SPRITE, RESF_DEFAULT, "kyoukkuri", NULL);
+	res_group_preload(rg, RES_TEXTURE, RESF_DEFAULT,
 		"loading",  // for transition
 		"stage6/sky",
 	NULL);
-	res_preload_multi(RES_MATERIAL, RESF_DEFAULT,
+	res_group_preload(rg, RES_MATERIAL, RESF_DEFAULT,
 		"credits/tower",
 	NULL);
-	res_preload_multi(RES_MODEL, RESF_DEFAULT,
+	res_group_preload(rg, RES_MODEL, RESF_DEFAULT,
 		"credits/metal_columns",
 		"credits/tower",
 		"cube",
@@ -603,7 +603,6 @@ static void credits_end_loop(void *ctx) {
 }
 
 void credits_enter(CallChain next) {
-	credits_preload();
 	credits_init();
 	credits.cc = next;
 	eventloop_enter(&credits, credits_logic_frame, credits_render_frame, credits_end_loop, FPS);

--- a/src/credits.c
+++ b/src/credits.c
@@ -555,21 +555,21 @@ static void credits_free(void) {
 }
 
 void credits_preload(void) {
-	preload_resource(RES_BGM, "credits", RESF_OPTIONAL);
-	preload_resources(RES_SHADER_PROGRAM, RESF_DEFAULT,
+	res_preload(RES_BGM, "credits", RESF_OPTIONAL);
+	res_preload_multi(RES_SHADER_PROGRAM, RESF_DEFAULT,
 		"pbr",
 		"envmap_reflect",
 		"stage6_sky",
 	NULL);
-	preload_resource(RES_SPRITE, "kyoukkuri", RESF_DEFAULT);
-	preload_resources(RES_TEXTURE, RESF_DEFAULT,
+	res_preload(RES_SPRITE, "kyoukkuri", RESF_DEFAULT);
+	res_preload_multi(RES_TEXTURE, RESF_DEFAULT,
 		"loading",  // for transition
 		"stage6/sky",
 	NULL);
-	preload_resources(RES_MATERIAL, RESF_DEFAULT,
+	res_preload_multi(RES_MATERIAL, RESF_DEFAULT,
 		"credits/tower",
 	NULL);
-	preload_resources(RES_MODEL, RESF_DEFAULT,
+	res_preload_multi(RES_MODEL, RESF_DEFAULT,
 		"credits/metal_columns",
 		"credits/tower",
 		"cube",

--- a/src/credits.h
+++ b/src/credits.h
@@ -10,6 +10,7 @@
 #include "taisei.h"
 
 #include "util/callchain.h"
+#include "resource/resource.h"
 
 void credits_enter(CallChain next);
-void credits_preload(void);
+void credits_preload(ResourceGroup *rg);

--- a/src/cutscenes/cutscene.c
+++ b/src/cutscenes/cutscene.c
@@ -409,7 +409,7 @@ static void cutscene_end_loop(void *ctx) {
 static void cutscene_preload(const CutscenePhase phases[]) {
 	for(const CutscenePhase *p = phases; p->background; ++p) {
 		if(*p->background) {
-			preload_resource(RES_TEXTURE, p->background, RESF_DEFAULT);
+			res_preload(RES_TEXTURE, p->background, RESF_DEFAULT);
 		}
 	}
 }

--- a/src/dialog.c
+++ b/src/dialog.c
@@ -386,6 +386,6 @@ bool dialog_is_active(Dialog *d) {
 	return d && d->state != DIALOG_STATE_FADEOUT;
 }
 
-void dialog_preload(void) {
-	res_preload(RES_SHADER_PROGRAM, "text_dialog", RESF_DEFAULT);
+void dialog_preload(ResourceGroup *rg) {
+	res_group_preload(rg, RES_SHADER_PROGRAM, RESF_DEFAULT, "text_dialog", NULL);
 }

--- a/src/dialog.c
+++ b/src/dialog.c
@@ -387,5 +387,5 @@ bool dialog_is_active(Dialog *d) {
 }
 
 void dialog_preload(void) {
-	preload_resource(RES_SHADER_PROGRAM, "text_dialog", RESF_DEFAULT);
+	res_preload(RES_SHADER_PROGRAM, "text_dialog", RESF_DEFAULT);
 }

--- a/src/dialog.h
+++ b/src/dialog.h
@@ -10,6 +10,7 @@
 #include "taisei.h"
 
 #include "color.h"
+#include "resource/resource.h"
 #include "resource/sprite.h"
 #include "coroutine.h"
 
@@ -130,6 +131,6 @@ bool dialog_page(Dialog *d)
 
 bool dialog_is_active(Dialog *d);
 
-void dialog_preload(void);
+void dialog_preload(ResourceGroup *rg);
 
 #include "dialog/dialog_interface.h"

--- a/src/dialog/dialog_interface.h
+++ b/src/dialog/dialog_interface.h
@@ -10,6 +10,7 @@
 #include "taisei.h"
 
 #include "dialog.h"
+#include "resource/resource.h"
 
 
 #define DIALOG_SCRIPTS \
@@ -35,6 +36,7 @@
 		_name##DialogEvents **out_events; \
 		int called_for_preload; \
 		ResourceFlags preload_rflags; \
+		ResourceGroup *preload_group; \
 	});
 
 #define WITHOUT_EVENTS(_name) \

--- a/src/dialog/dialog_macros.h
+++ b/src/dialog/dialog_macros.h
@@ -57,11 +57,11 @@
 	if(ARGS.called_for_preload)
 
 #define PRELOAD_CHAR(name) \
-	portrait_preload_base_sprite(#name, NULL, ARGS.preload_rflags); \
+	portrait_preload_base_sprite(ARGS.preload_group, #name, NULL, ARGS.preload_rflags); \
 	for(const char *_charname = #name; _charname; _charname = NULL)
 
 #define PRELOAD_VARIANT(variant) \
-	portrait_preload_base_sprite(_charname, #variant, ARGS.preload_rflags)
+	portrait_preload_base_sprite(ARGS.preload_group, _charname, #variant, ARGS.preload_rflags)
 
 #define PRELOAD_FACE(face) \
-	portrait_preload_face_sprite(_charname, #face, ARGS.preload_rflags)
+	portrait_preload_face_sprite(ARGS.preload_group, _charname, #face, ARGS.preload_rflags)

--- a/src/difficulty.c
+++ b/src/difficulty.c
@@ -56,6 +56,6 @@ const Color *difficulty_color(Difficulty diff) {
 
 void difficulty_preload(void) {
 	for(Difficulty diff = D_Easy; diff < NUM_SELECTABLE_DIFFICULTIES + D_Easy; ++diff) {
-		preload_resource(RES_SPRITE, difficulty_sprite_name(diff), RESF_PERMANENT);
+		res_preload(RES_SPRITE, difficulty_sprite_name(diff), RESF_PERMANENT);
 	}
 }

--- a/src/difficulty.c
+++ b/src/difficulty.c
@@ -54,8 +54,8 @@ const Color *difficulty_color(Difficulty diff) {
 	return d ? &d->color : &unknown_clr;
 }
 
-void difficulty_preload(void) {
+void difficulty_preload(ResourceGroup *rg) {
 	for(Difficulty diff = D_Easy; diff < NUM_SELECTABLE_DIFFICULTIES + D_Easy; ++diff) {
-		res_preload(RES_SPRITE, difficulty_sprite_name(diff), RESF_PERMANENT);
+		res_group_preload(rg, RES_SPRITE, RESF_DEFAULT, difficulty_sprite_name(diff), NULL);
 	}
 }

--- a/src/difficulty.h
+++ b/src/difficulty.h
@@ -10,6 +10,7 @@
 #include "taisei.h"
 
 #include "color.h"
+#include "resource/resource.h"
 
 typedef enum {
 	D_Any = 0,
@@ -31,7 +32,7 @@ const char *difficulty_sprite_name(Difficulty diff)
 const Color *difficulty_color(Difficulty diff)
 	attr_pure attr_returns_nonnull;
 
-void difficulty_preload(void);
+void difficulty_preload(ResourceGroup *rg);
 
 #define difficulty_value(easy, normal, hard, lunatic) ({ \
     typeof((easy)+(normal)+(hard)+(lunatic)) val; \

--- a/src/enemy.c
+++ b/src/enemy.c
@@ -345,7 +345,7 @@ void process_enemies(EnemyList *enemies) {
 }
 
 void enemies_preload(void) {
-	preload_resources(RES_ANIM, RESF_DEFAULT,
+	res_preload_multi(RES_ANIM, RESF_DEFAULT,
 		"enemy/fairy_blue",
 		"enemy/fairy_red",
 		"enemy/bigfairy",
@@ -353,14 +353,14 @@ void enemies_preload(void) {
 		"enemy/superfairy",
 	NULL);
 
-	preload_resources(RES_SPRITE, RESF_DEFAULT,
+	res_preload_multi(RES_SPRITE, RESF_DEFAULT,
 		"fairy_circle",
 		"fairy_circle_red",
 		"fairy_circle_big_and_mean",
 		"enemy/swirl",
 	NULL);
 
-	preload_resources(RES_SFX, RESF_OPTIONAL,
+	res_preload_multi(RES_SFX, RESF_OPTIONAL,
 		"enemydeath",
 	NULL);
 }

--- a/src/enemy.c
+++ b/src/enemy.c
@@ -344,8 +344,8 @@ void process_enemies(EnemyList *enemies) {
 	}
 }
 
-void enemies_preload(void) {
-	res_preload_multi(RES_ANIM, RESF_DEFAULT,
+void enemies_preload(ResourceGroup *rg) {
+	res_group_preload(rg, RES_ANIM, RESF_DEFAULT,
 		"enemy/fairy_blue",
 		"enemy/fairy_red",
 		"enemy/bigfairy",
@@ -353,14 +353,14 @@ void enemies_preload(void) {
 		"enemy/superfairy",
 	NULL);
 
-	res_preload_multi(RES_SPRITE, RESF_DEFAULT,
+	res_group_preload(rg, RES_SPRITE, RESF_DEFAULT,
 		"fairy_circle",
 		"fairy_circle_red",
 		"fairy_circle_big_and_mean",
 		"enemy/swirl",
 	NULL);
 
-	res_preload_multi(RES_SFX, RESF_OPTIONAL,
+	res_group_preload(rg, RES_SFX, RESF_OPTIONAL,
 		"enemydeath",
 	NULL);
 }

--- a/src/enemy.h
+++ b/src/enemy.h
@@ -15,6 +15,7 @@
 #include "entity.h"
 #include "coroutine.h"
 #include "move.h"
+#include "resource/resource.h"
 
 #ifdef DEBUG
 	#define ENEMY_DEBUG
@@ -132,4 +133,4 @@ cmplx enemy_visual_pos(Enemy *enemy);
 void enemy_kill(Enemy *enemy);
 void enemy_kill_all(EnemyList *enemies);
 
-void enemies_preload(void);
+void enemies_preload(ResourceGroup *rg);

--- a/src/events.c
+++ b/src/events.c
@@ -528,7 +528,7 @@ static bool events_handler_hotkeys(SDL_Event *event, void *arg) {
 	}
 
 	if(scan == config_get_int(CONFIG_KEY_RELOAD_RESOURCES)) {
-		reload_all_resources();
+		res_reload_all();
 		return true;
 	}
 

--- a/src/item.c
+++ b/src/item.c
@@ -387,16 +387,16 @@ void spawn_and_collect_items(cmplx pos, float collect_value, SpawnItemsArgs grou
 	spawn_items_internal(pos, collect_value, groups);
 }
 
-void items_preload(void) {
+void items_preload(ResourceGroup *rg) {
 	for(ItemType i = ITEM_FIRST; i <= ITEM_LAST; ++i) {
-		res_preload(RES_SPRITE, item_sprite_name(i), RESF_PERMANENT);
+		res_group_preload(rg, RES_SPRITE, 0, item_sprite_name(i), NULL);
 		const char *indicator = item_indicator_sprite_name(i);
 		if(indicator != NULL) {
-			res_preload(RES_SPRITE, indicator, RESF_PERMANENT);
+			res_group_preload(rg, RES_SPRITE, 0, indicator, NULL);
 		}
 	}
 
-	res_preload_multi(RES_SFX, RESF_OPTIONAL,
+	res_group_preload(rg, RES_SFX, RESF_OPTIONAL,
 		"item_generic",
 	NULL);
 }

--- a/src/item.c
+++ b/src/item.c
@@ -389,14 +389,14 @@ void spawn_and_collect_items(cmplx pos, float collect_value, SpawnItemsArgs grou
 
 void items_preload(void) {
 	for(ItemType i = ITEM_FIRST; i <= ITEM_LAST; ++i) {
-		preload_resource(RES_SPRITE, item_sprite_name(i), RESF_PERMANENT);
+		res_preload(RES_SPRITE, item_sprite_name(i), RESF_PERMANENT);
 		const char *indicator = item_indicator_sprite_name(i);
 		if(indicator != NULL) {
-			preload_resource(RES_SPRITE, indicator, RESF_PERMANENT);
+			res_preload(RES_SPRITE, indicator, RESF_PERMANENT);
 		}
 	}
 
-	preload_resources(RES_SFX, RESF_OPTIONAL,
+	res_preload_multi(RES_SFX, RESF_OPTIONAL,
 		"item_generic",
 	NULL);
 }

--- a/src/item.h
+++ b/src/item.h
@@ -10,6 +10,7 @@
 #include "taisei.h"
 
 #include "util.h"
+#include "resource/resource.h"
 #include "resource/texture.h"
 #include "objectpool.h"
 #include "entity.h"
@@ -94,7 +95,7 @@ void spawn_and_collect_items(cmplx pos, float collect_value, SpawnItemsArgs grou
 bool collect_item(Item *item, float value);
 void collect_all_items(float value);
 
-void items_preload(void);
+void items_preload(ResourceGroup *rg);
 
 #define POWER_VALUE 5
 #define POWER_VALUE_MINI 1

--- a/src/lasers/draw.c
+++ b/src/lasers/draw.c
@@ -250,8 +250,8 @@ static void create_pass2_resources(void) {
 	ldraw.pass2.quad.vertex_array = va;
 }
 
-void laserdraw_preload(void) {
-	res_preload_multi(RES_SHADER_PROGRAM, RESF_DEFAULT,
+void laserdraw_preload(ResourceGroup *rg) {
+	res_group_preload(rg, RES_SHADER_PROGRAM, RESF_DEFAULT,
 		"lasers/sdf_apply",
 		"lasers/sdf_generate",
 	NULL);

--- a/src/lasers/draw.c
+++ b/src/lasers/draw.c
@@ -251,7 +251,7 @@ static void create_pass2_resources(void) {
 }
 
 void laserdraw_preload(void) {
-	preload_resources(RES_SHADER_PROGRAM, RESF_DEFAULT,
+	res_preload_multi(RES_SHADER_PROGRAM, RESF_DEFAULT,
 		"lasers/sdf_apply",
 		"lasers/sdf_generate",
 	NULL);

--- a/src/lasers/draw.h
+++ b/src/lasers/draw.h
@@ -10,8 +10,9 @@
 #include "taisei.h"
 
 #include "entity.h"
+#include "resource/resource.h"
 
-void laserdraw_preload(void);
+void laserdraw_preload(ResourceGroup *rg);
 void laserdraw_init(void);
 void laserdraw_shutdown(void);
 

--- a/src/main.c
+++ b/src/main.c
@@ -48,7 +48,7 @@ static void taisei_shutdown(void) {
 	progress_unload();
 	stage_objpools_shutdown();
 	gamemode_shutdown();
-	shutdown_resources();
+	res_shutdown();
 	taskmgr_global_shutdown();
 	audio_shutdown();
 	video_shutdown();
@@ -373,13 +373,13 @@ static void main_post_vfsinit(CallChainResult ccr) {
 	events_init();
 	video_init();
 	filewatch_init();
-	init_resources();
+	res_init();
 	r_post_init();
 	draw_loading_screen();
 	dynstage_init_monitoring();
 
 	audio_init();
-	load_resources();
+	res_post_init();
 	gamepad_init();
 	progress_load();
 	video_post_init();

--- a/src/menu/charprofile.c
+++ b/src/menu/charprofile.c
@@ -359,16 +359,16 @@ static bool charprofile_input_handler(SDL_Event *event, void *arg) {
 
 }
 
-void preload_charprofile_menu(void) {
+void preload_charprofile_menu(ResourceGroup *rg) {
 	for(int i = 0; i < NUM_PROFILES-1; i++) {
 		for(int f = 0; f < NUM_FACES; f++) {
 			if(!profiles[i].faces[f]) {
 				break;
 			}
-			portrait_preload_face_sprite(profiles[i].name, profiles[i].faces[f], RESF_PERMANENT);
+			portrait_preload_face_sprite(rg, profiles[i].name, profiles[i].faces[f], RESF_DEFAULT);
 		}
-		portrait_preload_base_sprite(profiles[i].name, NULL, RESF_PERMANENT);
-		res_preload(RES_TEXTURE, profiles[i].background, RESF_PERMANENT);
+		portrait_preload_base_sprite(rg, profiles[i].name, NULL, RESF_DEFAULT);
+		res_group_preload(rg, RES_TEXTURE, RESF_DEFAULT, profiles[i].background, NULL);
 	}
 };
 
@@ -381,8 +381,6 @@ static void charprofile_input(MenuData *m) {
 
 MenuData *create_charprofile_menu(void) {
 	MenuData *m = alloc_menu();
-
-	preload_charprofile_menu();
 
 	m->input = charprofile_input;
 	m->draw = charprofile_draw;

--- a/src/menu/charprofile.c
+++ b/src/menu/charprofile.c
@@ -368,7 +368,7 @@ void preload_charprofile_menu(void) {
 			portrait_preload_face_sprite(profiles[i].name, profiles[i].faces[f], RESF_PERMANENT);
 		}
 		portrait_preload_base_sprite(profiles[i].name, NULL, RESF_PERMANENT);
-		preload_resource(RES_TEXTURE, profiles[i].background, RESF_PERMANENT);
+		res_preload(RES_TEXTURE, profiles[i].background, RESF_PERMANENT);
 	}
 };
 

--- a/src/menu/charprofile.h
+++ b/src/menu/charprofile.h
@@ -10,7 +10,8 @@
 #include "taisei.h"
 
 #include "menu.h"
+#include "resource/resource.h"
 
-void preload_charprofile_menu(void);
+void preload_charprofile_menu(ResourceGroup *rg);
 
 MenuData *create_charprofile_menu(void);

--- a/src/menu/charselect.c
+++ b/src/menu/charselect.c
@@ -382,12 +382,12 @@ void preload_char_menu(void) {
 	for(int i = 0; i < NUM_CHARACTERS; ++i) {
 		PlayerCharacter *pchar = plrchar_get(i);
 		portrait_preload_base_sprite(pchar->lower_name, NULL, RESF_PERMANENT);
-		preload_resource(RES_TEXTURE, pchar->menu_texture_name, RESF_PERMANENT);
+		res_preload(RES_TEXTURE, pchar->menu_texture_name, RESF_PERMANENT);
 	}
 
 	char *p = (char*)facedefs;
 
 	for(int i = 0; i < sizeof(facedefs) / FACENAME_LEN; ++i) {
-		preload_resource(RES_SPRITE, p + i * FACENAME_LEN, RESF_PERMANENT);
+		res_preload(RES_SPRITE, p + i * FACENAME_LEN, RESF_PERMANENT);
 	}
 }

--- a/src/menu/charselect.c
+++ b/src/menu/charselect.c
@@ -378,16 +378,16 @@ static void char_menu_input(MenuData *menu) {
 	}, EFLAG_MENU);
 }
 
-void preload_char_menu(void) {
+void preload_char_menu(ResourceGroup *rg) {
 	for(int i = 0; i < NUM_CHARACTERS; ++i) {
 		PlayerCharacter *pchar = plrchar_get(i);
-		portrait_preload_base_sprite(pchar->lower_name, NULL, RESF_PERMANENT);
-		res_preload(RES_TEXTURE, pchar->menu_texture_name, RESF_PERMANENT);
+		portrait_preload_base_sprite(rg, pchar->lower_name, NULL, RESF_DEFAULT);
+		res_group_preload(rg, RES_TEXTURE, RESF_DEFAULT, pchar->menu_texture_name, NULL);
 	}
 
 	char *p = (char*)facedefs;
 
 	for(int i = 0; i < sizeof(facedefs) / FACENAME_LEN; ++i) {
-		res_preload(RES_SPRITE, p + i * FACENAME_LEN, RESF_PERMANENT);
+		res_group_preload(rg, RES_SPRITE, RESF_DEFAULT, p + i * FACENAME_LEN, NULL);
 	}
 }

--- a/src/menu/charselect.h
+++ b/src/menu/charselect.h
@@ -10,7 +10,8 @@
 #include "taisei.h"
 
 #include "menu.h"
+#include "resource/resource.h"
 
-MenuData* create_char_menu(void);
+MenuData *create_char_menu(void);
 void draw_char_menu(MenuData *menu);
-void preload_char_menu(void);
+void preload_char_menu(ResourceGroup *rg);

--- a/src/menu/common.c
+++ b/src/menu/common.c
@@ -185,7 +185,7 @@ static void start_game_do_cleanup(CallChainResult ccr) {
 	replay_reset(&ctx->replay);
 	kill_aux_menus(ctx);
 	mem_free(ctx);
-	free_resources(false);
+	res_unload_all(false);
 	global.gameover = GAMEOVER_NONE;
 	replay_state_deinit(&global.replay.output);
 	main_menu_update_practice_menus();

--- a/src/menu/mainmenu.c
+++ b/src/menu/mainmenu.c
@@ -241,8 +241,8 @@ void draw_main_menu(MenuData *menu) {
 }
 
 void draw_loading_screen(void) {
-	preload_resource(RES_TEXTURE, "loading", RESF_DEFAULT);
-	preload_resource(RES_SHADER_PROGRAM, "text_default", RESF_PERMANENT);
+	res_preload(RES_TEXTURE, "loading", RESF_DEFAULT);
+	res_preload(RES_SHADER_PROGRAM, "text_default", RESF_PERMANENT);
 
 	set_ortho(SCREEN_W, SCREEN_H);
 	fill_screen("loading");
@@ -260,19 +260,19 @@ void draw_loading_screen(void) {
 void menu_preload(void) {
 	difficulty_preload();
 
-	preload_resources(RES_FONT, RESF_PERMANENT,
+	res_preload_multi(RES_FONT, RESF_PERMANENT,
 		"big",
 		"small",
 	NULL);
 
-	preload_resources(RES_TEXTURE, RESF_PERMANENT,
+	res_preload_multi(RES_TEXTURE, RESF_PERMANENT,
 		"abstract_brown",
 		"cell_noise",
 		"stage1/cirnobg",
 		"menu/mainmenubg",
 	NULL);
 
-	preload_resources(RES_SPRITE, RESF_PERMANENT,
+	res_preload_multi(RES_SPRITE, RESF_PERMANENT,
 		"part/smoke",
 		"part/petal",
 		"menu/logo",
@@ -280,18 +280,18 @@ void menu_preload(void) {
 		"star",
 	NULL);
 
-	preload_resources(RES_SHADER_PROGRAM, RESF_PERMANENT,
+	res_preload_multi(RES_SHADER_PROGRAM, RESF_PERMANENT,
 		"mainmenubg",
 		"sprite_circleclipped_indicator",
 	NULL);
 
-	preload_resources(RES_SFX, RESF_PERMANENT | RESF_OPTIONAL,
+	res_preload_multi(RES_SFX, RESF_PERMANENT | RESF_OPTIONAL,
 		"generic_shot",
 		"shot_special1",
 		"hit",
 	NULL);
 
-	preload_resources(RES_BGM, RESF_PERMANENT | RESF_OPTIONAL,
+	res_preload_multi(RES_BGM, RESF_PERMANENT | RESF_OPTIONAL,
 		"menu",
 	NULL);
 

--- a/src/menu/mainmenu.c
+++ b/src/menu/mainmenu.c
@@ -241,8 +241,10 @@ void draw_main_menu(MenuData *menu) {
 }
 
 void draw_loading_screen(void) {
-	res_preload(RES_TEXTURE, "loading", RESF_DEFAULT);
-	res_preload(RES_SHADER_PROGRAM, "text_default", RESF_PERMANENT);
+	ResourceGroup rg;
+	res_group_init(&rg);
+	res_group_preload(&rg, RES_TEXTURE, RESF_DEFAULT, "loading", NULL);
+	res_group_preload(&rg, RES_SHADER_PROGRAM, RESF_DEFAULT, "text_default", NULL);
 
 	set_ortho(SCREEN_W, SCREEN_H);
 	fill_screen("loading");
@@ -255,24 +257,25 @@ void draw_loading_screen(void) {
 	});
 
 	video_swap_buffers();
+	res_group_release(&rg);
 }
 
-void menu_preload(void) {
-	difficulty_preload();
+void menu_preload(ResourceGroup *rg) {
+	difficulty_preload(rg);
 
-	res_preload_multi(RES_FONT, RESF_PERMANENT,
+	res_group_preload(rg, RES_FONT, RESF_DEFAULT,
 		"big",
 		"small",
 	NULL);
 
-	res_preload_multi(RES_TEXTURE, RESF_PERMANENT,
+	res_group_preload(rg, RES_TEXTURE, RESF_DEFAULT,
 		"abstract_brown",
 		"cell_noise",
 		"stage1/cirnobg",
 		"menu/mainmenubg",
 	NULL);
 
-	res_preload_multi(RES_SPRITE, RESF_PERMANENT,
+	res_group_preload(rg, RES_SPRITE, RESF_DEFAULT,
 		"part/smoke",
 		"part/petal",
 		"menu/logo",
@@ -280,20 +283,20 @@ void menu_preload(void) {
 		"star",
 	NULL);
 
-	res_preload_multi(RES_SHADER_PROGRAM, RESF_PERMANENT,
+	res_group_preload(rg, RES_SHADER_PROGRAM, RESF_DEFAULT,
 		"mainmenubg",
 		"sprite_circleclipped_indicator",
 	NULL);
 
-	res_preload_multi(RES_SFX, RESF_PERMANENT | RESF_OPTIONAL,
+	res_group_preload(rg, RES_SFX, RESF_OPTIONAL,
 		"generic_shot",
 		"shot_special1",
 		"hit",
 	NULL);
 
-	res_preload_multi(RES_BGM, RESF_PERMANENT | RESF_OPTIONAL,
+	res_group_preload(rg, RES_BGM, RESF_OPTIONAL,
 		"menu",
 	NULL);
 
-	preload_char_menu();
+	preload_char_menu(rg);
 }

--- a/src/menu/mainmenu.h
+++ b/src/menu/mainmenu.h
@@ -10,10 +10,11 @@
 #include "taisei.h"
 
 #include "menu.h"
+#include "resource/resource.h"
 
-MenuData* create_main_menu(void);
+MenuData *create_main_menu(void);
 void draw_main_menu_bg(MenuData *m, double center_x, double center_y, double R, const char *tex1, const char *tex2);
 void draw_main_menu(MenuData *m);
 void main_menu_update_practice_menus(void);
 void draw_loading_screen(void);
-void menu_preload(void);
+void menu_preload(ResourceGroup *rg);

--- a/src/menu/media.c
+++ b/src/menu/media.c
@@ -35,13 +35,23 @@ static void draw_media_menu(MenuData *m) {
 	draw_menu_list(m, 100, 100, NULL, SCREEN_H, NULL);
 }
 
-MenuData *create_media_menu(void) {
-	MenuData *m = alloc_menu();
+static void end_media_menu(MenuData *m) {
+	res_group_release(m->context);
+	mem_free(m->context);
+}
 
+MenuData *create_media_menu(void) {
+	auto rg = ALLOC(ResourceGroup);
+	res_group_init(rg);
+	preload_charprofile_menu(rg);
+
+	MenuData *m = alloc_menu();
 	m->draw = draw_media_menu;
 	m->logic = animate_menu_list;
 	m->flags = MF_Abortable;
 	m->transition = TransFadeBlack;
+	m->end = end_media_menu;
+	m->context = rg;
 
 	add_menu_entry(m, "Character Profiles", menu_action_enter_charprofileview, NULL);
 	add_menu_entry(m, "Music Room", menu_action_enter_musicroom, NULL);
@@ -53,8 +63,9 @@ MenuData *create_media_menu(void) {
 		++m->cursor;
 	}
 
-	preload_charprofile_menu();
-
 	return m;
 }
 
+void preload_media_menu(ResourceGroup *rg) {
+	preload_charprofile_menu(rg);
+}

--- a/src/menu/media.h
+++ b/src/menu/media.h
@@ -10,5 +10,8 @@
 #include "taisei.h"
 
 #include "menu.h"
+#include "resource/resource.h"
+
+void preload_media_menu(ResourceGroup *rg);
 
 MenuData *create_media_menu(void);

--- a/src/menu/musicroom.c
+++ b/src/menu/musicroom.c
@@ -220,7 +220,7 @@ static void add_bgm(MenuData *m, const char *bgm_name, bool preload) {
 		// FIXME HACK: make this just RESF_OPTIONAL once we have proper refcounting for resources!
 		// Currently without RESF_PERMANENT we segfault after returning from demo playback,
 		// because transient resources get unloaded.
-		preload_resource(RES_BGM, bgm_name, RESF_PERMANENT | RESF_OPTIONAL);
+		res_preload(RES_BGM, bgm_name, RESF_PERMANENT | RESF_OPTIONAL);
 		return;
 	}
 

--- a/src/menu/musicroom.h
+++ b/src/menu/musicroom.h
@@ -11,4 +11,4 @@
 
 #include "menu.h"
 
-MenuData* create_musicroom_menu(void);
+MenuData *create_musicroom_menu(void);

--- a/src/player.c
+++ b/src/player.c
@@ -55,7 +55,6 @@ void player_stage_pre_init(Player *plr) {
 	plr->deathtime = -1;
 	plr->axis_lr = 0;
 	plr->axis_ud = 0;
-	plrmode_preload(plr->mode);
 }
 
 double player_property(Player *plr, PlrProperty prop) {
@@ -1670,26 +1669,26 @@ uint64_t player_next_extralife_threshold(uint64_t step) {
 	return base * (step * step + step + 2) / 2;
 }
 
-void player_preload(void) {
+void player_preload(ResourceGroup *rg) {
 	const int flags = RESF_DEFAULT;
 
-	res_preload_multi(RES_SHADER_PROGRAM, flags,
+	res_group_preload(rg, RES_SHADER_PROGRAM, flags,
 		"circle_distort",
 		"player_death",
 	NULL);
 
-	res_preload_multi(RES_TEXTURE, flags,
+	res_group_preload(rg, RES_TEXTURE, flags,
 		"static",
 	NULL);
 
-	res_preload_multi(RES_SPRITE, flags,
+	res_group_preload(rg, RES_SPRITE, flags,
 		"fairy_circle",
 		"focus",
 		"part/blast_huge_halo",
 		"part/powersurge_field",
 	NULL);
 
-	res_preload_multi(RES_SFX, flags | RESF_OPTIONAL,
+	res_group_preload(rg, RES_SFX, flags | RESF_OPTIONAL,
 		"death",
 		"extra_bomb",
 		"extra_life",

--- a/src/player.c
+++ b/src/player.c
@@ -1673,23 +1673,23 @@ uint64_t player_next_extralife_threshold(uint64_t step) {
 void player_preload(void) {
 	const int flags = RESF_DEFAULT;
 
-	preload_resources(RES_SHADER_PROGRAM, flags,
+	res_preload_multi(RES_SHADER_PROGRAM, flags,
 		"circle_distort",
 		"player_death",
 	NULL);
 
-	preload_resources(RES_TEXTURE, flags,
+	res_preload_multi(RES_TEXTURE, flags,
 		"static",
 	NULL);
 
-	preload_resources(RES_SPRITE, flags,
+	res_preload_multi(RES_SPRITE, flags,
 		"fairy_circle",
 		"focus",
 		"part/blast_huge_halo",
 		"part/powersurge_field",
 	NULL);
 
-	preload_resources(RES_SFX, flags | RESF_OPTIONAL,
+	res_preload_multi(RES_SFX, flags | RESF_OPTIONAL,
 		"death",
 		"extra_bomb",
 		"extra_life",

--- a/src/player.h
+++ b/src/player.h
@@ -9,6 +9,17 @@
 #pragma once
 #include "taisei.h"
 
+#include "util.h"
+#include "enemy.h"
+#include "gamepad.h"
+#include "aniplayer.h"
+#include "stats.h"
+#include "resource/resource.h"
+#include "resource/animation.h"
+#include "entity.h"
+#include "replay/state.h"
+#include "replay/eventcodes.h"
+
 #ifdef DEBUG
 	#define PLR_DPS_STATS
 #endif
@@ -18,16 +29,6 @@
 #else
 	#define IF_PLR_DPS_STATS(...)
 #endif
-
-#include "util.h"
-#include "enemy.h"
-#include "gamepad.h"
-#include "aniplayer.h"
-#include "stats.h"
-#include "resource/animation.h"
-#include "entity.h"
-#include "replay/state.h"
-#include "replay/eventcodes.h"
 
 enum {
 	PLR_MAX_POWER_EFFECTIVE = 400,
@@ -241,7 +242,7 @@ double player_get_bomb_progress(Player *plr);
 
 void player_damage_hook(Player *plr, EntityInterface *target, DamageInfo *dmg);
 
-void player_preload(void);
+void player_preload(ResourceGroup *rg);
 
 // FIXME: where should this be?
 cmplx plrutil_homing_target(cmplx org, cmplx fallback);

--- a/src/plrmodes.c
+++ b/src/plrmodes.c
@@ -47,7 +47,7 @@ void plrchar_preload(PlayerCharacter *pc) {
 
 	char buf[64];
 	plrchar_player_anim_name(pc, sizeof(buf), buf);
-	preload_resource(RES_ANIM, buf, RESF_DEFAULT);
+	res_preload(RES_ANIM, buf, RESF_DEFAULT);
 }
 
 void plrchar_render_bomb_portrait(PlayerCharacter *pc, Sprite *out_spr) {

--- a/src/plrmodes.c
+++ b/src/plrmodes.c
@@ -40,14 +40,14 @@ PlayerCharacter *plrchar_get(CharacterID id) {
 	return pc;
 }
 
-void plrchar_preload(PlayerCharacter *pc) {
+void plrchar_preload(PlayerCharacter *pc, ResourceGroup *rg) {
 	const char *name = pc->lower_name;
-	portrait_preload_base_sprite(name, NULL, RESF_DEFAULT);
-	portrait_preload_face_sprite(name, "normal", RESF_DEFAULT);
+	portrait_preload_base_sprite(rg, name, NULL, RESF_DEFAULT);
+	portrait_preload_face_sprite(rg, name, "normal", RESF_DEFAULT);
 
 	char buf[64];
 	plrchar_player_anim_name(pc, sizeof(buf), buf);
-	res_preload(RES_ANIM, buf, RESF_DEFAULT);
+	res_group_preload(rg, RES_ANIM, RESF_DEFAULT, buf, NULL);
 }
 
 void plrchar_render_bomb_portrait(PlayerCharacter *pc, Sprite *out_spr) {
@@ -132,11 +132,11 @@ PlayerMode *plrmode_parse(const char *name) {
 	return plrmode_find(char_id, shot_id);
 }
 
-void plrmode_preload(PlayerMode *mode) {
+void plrmode_preload(PlayerMode *mode, ResourceGroup *rg) {
 	assert(mode != NULL);
-	plrchar_preload(mode->character);
+	plrchar_preload(mode->character, rg);
 
 	if(mode->procs.preload) {
-		mode->procs.preload();
+		mode->procs.preload(rg);
 	}
 }

--- a/src/plrmodes.h
+++ b/src/plrmodes.h
@@ -74,7 +74,7 @@ typedef struct PlayerCharacter {
 
 typedef void (*PlayerModeInitProc)(Player *plr);
 typedef void (*PlayerModeFreeProc)(Player *plr);
-typedef void (*PlayerModePreloadProc)(void);
+typedef void (*PlayerModePreloadProc)(ResourceGroup *rg);
 typedef double (*PlayerModePropertyProc)(Player *plr, PlrProperty prop);
 
 typedef struct PlayerMode {
@@ -97,7 +97,7 @@ enum {
 };
 
 PlayerCharacter *plrchar_get(CharacterID id);
-void plrchar_preload(PlayerCharacter *pc);
+void plrchar_preload(PlayerCharacter *pc, ResourceGroup *rg);
 void plrchar_render_bomb_portrait(PlayerCharacter *pc, Sprite *out_spr);
 int plrchar_player_anim_name(PlayerCharacter *pc, size_t bufsize, char buf[bufsize]);
 Animation *plrchar_player_anim(PlayerCharacter *pc);
@@ -105,6 +105,6 @@ Animation *plrchar_player_anim(PlayerCharacter *pc);
 PlayerMode *plrmode_find(CharacterID charid, ShotModeID shotid);
 int plrmode_repr(char *out, size_t outsize, PlayerMode *mode, bool internal);
 PlayerMode *plrmode_parse(const char *name);
-void plrmode_preload(PlayerMode *mode);
+void plrmode_preload(PlayerMode *mode, ResourceGroup *rg);
 
 double player_property(Player *plr, PlrProperty prop);

--- a/src/plrmodes/marisa_a.c
+++ b/src/plrmodes/marisa_a.c
@@ -714,23 +714,23 @@ static double marisa_laser_property(Player *plr, PlrProperty prop) {
 	}
 }
 
-static void marisa_laser_preload(void) {
+static void marisa_laser_preload(ResourceGroup *rg) {
 	const int flags = RESF_DEFAULT;
 
-	res_preload_multi(RES_SPRITE, flags,
+	res_group_preload(rg, RES_SPRITE, flags,
 		"proj/marisa",
 		"part/maristar_orbit",
 		"hakkero",
 		"masterspark_ring",
 	NULL);
 
-	res_preload_multi(RES_TEXTURE, flags,
+	res_group_preload(rg, RES_TEXTURE, flags,
 		"marisa_bombbg",
 		"part/marisa_laser0",
 		"part/marisa_laser1",
 	NULL);
 
-	res_preload_multi(RES_SHADER_PROGRAM, flags,
+	res_group_preload(rg, RES_SHADER_PROGRAM, flags,
 		"blur25",
 		"blur5",
 		"marisa_laser",
@@ -739,11 +739,11 @@ static void marisa_laser_preload(void) {
 		"sprite_hakkero",
 	NULL);
 
-	res_preload_multi(RES_ANIM, flags,
+	res_group_preload(rg, RES_ANIM, flags,
 		"fire",
 	NULL);
 
-	res_preload_multi(RES_SFX, flags | RESF_OPTIONAL,
+	res_group_preload(rg, RES_SFX, flags | RESF_OPTIONAL,
 		"bomb_marisa_a",
 	NULL);
 }

--- a/src/plrmodes/marisa_a.c
+++ b/src/plrmodes/marisa_a.c
@@ -717,20 +717,20 @@ static double marisa_laser_property(Player *plr, PlrProperty prop) {
 static void marisa_laser_preload(void) {
 	const int flags = RESF_DEFAULT;
 
-	preload_resources(RES_SPRITE, flags,
+	res_preload_multi(RES_SPRITE, flags,
 		"proj/marisa",
 		"part/maristar_orbit",
 		"hakkero",
 		"masterspark_ring",
 	NULL);
 
-	preload_resources(RES_TEXTURE, flags,
+	res_preload_multi(RES_TEXTURE, flags,
 		"marisa_bombbg",
 		"part/marisa_laser0",
 		"part/marisa_laser1",
 	NULL);
 
-	preload_resources(RES_SHADER_PROGRAM, flags,
+	res_preload_multi(RES_SHADER_PROGRAM, flags,
 		"blur25",
 		"blur5",
 		"marisa_laser",
@@ -739,11 +739,11 @@ static void marisa_laser_preload(void) {
 		"sprite_hakkero",
 	NULL);
 
-	preload_resources(RES_ANIM, flags,
+	res_preload_multi(RES_ANIM, flags,
 		"fire",
 	NULL);
 
-	preload_resources(RES_SFX, flags | RESF_OPTIONAL,
+	res_preload_multi(RES_SFX, flags | RESF_OPTIONAL,
 		"bomb_marisa_a",
 	NULL);
 }

--- a/src/plrmodes/marisa_b.c
+++ b/src/plrmodes/marisa_b.c
@@ -521,10 +521,10 @@ static double marisa_star_property(Player *plr, PlrProperty prop) {
 	}
 }
 
-static void marisa_star_preload(void) {
+static void marisa_star_preload(ResourceGroup *rg) {
 	const int flags = RESF_DEFAULT;
 
-	res_preload_multi(RES_SPRITE, flags,
+	res_group_preload(rg, RES_SPRITE, flags,
 		"hakkero",
 		"masterspark_ring",
 		"part/maristar_orbit",
@@ -533,17 +533,17 @@ static void marisa_star_preload(void) {
 		"proj/maristar",
 	NULL);
 
-	res_preload_multi(RES_TEXTURE, flags,
+	res_group_preload(rg, RES_TEXTURE, flags,
 		"marisa_bombbg",
 	NULL);
 
-	res_preload_multi(RES_SHADER_PROGRAM, flags,
+	res_group_preload(rg, RES_SHADER_PROGRAM, flags,
 		"masterspark",
 		"maristar_bombbg",
 		"sprite_hakkero",
 	NULL);
 
-	res_preload_multi(RES_SFX, flags | RESF_OPTIONAL,
+	res_group_preload(rg, RES_SFX, flags | RESF_OPTIONAL,
 		"bomb_marisa_b",
 	NULL);
 }

--- a/src/plrmodes/marisa_b.c
+++ b/src/plrmodes/marisa_b.c
@@ -524,7 +524,7 @@ static double marisa_star_property(Player *plr, PlrProperty prop) {
 static void marisa_star_preload(void) {
 	const int flags = RESF_DEFAULT;
 
-	preload_resources(RES_SPRITE, flags,
+	res_preload_multi(RES_SPRITE, flags,
 		"hakkero",
 		"masterspark_ring",
 		"part/maristar_orbit",
@@ -533,17 +533,17 @@ static void marisa_star_preload(void) {
 		"proj/maristar",
 	NULL);
 
-	preload_resources(RES_TEXTURE, flags,
+	res_preload_multi(RES_TEXTURE, flags,
 		"marisa_bombbg",
 	NULL);
 
-	preload_resources(RES_SHADER_PROGRAM, flags,
+	res_preload_multi(RES_SHADER_PROGRAM, flags,
 		"masterspark",
 		"maristar_bombbg",
 		"sprite_hakkero",
 	NULL);
 
-	preload_resources(RES_SFX, flags | RESF_OPTIONAL,
+	res_preload_multi(RES_SFX, flags | RESF_OPTIONAL,
 		"bomb_marisa_b",
 	NULL);
 }

--- a/src/plrmodes/reimu_a.c
+++ b/src/plrmodes/reimu_a.c
@@ -45,7 +45,7 @@ DEFINE_ENTITY_TYPE(ReimuASlave, {
 static void reimu_spirit_preload(void) {
 	const int flags = RESF_DEFAULT;
 
-	preload_resources(RES_SPRITE, flags,
+	res_preload_multi(RES_SPRITE, flags,
 		"yinyang",
 		"proj/ofuda",
 		"proj/needle",
@@ -55,16 +55,16 @@ static void reimu_spirit_preload(void) {
 		"part/fantasyseal_impact",
 	NULL);
 
-	preload_resources(RES_TEXTURE, flags,
+	res_preload_multi(RES_TEXTURE, flags,
 		"runes",
 	NULL);
 
-	preload_resources(RES_SHADER_PROGRAM, flags,
+	res_preload_multi(RES_SHADER_PROGRAM, flags,
 		"sprite_yinyang",
 		"reimu_bomb_bg",
 	NULL);
 
-	preload_resources(RES_SFX, flags | RESF_OPTIONAL,
+	res_preload_multi(RES_SFX, flags | RESF_OPTIONAL,
 		"boom",
 		"bomb_reimu_a",
 		"bomb_marisa_b",

--- a/src/plrmodes/reimu_a.c
+++ b/src/plrmodes/reimu_a.c
@@ -42,10 +42,10 @@ DEFINE_ENTITY_TYPE(ReimuASlave, {
 	uint alive;
 });
 
-static void reimu_spirit_preload(void) {
+static void reimu_spirit_preload(ResourceGroup *rg) {
 	const int flags = RESF_DEFAULT;
 
-	res_preload_multi(RES_SPRITE, flags,
+	res_group_preload(rg, RES_SPRITE, flags,
 		"yinyang",
 		"proj/ofuda",
 		"proj/needle",
@@ -55,16 +55,16 @@ static void reimu_spirit_preload(void) {
 		"part/fantasyseal_impact",
 	NULL);
 
-	res_preload_multi(RES_TEXTURE, flags,
+	res_group_preload(rg, RES_TEXTURE, flags,
 		"runes",
 	NULL);
 
-	res_preload_multi(RES_SHADER_PROGRAM, flags,
+	res_group_preload(rg, RES_SHADER_PROGRAM, flags,
 		"sprite_yinyang",
 		"reimu_bomb_bg",
 	NULL);
 
-	res_preload_multi(RES_SFX, flags | RESF_OPTIONAL,
+	res_group_preload(rg, RES_SFX, flags | RESF_OPTIONAL,
 		"boom",
 		"bomb_reimu_a",
 		"bomb_marisa_b",

--- a/src/plrmodes/reimu_b.c
+++ b/src/plrmodes/reimu_b.c
@@ -679,7 +679,7 @@ static void reimu_dream_init(Player *plr) {
 static void reimu_dream_preload(void) {
 	const int flags = RESF_DEFAULT;
 
-	preload_resources(RES_SPRITE, flags,
+	res_preload_multi(RES_SPRITE, flags,
 		"yinyang",
 		"proj/ofuda",
 		"proj/needle2",
@@ -688,19 +688,19 @@ static void reimu_dream_preload(void) {
 		"part/stardust",
 	NULL);
 
-	preload_resources(RES_TEXTURE, flags,
+	res_preload_multi(RES_TEXTURE, flags,
 		"runes",
 		"gaplight",
 	NULL);
 
-	preload_resources(RES_SHADER_PROGRAM, flags,
+	res_preload_multi(RES_SHADER_PROGRAM, flags,
 		"sprite_yinyang",
 		"reimu_gap",
 		"reimu_gap_light",
 		"reimu_bomb_bg",
 	NULL);
 
-	preload_resources(RES_SFX, flags | RESF_OPTIONAL,
+	res_preload_multi(RES_SFX, flags | RESF_OPTIONAL,
 		"bomb_marisa_a",
 		"boon",
 	NULL);

--- a/src/plrmodes/reimu_b.c
+++ b/src/plrmodes/reimu_b.c
@@ -676,10 +676,10 @@ static void reimu_dream_init(Player *plr) {
 	INVOKE_TASK(reimu_dream_controller, ENT_BOX(plr));
 }
 
-static void reimu_dream_preload(void) {
+static void reimu_dream_preload(ResourceGroup *rg) {
 	const int flags = RESF_DEFAULT;
 
-	res_preload_multi(RES_SPRITE, flags,
+	res_group_preload(rg, RES_SPRITE, flags,
 		"yinyang",
 		"proj/ofuda",
 		"proj/needle2",
@@ -688,19 +688,19 @@ static void reimu_dream_preload(void) {
 		"part/stardust",
 	NULL);
 
-	res_preload_multi(RES_TEXTURE, flags,
+	res_group_preload(rg, RES_TEXTURE, flags,
 		"runes",
 		"gaplight",
 	NULL);
 
-	res_preload_multi(RES_SHADER_PROGRAM, flags,
+	res_group_preload(rg, RES_SHADER_PROGRAM, flags,
 		"sprite_yinyang",
 		"reimu_gap",
 		"reimu_gap_light",
 		"reimu_bomb_bg",
 	NULL);
 
-	res_preload_multi(RES_SFX, flags | RESF_OPTIONAL,
+	res_group_preload(rg, RES_SFX, flags | RESF_OPTIONAL,
 		"bomb_marisa_a",
 		"boon",
 	NULL);

--- a/src/plrmodes/youmu_a.c
+++ b/src/plrmodes/youmu_a.c
@@ -619,7 +619,7 @@ static void youmu_mirror_init(Player *plr) {
 static void youmu_mirror_preload(void) {
 	const int flags = RESF_DEFAULT;
 
-	preload_resources(RES_SPRITE, flags,
+	res_preload_multi(RES_SPRITE, flags,
 		"part/arc",
 		"part/blast_huge_halo",
 		"part/myon",
@@ -629,17 +629,17 @@ static void youmu_mirror_preload(void) {
 		"proj/youmu",
 	NULL);
 
-	preload_resources(RES_TEXTURE, flags,
+	res_preload_multi(RES_TEXTURE, flags,
 		"youmu_bombbg1",
 	NULL);
 
-	preload_resources(RES_SHADER_PROGRAM, flags,
+	res_preload_multi(RES_SHADER_PROGRAM, flags,
 		"sprite_youmu_myon_shot",
 		"youmu_bomb_bg",
 		"youmua_bomb",
 	NULL);
 
-	preload_resources(RES_SFX, flags | RESF_OPTIONAL,
+	res_preload_multi(RES_SFX, flags | RESF_OPTIONAL,
 		"bomb_youmu_b",
 	NULL);
 }

--- a/src/plrmodes/youmu_a.c
+++ b/src/plrmodes/youmu_a.c
@@ -616,10 +616,10 @@ static void youmu_mirror_init(Player *plr) {
 	INVOKE_TASK(youmu_mirror_controller, ENT_BOX(plr));
 }
 
-static void youmu_mirror_preload(void) {
+static void youmu_mirror_preload(ResourceGroup *rg) {
 	const int flags = RESF_DEFAULT;
 
-	res_preload_multi(RES_SPRITE, flags,
+	res_group_preload(rg, RES_SPRITE, flags,
 		"part/arc",
 		"part/blast_huge_halo",
 		"part/myon",
@@ -629,17 +629,17 @@ static void youmu_mirror_preload(void) {
 		"proj/youmu",
 	NULL);
 
-	res_preload_multi(RES_TEXTURE, flags,
+	res_group_preload(rg, RES_TEXTURE, flags,
 		"youmu_bombbg1",
 	NULL);
 
-	res_preload_multi(RES_SHADER_PROGRAM, flags,
+	res_group_preload(rg, RES_SHADER_PROGRAM, flags,
 		"sprite_youmu_myon_shot",
 		"youmu_bomb_bg",
 		"youmua_bomb",
 	NULL);
 
-	res_preload_multi(RES_SFX, flags | RESF_OPTIONAL,
+	res_group_preload(rg, RES_SFX, flags | RESF_OPTIONAL,
 		"bomb_youmu_b",
 	NULL);
 }

--- a/src/plrmodes/youmu_b.c
+++ b/src/plrmodes/youmu_b.c
@@ -595,19 +595,19 @@ static void youmu_haunting_init(Player *plr) {
 	INVOKE_TASK(youmu_haunting_controller, ENT_BOX(plr));
 }
 
-static void youmu_haunting_preload(void) {
+static void youmu_haunting_preload(ResourceGroup *rg) {
 	const int flags = RESF_DEFAULT;
 
-	res_preload_multi(RES_SPRITE, flags,
+	res_group_preload(rg, RES_SPRITE, flags,
 		"proj/youmu",
 		"part/youmu_slice",
 	NULL);
 
-	res_preload_multi(RES_TEXTURE, flags,
+	res_group_preload(rg, RES_TEXTURE, flags,
 		"youmu_bombbg1",
 	NULL);
 
-	res_preload_multi(RES_SFX, flags | RESF_OPTIONAL,
+	res_group_preload(rg, RES_SFX, flags | RESF_OPTIONAL,
 		"bomb_youmu_b",
 	NULL);
 }

--- a/src/plrmodes/youmu_b.c
+++ b/src/plrmodes/youmu_b.c
@@ -598,16 +598,16 @@ static void youmu_haunting_init(Player *plr) {
 static void youmu_haunting_preload(void) {
 	const int flags = RESF_DEFAULT;
 
-	preload_resources(RES_SPRITE, flags,
+	res_preload_multi(RES_SPRITE, flags,
 		"proj/youmu",
 		"part/youmu_slice",
 	NULL);
 
-	preload_resources(RES_TEXTURE, flags,
+	res_preload_multi(RES_TEXTURE, flags,
 		"youmu_bombbg1",
 	NULL);
 
-	preload_resources(RES_SFX, flags | RESF_OPTIONAL,
+	res_preload_multi(RES_SFX, flags | RESF_OPTIONAL,
 		"bomb_youmu_b",
 	NULL);
 }

--- a/src/portrait.c
+++ b/src/portrait.c
@@ -35,7 +35,7 @@ Sprite *portrait_get_base_sprite(const char *charname, const char *variant) {
 void portrait_preload_base_sprite(const char *charname, const char *variant, ResourceFlags rflags) {
 	char buf[BUFFER_SIZE];
 	portrait_get_base_sprite_name(charname, variant, sizeof(buf), buf);
-	preload_resource(RES_SPRITE, buf, rflags);
+	res_preload(RES_SPRITE, buf, rflags);
 }
 
 int portrait_get_face_sprite_name(const char *charname, const char *face, size_t bufsize, char buf[bufsize]) {
@@ -51,7 +51,7 @@ Sprite *portrait_get_face_sprite(const char *charname, const char *face) {
 void portrait_preload_face_sprite(const char *charname, const char *face, ResourceFlags rflags) {
 	char buf[BUFFER_SIZE];
 	portrait_get_face_sprite_name(charname, face, sizeof(buf), buf);
-	preload_resource(RES_SPRITE, buf, rflags);
+	res_preload(RES_SPRITE, buf, rflags);
 }
 
 void portrait_render(Sprite *s_base, Sprite *s_face, Sprite *s_out) {

--- a/src/portrait.c
+++ b/src/portrait.c
@@ -32,10 +32,10 @@ Sprite *portrait_get_base_sprite(const char *charname, const char *variant) {
 	return res_sprite(buf);
 }
 
-void portrait_preload_base_sprite(const char *charname, const char *variant, ResourceFlags rflags) {
+void portrait_preload_base_sprite(ResourceGroup *rg, const char *charname, const char *variant, ResourceFlags rflags) {
 	char buf[BUFFER_SIZE];
 	portrait_get_base_sprite_name(charname, variant, sizeof(buf), buf);
-	res_preload(RES_SPRITE, buf, rflags);
+	res_group_preload(rg, RES_SPRITE, rflags, buf, NULL);
 }
 
 int portrait_get_face_sprite_name(const char *charname, const char *face, size_t bufsize, char buf[bufsize]) {
@@ -48,10 +48,10 @@ Sprite *portrait_get_face_sprite(const char *charname, const char *face) {
 	return res_sprite(buf);
 }
 
-void portrait_preload_face_sprite(const char *charname, const char *face, ResourceFlags rflags) {
+void portrait_preload_face_sprite(ResourceGroup *rg, const char *charname, const char *face, ResourceFlags rflags) {
 	char buf[BUFFER_SIZE];
 	portrait_get_face_sprite_name(charname, face, sizeof(buf), buf);
-	res_preload(RES_SPRITE, buf, rflags);
+	res_group_preload(rg, RES_SPRITE, rflags, buf, NULL);
 }
 
 void portrait_render(Sprite *s_base, Sprite *s_face, Sprite *s_out) {

--- a/src/portrait.h
+++ b/src/portrait.h
@@ -9,6 +9,7 @@
 #pragma once
 #include "taisei.h"
 
+#include "resource/resource.h"
 #include "resource/sprite.h"
 
 #define PORTRAIT_PREFIX "dialog/"
@@ -27,14 +28,14 @@ int portrait_get_base_sprite_name(const char *charname, const char *variant, siz
 Sprite *portrait_get_base_sprite(const char *charname, const char *variant)
 	attr_nonnull(1) attr_returns_nonnull;
 
-void portrait_preload_base_sprite(const char *charname, const char *variant, ResourceFlags rflags)
-	attr_nonnull(1);
+void portrait_preload_base_sprite(ResourceGroup *rg, const char *charname, const char *variant, ResourceFlags rflags)
+	attr_nonnull(2);
 
 int portrait_get_face_sprite_name(const char *charname, const char *face, size_t bufsize, char buf[bufsize])
 	attr_nonnull(1, 2, 4);
 
-void portrait_preload_face_sprite(const char *charname, const char *variant, ResourceFlags rflags)
-	attr_nonnull(1, 2);
+void portrait_preload_face_sprite(ResourceGroup *rg, const char *charname, const char *variant, ResourceFlags rflags)
+	attr_nonnull(2, 3);
 
 Sprite *portrait_get_face_sprite(const char *charname, const char *face)
 	attr_nonnull(1, 2) attr_returns_nonnull;

--- a/src/projectile.c
+++ b/src/projectile.c
@@ -1024,7 +1024,7 @@ void petal_explosion(int n, cmplx pos) {
 	}
 }
 
-void projectiles_preload(void) {
+void projectiles_preload(ResourceGroup *rg) {
 	const char *shaders[] = {
 		// This array defines a shader-based fallback draw order
 		"sprite_silhouette",
@@ -1036,17 +1036,12 @@ void projectiles_preload(void) {
 	const uint num_shaders = sizeof(shaders)/sizeof(*shaders);
 
 	for(uint i = 0; i < num_shaders; ++i) {
-		res_preload(RES_SHADER_PROGRAM, shaders[i], RESF_PERMANENT);
+		res_group_preload(rg, RES_SHADER_PROGRAM, RESF_DEFAULT, shaders[i], NULL);
 	}
-
-	// FIXME: Why is this here?
-	res_preload_multi(RES_TEXTURE, RESF_PERMANENT,
-		"part/lasercurve",
-	NULL);
 
 	// TODO: Maybe split this up into stage-specific preloads too?
 	// some of these are ubiquitous, but some only appear in very specific parts.
-	res_preload_multi(RES_SPRITE, RESF_PERMANENT,
+	res_group_preload(rg, RES_SPRITE, RESF_DEFAULT,
 		"part/blast",
 		"part/bullet_flare",
 		"part/flare",
@@ -1061,11 +1056,11 @@ void projectiles_preload(void) {
 		"part/stardust_green",
 	NULL);
 
-	res_preload_multi(RES_ANIM, RESF_PERMANENT,
+	res_group_preload(rg, RES_ANIM, RESF_DEFAULT,
 		"part/bullet_clear",
 	NULL);
 
-	res_preload_multi(RES_SFX, RESF_PERMANENT,
+	res_group_preload(rg, RES_SFX, RESF_OPTIONAL,
 		"shot1",
 		"shot2",
 		"shot3",
@@ -1074,7 +1069,7 @@ void projectiles_preload(void) {
 		"redirect",
 	NULL);
 
-	#define PP(name) (_pp_##name).preload(&_pp_##name);
+	#define PP(name) (_pp_##name).preload(&_pp_##name, rg);
 	#include "projectile_prototypes/all.inc.h"
 
 	ht_create(&shader_sublayer_map);
@@ -1089,4 +1084,6 @@ void projectiles_preload(void) {
 
 void projectiles_free(void) {
 	ht_destroy(&shader_sublayer_map);
+	#define PP(name) (_pp_##name).reset(&_pp_##name);
+	#include "projectile_prototypes/all.inc.h"
 }

--- a/src/projectile.c
+++ b/src/projectile.c
@@ -1036,17 +1036,17 @@ void projectiles_preload(void) {
 	const uint num_shaders = sizeof(shaders)/sizeof(*shaders);
 
 	for(uint i = 0; i < num_shaders; ++i) {
-		preload_resource(RES_SHADER_PROGRAM, shaders[i], RESF_PERMANENT);
+		res_preload(RES_SHADER_PROGRAM, shaders[i], RESF_PERMANENT);
 	}
 
 	// FIXME: Why is this here?
-	preload_resources(RES_TEXTURE, RESF_PERMANENT,
+	res_preload_multi(RES_TEXTURE, RESF_PERMANENT,
 		"part/lasercurve",
 	NULL);
 
 	// TODO: Maybe split this up into stage-specific preloads too?
 	// some of these are ubiquitous, but some only appear in very specific parts.
-	preload_resources(RES_SPRITE, RESF_PERMANENT,
+	res_preload_multi(RES_SPRITE, RESF_PERMANENT,
 		"part/blast",
 		"part/bullet_flare",
 		"part/flare",
@@ -1061,11 +1061,11 @@ void projectiles_preload(void) {
 		"part/stardust_green",
 	NULL);
 
-	preload_resources(RES_ANIM, RESF_PERMANENT,
+	res_preload_multi(RES_ANIM, RESF_PERMANENT,
 		"part/bullet_clear",
 	NULL);
 
-	preload_resources(RES_SFX, RESF_PERMANENT,
+	res_preload_multi(RES_SFX, RESF_PERMANENT,
 		"shot1",
 		"shot2",
 		"shot3",

--- a/src/projectile.h
+++ b/src/projectile.h
@@ -10,6 +10,7 @@
 #include "taisei.h"
 
 #include "util.h"
+#include "resource/resource.h"
 #include "resource/sprite.h"
 #include "resource/shader_program.h"
 #include "color.h"
@@ -196,8 +197,9 @@ typedef struct ProjArgs {
 } attr_designated_init ProjArgs;
 
 struct ProjPrototype {
-	void (*preload)(ProjPrototype *proto);
+	void (*preload)(ProjPrototype *proto, ResourceGroup *rg);
 	void (*process_args)(ProjPrototype *proto, ProjArgs *args);
+	void (*reset)(ProjPrototype *proto);
 	void (*init_projectile)(ProjPrototype *proto, Projectile *p);
 	void (*deinit_projectile)(ProjPrototype *proto, Projectile *p);
 	void *private;
@@ -257,7 +259,7 @@ ProjDrawRule pdraw_blast(void);
 
 void petal_explosion(int n, cmplx pos);
 
-void projectiles_preload(void);
+void projectiles_preload(ResourceGroup *rg);
 void projectiles_free(void);
 
 cmplx projectile_graze_size(Projectile *p);

--- a/src/projectile_prototypes.c
+++ b/src/projectile_prototypes.c
@@ -19,9 +19,14 @@ typedef struct PPBasicPriv {
 	cmplx collision_size;
 } PPBasicPriv;
 
-static void pp_basic_preload(ProjPrototype *proto) {
-	res_preload(RES_SPRITE, ((PPBasicPriv*)proto->private)->sprite_name, RESF_PERMANENT);
+static void pp_basic_preload(ProjPrototype *proto, ResourceGroup *rg) {
+	res_group_preload(rg, RES_SPRITE, 0, ((PPBasicPriv*)proto->private)->sprite_name, NULL);
 	// not assigning ->sprite here because it'll block the thread until loaded
+}
+
+static void pp_basic_reset(ProjPrototype *proto) {
+	PPBasicPriv *pdata = proto->private;
+	pdata->sprite = NULL;
 }
 
 static void pp_basic_init_projectile(ProjPrototype *proto, Projectile *p) {
@@ -38,6 +43,7 @@ static void pp_basic_init_projectile(ProjPrototype *proto, Projectile *p) {
 #define _PP_BASIC(sprite, width, height, colwidth, colheight) \
 	ProjPrototype _pp_##sprite = { \
 		.preload = pp_basic_preload, \
+		.reset = pp_basic_reset, \
 		.init_projectile = pp_basic_init_projectile, \
 		.private = (&(PPBasicPriv) { \
 			.sprite_name = "proj/" #sprite, \
@@ -55,6 +61,7 @@ static void pp_basic_init_projectile(ProjPrototype *proto, Projectile *p) {
 
 ProjPrototype _pp_blast = {
 	.preload = pp_basic_preload,
+	.reset = pp_basic_reset,
 	.init_projectile = pp_basic_init_projectile,
 	.private = &(PPBasicPriv) {
 		.sprite_name = "part/blast",

--- a/src/projectile_prototypes.c
+++ b/src/projectile_prototypes.c
@@ -20,7 +20,7 @@ typedef struct PPBasicPriv {
 } PPBasicPriv;
 
 static void pp_basic_preload(ProjPrototype *proto) {
-	preload_resource(RES_SPRITE, ((PPBasicPriv*)proto->private)->sprite_name, RESF_PERMANENT);
+	res_preload(RES_SPRITE, ((PPBasicPriv*)proto->private)->sprite_name, RESF_PERMANENT);
 	// not assigning ->sprite here because it'll block the thread until loaded
 }
 

--- a/src/renderer/api.c
+++ b/src/renderer/api.c
@@ -46,7 +46,7 @@ void r_post_init(void) {
 	_r_models_init();
 	_r_sprite_batch_init();
 
-	preload_resources(RES_SHADER_PROGRAM, RESF_PERMANENT,
+	res_preload_multi(RES_SHADER_PROGRAM, RESF_PERMANENT,
 		"sprite_default",
 		"texture_post_load",
 		"standard",
@@ -54,7 +54,7 @@ void r_post_init(void) {
 	NULL);
 
 #if DEBUG
-	preload_resources(RES_FONT, RESF_PERMANENT,
+	res_preload_multi(RES_FONT, RESF_PERMANENT,
 		"monotiny",
 	NULL);
 #endif

--- a/src/renderer/api.c
+++ b/src/renderer/api.c
@@ -16,6 +16,7 @@
 #include "common/state.h"
 #include "util/glm.h"
 #include "util/graphics.h"
+#include "resource/resource.h"
 #include "resource/texture.h"
 #include "resource/sprite.h"
 #include "coroutine.h"
@@ -23,6 +24,7 @@
 #define B _r_backend.funcs
 
 static struct {
+	ResourceGroup rg;
 	struct {
 		ShaderProgram *standard;
 		ShaderProgram *standardnotex;
@@ -46,7 +48,9 @@ void r_post_init(void) {
 	_r_models_init();
 	_r_sprite_batch_init();
 
-	res_preload_multi(RES_SHADER_PROGRAM, RESF_PERMANENT,
+	res_group_init(&R.rg);
+
+	res_group_preload(&R.rg, RES_SHADER_PROGRAM, RESF_DEFAULT,
 		"sprite_default",
 		"texture_post_load",
 		"standard",
@@ -54,7 +58,7 @@ void r_post_init(void) {
 	NULL);
 
 #if DEBUG
-	res_preload_multi(RES_FONT, RESF_PERMANENT,
+	res_group_preload(&R.rg, RES_FONT, RESF_DEFAULT,
 		"monotiny",
 	NULL);
 #endif
@@ -73,6 +77,10 @@ void r_post_init(void) {
 	r_framebuffer_clear(NULL, BUFFER_ALL, RGBA(0, 0, 0, 1), 1);
 
 	log_info("Rendering subsystem initialized (%s)", _r_backend.name);
+}
+
+void r_release_resources(void) {
+	res_group_release(&R.rg);
 }
 
 void r_shutdown(void) {

--- a/src/renderer/api.h
+++ b/src/renderer/api.h
@@ -982,12 +982,12 @@ void r_clear(BufferKindFlags flags, const Color *colorval, float depthval) {
 
 INLINE attr_nonnull(1)
 void r_draw_model(const char *model) {
-	r_draw_model_ptr(get_resource_data(RES_MODEL, model, RESF_DEFAULT), 0, 0);
+	r_draw_model_ptr(res_get_data(RES_MODEL, model, RESF_DEFAULT), 0, 0);
 }
 
 INLINE attr_nonnull(1)
 void r_draw_model_instanced(const char *model, uint instances, uint base_instance) {
-	r_draw_model_ptr(get_resource_data(RES_MODEL, model, RESF_DEFAULT), instances, base_instance);
+	r_draw_model_ptr(res_get_data(RES_MODEL, model, RESF_DEFAULT), instances, base_instance);
 }
 
 INLINE

--- a/src/renderer/api.h
+++ b/src/renderer/api.h
@@ -517,6 +517,7 @@ SDL_Window* r_create_window(const char *title, int x, int y, int w, int h, uint3
 
 void r_init(void);
 void r_post_init(void);
+void r_release_resources(void);
 void r_shutdown(void);
 const char *r_backend_name(void);
 

--- a/src/replay/play.c
+++ b/src/replay/play.c
@@ -93,7 +93,7 @@ static void replay_do_cleanup(CallChainResult ccr) {
 
 	global.gameover = 0;
 	replay_state_deinit(&global.replay.input);
-	free_resources(false);
+	res_unload_all(false);
 
 	CallChain cc = ctx->cc;
 	mem_free(ctx);

--- a/src/resource/animation.c
+++ b/src/resource/animation.c
@@ -301,7 +301,7 @@ static void load_animation_stage2(ResourceLoadState *st) {
 	for(int i = 0; i < ani->sprite_count; ++i) {
 		snprintf(buf, sizeof(buf), "%s.frame%04d", st->name, i);
 
-		if(!(ani->sprites[i] = get_resource_data(RES_SPRITE, buf, st->flags))) {
+		if(!(ani->sprites[i] = res_get_data(RES_SPRITE, buf, st->flags))) {
 			log_error("Animation frame '%s' not found but @sprite_count was %d",buf,ani->sprite_count);
 			unload_animation(ani);
 			ani = NULL;

--- a/src/resource/font.c
+++ b/src/resource/font.c
@@ -121,6 +121,8 @@ static struct {
 		SDL_mutex *new_face;
 		SDL_mutex *done_face;
 	} mutex;
+
+	ResourceGroup rg;
 } globals;
 
 static double global_font_scale(void) {
@@ -196,7 +198,9 @@ static void init_fonts(void) {
 		fonts_event, NULL, EPRIO_SYSTEM,
 	});
 
-	res_preload_multi(RES_FONT, RESF_PERMANENT,
+	res_group_init(&globals.rg);
+
+	res_group_preload(&globals.rg, RES_FONT, RESF_DEFAULT,
 		"standard",
 	NULL);
 
@@ -223,10 +227,13 @@ static void init_fonts(void) {
 }
 
 static void post_init_fonts(void) {
-	globals.default_shader = res_get_data(RES_SHADER_PROGRAM, "text_default", RESF_PERMANENT | RESF_PRELOAD);
+	res_group_preload(&globals.rg, RES_SHADER_PROGRAM, RESF_DEFAULT, "text_default", NULL);
+	globals.default_shader = res_shader("text_default");
 }
 
 static void shutdown_fonts(void) {
+	res_group_release(&globals.rg);
+	res_purge();
 	r_texture_destroy(globals.render_tex);
 	r_framebuffer_destroy(globals.render_buf);
 	events_unregister_handler(fonts_event);

--- a/src/resource/font.c
+++ b/src/resource/font.c
@@ -196,7 +196,7 @@ static void init_fonts(void) {
 		fonts_event, NULL, EPRIO_SYSTEM,
 	});
 
-	preload_resources(RES_FONT, RESF_PERMANENT,
+	res_preload_multi(RES_FONT, RESF_PERMANENT,
 		"standard",
 	NULL);
 
@@ -223,7 +223,7 @@ static void init_fonts(void) {
 }
 
 static void post_init_fonts(void) {
-	globals.default_shader = get_resource_data(RES_SHADER_PROGRAM, "text_default", RESF_PERMANENT | RESF_PRELOAD);
+	globals.default_shader = res_get_data(RES_SHADER_PROGRAM, "text_default", RESF_PERMANENT | RESF_PRELOAD);
 }
 
 static void shutdown_fonts(void) {
@@ -799,7 +799,7 @@ static void* reload_font_callback(const char *name, Resource *res, void *varg) {
 }
 
 static void reload_fonts(double quality) {
-	resource_for_each(RES_FONT, reload_font_callback, &(struct rlfonts_arg) { quality });
+	res_for_each(RES_FONT, reload_font_callback, &(struct rlfonts_arg) { quality });
 }
 
 static inline int apply_kerning(Font *font, uint prev_index, Glyph *gthis) {

--- a/src/resource/material.c
+++ b/src/resource/material.c
@@ -116,7 +116,7 @@ static void material_load_stage1(ResourceLoadState *st) {
 
 #define LOADMAP(_map_) do { \
 	if(ld->_map_##_map) { \
-		ld->mat->_map_##_map = get_resource_data( \
+		ld->mat->_map_##_map = res_get_data( \
 			RES_TEXTURE, ld->_map_##_map, st->flags & ~RESF_RELOAD); \
 		if(UNLIKELY(ld->mat->_map_##_map == NULL)) { \
 			log_error("%s: failed to load " #_map_ " map '%s'", st->name, ld->_map_##_map); \

--- a/src/resource/postprocess.c
+++ b/src/resource/postprocess.c
@@ -35,7 +35,7 @@ static bool postprocess_load_callback(const char *key, const char *value, void *
 		current->uniforms = NULL;
 
 		// if loading this fails, get_resource will print a warning
-		current->shader = get_resource_data(RES_SHADER_PROGRAM, value, ldata->resflags);
+		current->shader = res_get_data(RES_SHADER_PROGRAM, value, ldata->resflags);
 
 		list_append(slist, current);
 		return true;
@@ -68,7 +68,7 @@ static bool postprocess_load_callback(const char *key, const char *value, void *
 	const UniformTypeInfo *type_info = r_uniform_type_info(type);
 
 	if(UNIFORM_TYPE_IS_SAMPLER(type)) {
-		Texture *tex = get_resource_data(RES_TEXTURE, value, ldata->resflags);
+		Texture *tex = res_get_data(RES_TEXTURE, value, ldata->resflags);
 
 		if(tex) {
 			list_append(&current->uniforms, ALLOC(PostprocessShaderUniform, {

--- a/src/resource/resource.c
+++ b/src/resource/resource.c
@@ -1571,16 +1571,6 @@ char *res_util_basename(const char *prefix, const char *path) {
 	return out;
 }
 
-const char *res_util_filename(const char *path) {
-	char *sep = strrchr(path, '/');
-
-	if(sep) {
-		return sep + 1;
-	}
-
-	return path;
-}
-
 static void preload_path(const char *path, ResourceType type, ResourceFlags flags) {
 	if(_handlers[type]->procs.check(path)) {
 		char *name = get_name_from_path(_handlers[type], path);

--- a/src/resource/resource.h
+++ b/src/resource/resource.h
@@ -160,7 +160,6 @@ void *res_for_each(ResourceType type, void *(*callback)(const char *name, Resour
 
 void res_util_strip_ext(char *path);
 char *res_util_basename(const char *prefix, const char *path);
-const char *res_util_filename(const char *path);
 
 #define DEFINE_RESOURCE_GETTER(_type, _name, _enum) \
 	attr_nonnull_all attr_returns_nonnull \

--- a/src/resource/shader_program.c
+++ b/src/resource/shader_program.c
@@ -89,7 +89,7 @@ static void load_shader_program_stage2(ResourceLoadState *st) {
 	char *objname = ldata.objlist;
 
 	for(int i = 0; i < ldata.num_objects; ++i) {
-		if(!(objs[i] = get_resource_data(RES_SHADER_OBJECT, objname, st->flags & ~RESF_RELOAD))) {
+		if(!(objs[i] = res_get_data(RES_SHADER_OBJECT, objname, st->flags & ~RESF_RELOAD))) {
 			log_error("%s: couldn't load shader object '%s'", st->path, objname);
 			mem_free(ldata.objlist);
 			res_load_failed(st);

--- a/src/resource/sprite.c
+++ b/src/resource/sprite.c
@@ -111,7 +111,7 @@ static void load_sprite_stage2(ResourceLoadState *st) {
 	struct sprite_load_state *state = NOT_NULL(st->opaque);
 	Sprite *spr = NOT_NULL(state->spr);
 
-	spr->tex = get_resource_data(RES_TEXTURE, state->texture_name, st->flags & ~RESF_RELOAD);
+	spr->tex = res_get_data(RES_TEXTURE, state->texture_name, st->flags & ~RESF_RELOAD);
 
 	mem_free(state->texture_name);
 	mem_free(state);

--- a/src/stage.c
+++ b/src/stage.c
@@ -805,7 +805,7 @@ static void stage_preload(void) {
 	enemies_preload();
 
 	if(global.stage->type != STAGE_SPELL) {
-		preload_resource(RES_BGM, "gameover", RESF_DEFAULT);
+		res_preload(RES_BGM, "gameover", RESF_DEFAULT);
 		dialog_preload();
 	}
 

--- a/src/stage.h
+++ b/src/stage.h
@@ -18,6 +18,7 @@
 #include "coroutine.h"
 #include "dynarray.h"
 #include "stageinfo.h"
+#include "resource/resource.h"
 
 typedef struct StageClearBonus {
 	uint64_t base;
@@ -28,7 +29,7 @@ typedef struct StageClearBonus {
 	bool all_clear;
 } StageClearBonus;
 
-void stage_enter(StageInfo *stage, CallChain next);
+void stage_enter(StageInfo *stage, ResourceGroup *rg, CallChain next);
 void stage_finish(int gameover);
 
 void stage_pause(void);

--- a/src/stagedraw.c
+++ b/src/stagedraw.c
@@ -269,27 +269,27 @@ static void stage_draw_destroy_framebuffers(void) {
 void stage_draw_pre_init(void) {
 	stagedraw.mfb_group = fbmgr_group_create();
 
-	preload_resources(RES_POSTPROCESS, RESF_OPTIONAL,
+	res_preload_multi(RES_POSTPROCESS, RESF_OPTIONAL,
 		"viewport",
 	NULL);
 
-	preload_resources(RES_SPRITE, RESF_PERMANENT,
+	res_preload_multi(RES_SPRITE, RESF_PERMANENT,
 		"hud/heart",
 		"hud/star",
 		"star",
 	NULL);
 
-	preload_resources(RES_TEXTURE, RESF_PERMANENT,
+	res_preload_multi(RES_TEXTURE, RESF_PERMANENT,
 		"powersurge_flow",
 		"titletransition",
 		"hud",
 	NULL);
 
-	preload_resources(RES_MODEL, RESF_PERMANENT,
+	res_preload_multi(RES_MODEL, RESF_PERMANENT,
 		"hud",
 	NULL);
 
-	preload_resources(RES_SHADER_PROGRAM, RESF_PERMANENT,
+	res_preload_multi(RES_SHADER_PROGRAM, RESF_PERMANENT,
 		"ingame_menu",
 		"powersurge_effect",
 		"powersurge_feedback",
@@ -306,7 +306,7 @@ void stage_draw_pre_init(void) {
 		#endif
 	NULL);
 
-	preload_resources(RES_FONT, RESF_PERMANENT,
+	res_preload_multi(RES_FONT, RESF_PERMANENT,
 		"mono",
 		"small",
 		"monosmall",
@@ -322,20 +322,20 @@ void stage_draw_pre_init(void) {
 	stagedraw.objpool_stats = env_get("TAISEI_OBJPOOL_STATS", OBJPOOLSTATS_DEFAULT);
 
 	if(stagedraw.framerate_graphs) {
-		preload_resources(RES_SHADER_PROGRAM, RESF_PERMANENT,
+		res_preload_multi(RES_SHADER_PROGRAM, RESF_PERMANENT,
 			"graph",
 		NULL);
 	}
 
 	if(stagedraw.objpool_stats) {
-		preload_resources(RES_FONT, RESF_PERMANENT,
+		res_preload_multi(RES_FONT, RESF_PERMANENT,
 			"monotiny",
 		NULL);
 	}
 }
 
 void stage_draw_init(void) {
-	stagedraw.viewport_pp = get_resource_data(RES_POSTPROCESS, "viewport", RESF_OPTIONAL);
+	stagedraw.viewport_pp = res_get_data(RES_POSTPROCESS, "viewport", RESF_OPTIONAL);
 	stagedraw.hud_text.shader = res_shader("text_hud");
 	stagedraw.hud_text.font = res_font("standard");
 	stagedraw.shaders.fxaa = res_shader("fxaa");

--- a/src/stagedraw.c
+++ b/src/stagedraw.c
@@ -266,30 +266,28 @@ static void stage_draw_destroy_framebuffers(void) {
 	stagedraw.mfb_group = NULL;
 }
 
-void stage_draw_pre_init(void) {
-	stagedraw.mfb_group = fbmgr_group_create();
-
-	res_preload_multi(RES_POSTPROCESS, RESF_OPTIONAL,
+void stage_draw_preload(ResourceGroup *rg) {
+	res_group_preload(rg, RES_POSTPROCESS, RESF_OPTIONAL,
 		"viewport",
 	NULL);
 
-	res_preload_multi(RES_SPRITE, RESF_PERMANENT,
+	res_group_preload(rg, RES_SPRITE, RESF_DEFAULT,
 		"hud/heart",
 		"hud/star",
 		"star",
 	NULL);
 
-	res_preload_multi(RES_TEXTURE, RESF_PERMANENT,
+	res_group_preload(rg, RES_TEXTURE, RESF_DEFAULT,
 		"powersurge_flow",
 		"titletransition",
 		"hud",
 	NULL);
 
-	res_preload_multi(RES_MODEL, RESF_PERMANENT,
+	res_group_preload(rg, RES_MODEL, RESF_DEFAULT,
 		"hud",
 	NULL);
 
-	res_preload_multi(RES_SHADER_PROGRAM, RESF_PERMANENT,
+	res_group_preload(rg, RES_SHADER_PROGRAM, RESF_DEFAULT,
 		"ingame_menu",
 		"powersurge_effect",
 		"powersurge_feedback",
@@ -306,14 +304,14 @@ void stage_draw_pre_init(void) {
 		#endif
 	NULL);
 
-	res_preload_multi(RES_FONT, RESF_PERMANENT,
+	res_group_preload(rg, RES_FONT, RESF_DEFAULT,
 		"mono",
 		"small",
 		"monosmall",
 	NULL);
 
 	if(stage_is_demo_mode()) {
-		preload_resources(RES_SHADER_PROGRAM, RESF_DEFAULT,
+		res_group_preload(rg, RES_SHADER_PROGRAM, RESF_DEFAULT,
 			"text_demo",
 		NULL);
 	}
@@ -322,19 +320,21 @@ void stage_draw_pre_init(void) {
 	stagedraw.objpool_stats = env_get("TAISEI_OBJPOOL_STATS", OBJPOOLSTATS_DEFAULT);
 
 	if(stagedraw.framerate_graphs) {
-		res_preload_multi(RES_SHADER_PROGRAM, RESF_PERMANENT,
+		res_group_preload(rg, RES_SHADER_PROGRAM, RESF_DEFAULT,
 			"graph",
 		NULL);
 	}
 
 	if(stagedraw.objpool_stats) {
-		res_preload_multi(RES_FONT, RESF_PERMANENT,
+		res_group_preload(rg, RES_FONT, RESF_DEFAULT,
 			"monotiny",
 		NULL);
 	}
 }
 
 void stage_draw_init(void) {
+	stagedraw.mfb_group = fbmgr_group_create();
+
 	stagedraw.viewport_pp = res_get_data(RES_POSTPROCESS, "viewport", RESF_OPTIONAL);
 	stagedraw.hud_text.shader = res_shader("text_hud");
 	stagedraw.hud_text.font = res_font("standard");

--- a/src/stagedraw.h
+++ b/src/stagedraw.h
@@ -10,6 +10,7 @@
 #include "taisei.h"
 
 #include "stage.h"
+#include "resource/resource.h"
 #include "util/graphics.h"
 
 typedef enum StageFBPair {
@@ -26,7 +27,7 @@ typedef COEVENTS_ARRAY(
 	postprocess_after_overlay
 ) StageDrawEvents;
 
-void stage_draw_pre_init(void);
+void stage_draw_preload(ResourceGroup *rg);
 void stage_draw_init(void);
 void stage_draw_shutdown(void);
 

--- a/src/stageinfo.h
+++ b/src/stageinfo.h
@@ -15,6 +15,7 @@
 #include "progress.h"
 
 typedef void (*StageProc)(void);
+typedef void (*StagePreloadProc)(ResourceGroup *rg);
 typedef bool (*ShaderRule)(Framebuffer*); // true = drawn to color buffer
 
 // two highest bits of uint16_t, WAY higher than the amount of spells in this game can ever possibly be
@@ -31,7 +32,7 @@ typedef enum StageType {
 typedef struct StageProcs StageProcs;
 struct StageProcs {
 	StageProc begin;
-	StageProc preload;
+	StagePreloadProc preload;
 	StageProc end;
 	StageProc draw;
 	ShaderRule *shader_rules;

--- a/src/stages/stage1/stage1.c
+++ b/src/stages/stage1/stage1.c
@@ -88,30 +88,30 @@ static void stage1_spellpractice_start(void) {
 	INVOKE_TASK_WHEN(&cirno->events.defeated, common_call_func, stage1_bg_disable_snow);
 }
 
-static void stage1_preload(void) {
+static void stage1_preload(ResourceGroup *rg) {
 	// DIALOG_PRELOAD(&global.plr, Stage1PreBoss, RESF_DEFAULT);
-	portrait_preload_base_sprite("cirno", NULL, RESF_DEFAULT);
-	portrait_preload_face_sprite("cirno", "normal", RESF_DEFAULT);
-	res_preload_multi(RES_BGM, RESF_OPTIONAL, "stage1", "stage1boss", NULL);
-	res_preload_multi(RES_SPRITE, RESF_DEFAULT,
+	portrait_preload_base_sprite(rg, "cirno", NULL, RESF_DEFAULT);
+	portrait_preload_face_sprite(rg, "cirno", "normal", RESF_DEFAULT);
+	res_group_preload(rg, RES_BGM, RESF_OPTIONAL, "stage1", "stage1boss", NULL);
+	res_group_preload(rg, RES_SPRITE, RESF_DEFAULT,
 		"stage1/cirnobg",
 		"stage1/fog",
 		"stage1/snowlayer",
 		"stage1/waterplants",
 	NULL);
-	res_preload_multi(RES_TEXTURE, RESF_DEFAULT,
+	res_group_preload(rg, RES_TEXTURE, RESF_DEFAULT,
 		"fractal_noise",
 		"stage1/horizon",
 	NULL);
-	res_preload_multi(RES_SHADER_PROGRAM, RESF_DEFAULT,
+	res_group_preload(rg, RES_SHADER_PROGRAM, RESF_DEFAULT,
 		"blur5",
 		"stage1_water",
 		"zbuf_fog",
 	NULL);
-	res_preload_multi(RES_ANIM, RESF_DEFAULT,
+	res_group_preload(rg, RES_ANIM, RESF_DEFAULT,
 		"boss/cirno",
 	NULL);
-	res_preload_multi(RES_SFX, RESF_OPTIONAL,
+	res_group_preload(rg, RES_SFX, RESF_OPTIONAL,
 		"laser1",
 	NULL);
 }

--- a/src/stages/stage1/stage1.c
+++ b/src/stages/stage1/stage1.c
@@ -92,26 +92,26 @@ static void stage1_preload(void) {
 	// DIALOG_PRELOAD(&global.plr, Stage1PreBoss, RESF_DEFAULT);
 	portrait_preload_base_sprite("cirno", NULL, RESF_DEFAULT);
 	portrait_preload_face_sprite("cirno", "normal", RESF_DEFAULT);
-	preload_resources(RES_BGM, RESF_OPTIONAL, "stage1", "stage1boss", NULL);
-	preload_resources(RES_SPRITE, RESF_DEFAULT,
+	res_preload_multi(RES_BGM, RESF_OPTIONAL, "stage1", "stage1boss", NULL);
+	res_preload_multi(RES_SPRITE, RESF_DEFAULT,
 		"stage1/cirnobg",
 		"stage1/fog",
 		"stage1/snowlayer",
 		"stage1/waterplants",
 	NULL);
-	preload_resources(RES_TEXTURE, RESF_DEFAULT,
+	res_preload_multi(RES_TEXTURE, RESF_DEFAULT,
 		"fractal_noise",
 		"stage1/horizon",
 	NULL);
-	preload_resources(RES_SHADER_PROGRAM, RESF_DEFAULT,
+	res_preload_multi(RES_SHADER_PROGRAM, RESF_DEFAULT,
 		"blur5",
 		"stage1_water",
 		"zbuf_fog",
 	NULL);
-	preload_resources(RES_ANIM, RESF_DEFAULT,
+	res_preload_multi(RES_ANIM, RESF_DEFAULT,
 		"boss/cirno",
 	NULL);
-	preload_resources(RES_SFX, RESF_OPTIONAL,
+	res_preload_multi(RES_SFX, RESF_OPTIONAL,
 		"laser1",
 	NULL);
 }

--- a/src/stages/stage2/stage2.c
+++ b/src/stages/stage2/stage2.c
@@ -71,46 +71,46 @@ static void stage2_end(void) {
 static void stage2_preload(void) {
 	portrait_preload_base_sprite("hina", NULL, RESF_DEFAULT);
 	portrait_preload_face_sprite("hina", "normal", RESF_DEFAULT);
-	preload_resources(RES_BGM, RESF_OPTIONAL, "stage2", "stage2boss", NULL);
+	res_preload_multi(RES_BGM, RESF_OPTIONAL, "stage2", "stage2boss", NULL);
 
-	preload_resources(RES_SPRITE, RESF_DEFAULT,
+	res_preload_multi(RES_SPRITE, RESF_DEFAULT,
 		"fairy_circle_big",
 		"part/blast_huge_rays",
 	NULL);
-	preload_resources(RES_TEXTURE, RESF_DEFAULT,
+	res_preload_multi(RES_TEXTURE, RESF_DEFAULT,
 		"fractal_noise",
 		"ibl_brdf_lut",
 		"stage2/envmap",
 		"stage2/spellbg1",
 		"stage2/spellbg2",
 	NULL);
-	preload_resources(RES_MATERIAL, RESF_DEFAULT,
+	res_preload_multi(RES_MATERIAL, RESF_DEFAULT,
 		"stage2/branch",
 		"stage2/ground",
 		"stage2/lakefloor",
 		"stage2/leaves",
 		"stage2/rocks",
 	NULL);
-	preload_resources(RES_MODEL, RESF_DEFAULT,
+	res_preload_multi(RES_MODEL, RESF_DEFAULT,
 		"stage2/branch",
 		"stage2/grass",
 		"stage2/ground",
 		"stage2/leaves",
 		"stage2/rocks",
 	NULL);
-	preload_resources(RES_SHADER_PROGRAM, RESF_DEFAULT,
+	res_preload_multi(RES_SHADER_PROGRAM, RESF_DEFAULT,
 		"fireparticles",
 		"pbr",
 		"pbr_diffuse_alpha_discard",
 		"pbr_water",
 		"zbuf_fog_tonemap",
 	NULL);
-	preload_resources(RES_ANIM, RESF_DEFAULT,
+	res_preload_multi(RES_ANIM, RESF_DEFAULT,
 		"boss/wriggle",
 		"boss/hina",
 		"fire",
 	NULL);
-	preload_resources(RES_SFX, RESF_OPTIONAL,
+	res_preload_multi(RES_SFX, RESF_OPTIONAL,
 		"laser1",
 	NULL);
 }

--- a/src/stages/stage2/stage2.c
+++ b/src/stages/stage2/stage2.c
@@ -68,49 +68,49 @@ static void stage2_end(void) {
 	stage2_drawsys_shutdown();
 }
 
-static void stage2_preload(void) {
-	portrait_preload_base_sprite("hina", NULL, RESF_DEFAULT);
-	portrait_preload_face_sprite("hina", "normal", RESF_DEFAULT);
-	res_preload_multi(RES_BGM, RESF_OPTIONAL, "stage2", "stage2boss", NULL);
+static void stage2_preload(ResourceGroup *rg) {
+	portrait_preload_base_sprite(rg, "hina", NULL, RESF_DEFAULT);
+	portrait_preload_face_sprite(rg, "hina", "normal", RESF_DEFAULT);
+	res_group_preload(rg, RES_BGM, RESF_OPTIONAL, "stage2", "stage2boss", NULL);
 
-	res_preload_multi(RES_SPRITE, RESF_DEFAULT,
+	res_group_preload(rg, RES_SPRITE, RESF_DEFAULT,
 		"fairy_circle_big",
 		"part/blast_huge_rays",
 	NULL);
-	res_preload_multi(RES_TEXTURE, RESF_DEFAULT,
+	res_group_preload(rg, RES_TEXTURE, RESF_DEFAULT,
 		"fractal_noise",
 		"ibl_brdf_lut",
 		"stage2/envmap",
 		"stage2/spellbg1",
 		"stage2/spellbg2",
 	NULL);
-	res_preload_multi(RES_MATERIAL, RESF_DEFAULT,
+	res_group_preload(rg, RES_MATERIAL, RESF_DEFAULT,
 		"stage2/branch",
 		"stage2/ground",
 		"stage2/lakefloor",
 		"stage2/leaves",
 		"stage2/rocks",
 	NULL);
-	res_preload_multi(RES_MODEL, RESF_DEFAULT,
+	res_group_preload(rg, RES_MODEL, RESF_DEFAULT,
 		"stage2/branch",
 		"stage2/grass",
 		"stage2/ground",
 		"stage2/leaves",
 		"stage2/rocks",
 	NULL);
-	res_preload_multi(RES_SHADER_PROGRAM, RESF_DEFAULT,
+	res_group_preload(rg, RES_SHADER_PROGRAM, RESF_DEFAULT,
 		"fireparticles",
 		"pbr",
 		"pbr_diffuse_alpha_discard",
 		"pbr_water",
 		"zbuf_fog_tonemap",
 	NULL);
-	res_preload_multi(RES_ANIM, RESF_DEFAULT,
+	res_group_preload(rg, RES_ANIM, RESF_DEFAULT,
 		"boss/wriggle",
 		"boss/hina",
 		"fire",
 	NULL);
-	res_preload_multi(RES_SFX, RESF_OPTIONAL,
+	res_group_preload(rg, RES_SFX, RESF_OPTIONAL,
 		"laser1",
 	NULL);
 }

--- a/src/stages/stage3/stage3.c
+++ b/src/stages/stage3/stage3.c
@@ -84,13 +84,13 @@ static void stage3_spellpractice_start(void) {
 	boss_engage(global.boss);
 }
 
-static void stage3_preload(void) {
-	portrait_preload_base_sprite("wriggle", NULL, RESF_DEFAULT);
-	portrait_preload_face_sprite("wriggle", "proud", RESF_DEFAULT);
-	portrait_preload_base_sprite("scuttle", NULL, RESF_DEFAULT);
-	portrait_preload_face_sprite("scuttle", "normal", RESF_DEFAULT);
-	res_preload_multi(RES_BGM, RESF_OPTIONAL, "stage3", "stage3boss", NULL);
-	res_preload_multi(RES_TEXTURE, RESF_DEFAULT,
+static void stage3_preload(ResourceGroup *rg) {
+	portrait_preload_base_sprite(rg, "wriggle", NULL, RESF_DEFAULT);
+	portrait_preload_face_sprite(rg, "wriggle", "proud", RESF_DEFAULT);
+	portrait_preload_base_sprite(rg, "scuttle", NULL, RESF_DEFAULT);
+	portrait_preload_face_sprite(rg, "scuttle", "normal", RESF_DEFAULT);
+	res_group_preload(rg, RES_BGM, RESF_OPTIONAL, "stage3", "stage3boss", NULL);
+	res_group_preload(rg, RES_TEXTURE, RESF_DEFAULT,
 		"ibl_brdf_lut",
 		"stage3/envmap",
 		"stage3/spellbg1",
@@ -99,19 +99,19 @@ static void stage3_preload(void) {
 		"stage3/wspellclouds",
 		"stage3/wspellswarm",
 	NULL);
-	res_preload_multi(RES_MATERIAL, RESF_DEFAULT,
+	res_group_preload(rg, RES_MATERIAL, RESF_DEFAULT,
 		"stage3/ground",
 		"stage3/leaves",
 		"stage3/rocks",
 		"stage3/trees",
 	NULL);
-	res_preload_multi(RES_MODEL, RESF_DEFAULT,
+	res_group_preload(rg, RES_MODEL, RESF_DEFAULT,
 		"stage3/ground",
 		"stage3/leaves",
 		"stage3/rocks",
 		"stage3/trees",
 	NULL);
-	res_preload_multi(RES_SHADER_PROGRAM, RESF_DEFAULT,
+	res_group_preload(rg, RES_SHADER_PROGRAM, RESF_DEFAULT,
 		"glitch",
 		"maristar_bombbg",
 		"pbr",
@@ -119,11 +119,11 @@ static void stage3_preload(void) {
 		"stage3_wriggle_bg",
 		"zbuf_fog",
 	NULL);
-	res_preload_multi(RES_ANIM, RESF_DEFAULT,
+	res_group_preload(rg, RES_ANIM, RESF_DEFAULT,
 		"boss/scuttle",
 		"boss/wriggleex",
 	NULL);
-	res_preload_multi(RES_SFX, RESF_OPTIONAL,
+	res_group_preload(rg, RES_SFX, RESF_OPTIONAL,
 		"laser1",
 	NULL);
 }

--- a/src/stages/stage3/stage3.c
+++ b/src/stages/stage3/stage3.c
@@ -89,8 +89,8 @@ static void stage3_preload(void) {
 	portrait_preload_face_sprite("wriggle", "proud", RESF_DEFAULT);
 	portrait_preload_base_sprite("scuttle", NULL, RESF_DEFAULT);
 	portrait_preload_face_sprite("scuttle", "normal", RESF_DEFAULT);
-	preload_resources(RES_BGM, RESF_OPTIONAL, "stage3", "stage3boss", NULL);
-	preload_resources(RES_TEXTURE, RESF_DEFAULT,
+	res_preload_multi(RES_BGM, RESF_OPTIONAL, "stage3", "stage3boss", NULL);
+	res_preload_multi(RES_TEXTURE, RESF_DEFAULT,
 		"ibl_brdf_lut",
 		"stage3/envmap",
 		"stage3/spellbg1",
@@ -99,19 +99,19 @@ static void stage3_preload(void) {
 		"stage3/wspellclouds",
 		"stage3/wspellswarm",
 	NULL);
-	preload_resources(RES_MATERIAL, RESF_DEFAULT,
+	res_preload_multi(RES_MATERIAL, RESF_DEFAULT,
 		"stage3/ground",
 		"stage3/leaves",
 		"stage3/rocks",
 		"stage3/trees",
 	NULL);
-	preload_resources(RES_MODEL, RESF_DEFAULT,
+	res_preload_multi(RES_MODEL, RESF_DEFAULT,
 		"stage3/ground",
 		"stage3/leaves",
 		"stage3/rocks",
 		"stage3/trees",
 	NULL);
-	preload_resources(RES_SHADER_PROGRAM, RESF_DEFAULT,
+	res_preload_multi(RES_SHADER_PROGRAM, RESF_DEFAULT,
 		"glitch",
 		"maristar_bombbg",
 		"pbr",
@@ -119,11 +119,11 @@ static void stage3_preload(void) {
 		"stage3_wriggle_bg",
 		"zbuf_fog",
 	NULL);
-	preload_resources(RES_ANIM, RESF_DEFAULT,
+	res_preload_multi(RES_ANIM, RESF_DEFAULT,
 		"boss/scuttle",
 		"boss/wriggleex",
 	NULL);
-	preload_resources(RES_SFX, RESF_OPTIONAL,
+	res_preload_multi(RES_SFX, RESF_OPTIONAL,
 		"laser1",
 	NULL);
 }

--- a/src/stages/stage4/stage4.c
+++ b/src/stages/stage4/stage4.c
@@ -92,42 +92,42 @@ static void stage4_spellpractice_start(void) {
 	stage_start_bgm("stage4boss");
 }
 
-static void stage4_preload(void) {
-	portrait_preload_base_sprite("kurumi", NULL, RESF_DEFAULT);
-	portrait_preload_face_sprite("kurumi", "normal", RESF_DEFAULT);
-	res_preload_multi(RES_BGM, RESF_OPTIONAL, "stage4", "stage4boss", NULL);
-	res_preload_multi(RES_TEXTURE, RESF_DEFAULT,
+static void stage4_preload(ResourceGroup *rg) {
+	portrait_preload_base_sprite(rg, "kurumi", NULL, RESF_DEFAULT);
+	portrait_preload_face_sprite(rg, "kurumi", "normal", RESF_DEFAULT);
+	res_group_preload(rg, RES_BGM, RESF_OPTIONAL, "stage4", "stage4boss", NULL);
+	res_group_preload(rg, RES_TEXTURE, RESF_DEFAULT,
 		"fractal_noise",
 		"stage4/kurumibg1",
 		"stage4/kurumibg2",
 	NULL);
-	res_preload_multi(RES_SPRITE, RESF_DEFAULT,
+	res_group_preload(rg, RES_SPRITE, RESF_DEFAULT,
 		"stage6/scythe", // Stage 6 is intentional
 	NULL);
-	res_preload_multi(RES_SHADER_PROGRAM, RESF_DEFAULT,
+	res_group_preload(rg, RES_SHADER_PROGRAM, RESF_DEFAULT,
 		"alpha_discard",
 		"pbr",
 		"sprite_negative",
 		"ssr_water",
 		"zbuf_fog",
 	NULL);
-	res_preload_multi(RES_ANIM, RESF_DEFAULT,
+	res_group_preload(rg, RES_ANIM, RESF_DEFAULT,
 		"boss/kurumi",
 	NULL);
-	res_preload_multi(RES_MATERIAL, RESF_DEFAULT,
+	res_group_preload(rg, RES_MATERIAL, RESF_DEFAULT,
 		"stage4/corridor",
 		"stage4/ground",
 		"stage4/mansion",
 	NULL);
-	res_preload_multi(RES_MODEL, RESF_DEFAULT,
+	res_group_preload(rg, RES_MODEL, RESF_DEFAULT,
 		"stage4/corridor",
 		"stage4/ground",
 		"stage4/mansion",
 	NULL);
-	res_preload_multi(RES_TEXTURE, RESF_OPTIONAL,
+	res_group_preload(rg, RES_TEXTURE, RESF_OPTIONAL,
 		"part/sinewave",
 	NULL);
-	res_preload_multi(RES_SFX, RESF_OPTIONAL,
+	res_group_preload(rg, RES_SFX, RESF_OPTIONAL,
 		"laser1",
 		"boom",
 		"warp",
@@ -135,7 +135,7 @@ static void stage4_preload(void) {
 
 	// XXX: Special case for spell practice of the god damn extra spell, because it always needs a special case.
 	// TODO: Maybe add spell-specific preloads instead of putting everything into the stage one?
-	enemies_preload();
+	enemies_preload(rg);
 }
 
 static void stage4_end(void) {

--- a/src/stages/stage4/stage4.c
+++ b/src/stages/stage4/stage4.c
@@ -95,39 +95,39 @@ static void stage4_spellpractice_start(void) {
 static void stage4_preload(void) {
 	portrait_preload_base_sprite("kurumi", NULL, RESF_DEFAULT);
 	portrait_preload_face_sprite("kurumi", "normal", RESF_DEFAULT);
-	preload_resources(RES_BGM, RESF_OPTIONAL, "stage4", "stage4boss", NULL);
-	preload_resources(RES_TEXTURE, RESF_DEFAULT,
+	res_preload_multi(RES_BGM, RESF_OPTIONAL, "stage4", "stage4boss", NULL);
+	res_preload_multi(RES_TEXTURE, RESF_DEFAULT,
 		"fractal_noise",
 		"stage4/kurumibg1",
 		"stage4/kurumibg2",
 	NULL);
-	preload_resources(RES_SPRITE, RESF_DEFAULT,
+	res_preload_multi(RES_SPRITE, RESF_DEFAULT,
 		"stage6/scythe", // Stage 6 is intentional
 	NULL);
-	preload_resources(RES_SHADER_PROGRAM, RESF_DEFAULT,
+	res_preload_multi(RES_SHADER_PROGRAM, RESF_DEFAULT,
 		"alpha_discard",
 		"pbr",
 		"sprite_negative",
 		"ssr_water",
 		"zbuf_fog",
 	NULL);
-	preload_resources(RES_ANIM, RESF_DEFAULT,
+	res_preload_multi(RES_ANIM, RESF_DEFAULT,
 		"boss/kurumi",
 	NULL);
-	preload_resources(RES_MATERIAL, RESF_DEFAULT,
+	res_preload_multi(RES_MATERIAL, RESF_DEFAULT,
 		"stage4/corridor",
 		"stage4/ground",
 		"stage4/mansion",
 	NULL);
-	preload_resources(RES_MODEL, RESF_DEFAULT,
+	res_preload_multi(RES_MODEL, RESF_DEFAULT,
 		"stage4/corridor",
 		"stage4/ground",
 		"stage4/mansion",
 	NULL);
-	preload_resources(RES_TEXTURE, RESF_OPTIONAL,
+	res_preload_multi(RES_TEXTURE, RESF_OPTIONAL,
 		"part/sinewave",
 	NULL);
-	preload_resources(RES_SFX, RESF_OPTIONAL,
+	res_preload_multi(RES_SFX, RESF_OPTIONAL,
 		"laser1",
 		"boom",
 		"warp",

--- a/src/stages/stage5/stage5.c
+++ b/src/stages/stage5/stage5.c
@@ -74,8 +74,8 @@ static void stage5_start(void) {
 static void stage5_preload(void) {
 	portrait_preload_base_sprite("iku", NULL, RESF_DEFAULT);
 	portrait_preload_face_sprite("iku", "normal", RESF_DEFAULT);
-	preload_resources(RES_BGM, RESF_OPTIONAL, "stage5", "stage5boss", NULL);
-	preload_resources(RES_SPRITE, RESF_DEFAULT,
+	res_preload_multi(RES_BGM, RESF_OPTIONAL, "stage5", "stage5boss", NULL);
+	res_preload_multi(RES_SPRITE, RESF_DEFAULT,
 		"part/blast_huge_halo",
 		"part/blast_huge_rays",
 		"stage5/noise",
@@ -83,28 +83,28 @@ static void stage5_preload(void) {
 		"stage5/spell_clouds",
 		"stage5/spell_lightning",
 	NULL);
-	preload_resources(RES_TEXTURE, RESF_DEFAULT,
+	res_preload_multi(RES_TEXTURE, RESF_DEFAULT,
 		"stage5/envmap",
 	NULL);
-	preload_resources(RES_MATERIAL, RESF_DEFAULT,
+	res_preload_multi(RES_MATERIAL, RESF_DEFAULT,
 		"stage5/metal",
 		"stage5/stairs",
 		"stage5/wall",
 	NULL);
-	preload_resources(RES_MODEL, RESF_DEFAULT,
+	res_preload_multi(RES_MODEL, RESF_DEFAULT,
 		"stage5/stairs",
 		"stage5/wall",
 		"stage5/metal",
 	NULL);
-	preload_resources(RES_SHADER_PROGRAM, RESF_DEFAULT,
+	res_preload_multi(RES_SHADER_PROGRAM, RESF_DEFAULT,
 		"pbr",
 		"zbuf_fog",
 	NULL);
-	preload_resources(RES_ANIM, RESF_DEFAULT,
+	res_preload_multi(RES_ANIM, RESF_DEFAULT,
 		"boss/iku",
 		"boss/iku_mid",
 	NULL);
-	preload_resources(RES_SFX, RESF_OPTIONAL,
+	res_preload_multi(RES_SFX, RESF_OPTIONAL,
 		"boom",
 		"laser1",
 		"enemydeath",

--- a/src/stages/stage5/stage5.c
+++ b/src/stages/stage5/stage5.c
@@ -71,11 +71,11 @@ static void stage5_start(void) {
 	INVOKE_TASK(stage5_timeline);
 }
 
-static void stage5_preload(void) {
-	portrait_preload_base_sprite("iku", NULL, RESF_DEFAULT);
-	portrait_preload_face_sprite("iku", "normal", RESF_DEFAULT);
-	res_preload_multi(RES_BGM, RESF_OPTIONAL, "stage5", "stage5boss", NULL);
-	res_preload_multi(RES_SPRITE, RESF_DEFAULT,
+static void stage5_preload(ResourceGroup *rg) {
+	portrait_preload_base_sprite(rg, "iku", NULL, RESF_DEFAULT);
+	portrait_preload_face_sprite(rg, "iku", "normal", RESF_DEFAULT);
+	res_group_preload(rg, RES_BGM, RESF_OPTIONAL, "stage5", "stage5boss", NULL);
+	res_group_preload(rg, RES_SPRITE, RESF_DEFAULT,
 		"part/blast_huge_halo",
 		"part/blast_huge_rays",
 		"stage5/noise",
@@ -83,28 +83,28 @@ static void stage5_preload(void) {
 		"stage5/spell_clouds",
 		"stage5/spell_lightning",
 	NULL);
-	res_preload_multi(RES_TEXTURE, RESF_DEFAULT,
+	res_group_preload(rg, RES_TEXTURE, RESF_DEFAULT,
 		"stage5/envmap",
 	NULL);
-	res_preload_multi(RES_MATERIAL, RESF_DEFAULT,
+	res_group_preload(rg, RES_MATERIAL, RESF_DEFAULT,
 		"stage5/metal",
 		"stage5/stairs",
 		"stage5/wall",
 	NULL);
-	res_preload_multi(RES_MODEL, RESF_DEFAULT,
+	res_group_preload(rg, RES_MODEL, RESF_DEFAULT,
 		"stage5/stairs",
 		"stage5/wall",
 		"stage5/metal",
 	NULL);
-	res_preload_multi(RES_SHADER_PROGRAM, RESF_DEFAULT,
+	res_group_preload(rg, RES_SHADER_PROGRAM, RESF_DEFAULT,
 		"pbr",
 		"zbuf_fog",
 	NULL);
-	res_preload_multi(RES_ANIM, RESF_DEFAULT,
+	res_group_preload(rg, RES_ANIM, RESF_DEFAULT,
 		"boss/iku",
 		"boss/iku_mid",
 	NULL);
-	res_preload_multi(RES_SFX, RESF_OPTIONAL,
+	res_group_preload(rg, RES_SFX, RESF_OPTIONAL,
 		"boom",
 		"laser1",
 		"enemydeath",

--- a/src/stages/stage6/stage6.c
+++ b/src/stages/stage6/stage6.c
@@ -83,21 +83,21 @@ struct stage6_spells_s stage6_spells = {
 	},
 };
 
-static void stage6_preload(void) {
-	portrait_preload_base_sprite("elly", NULL, RESF_DEFAULT);
-	portrait_preload_face_sprite("elly", "normal", RESF_DEFAULT);
-	portrait_preload_base_sprite("elly", "beaten", RESF_DEFAULT);
-	portrait_preload_face_sprite("elly", "shouting", RESF_DEFAULT);
-	res_preload_multi(RES_BGM, RESF_OPTIONAL,
+static void stage6_preload(ResourceGroup *rg) {
+	portrait_preload_base_sprite(rg, "elly", NULL, RESF_DEFAULT);
+	portrait_preload_face_sprite(rg, "elly", "normal", RESF_DEFAULT);
+	portrait_preload_base_sprite(rg, "elly", "beaten", RESF_DEFAULT);
+	portrait_preload_face_sprite(rg, "elly", "shouting", RESF_DEFAULT);
+	res_group_preload(rg, RES_BGM, RESF_OPTIONAL,
 		"stage6",
 		"stage6boss_phase1",
 		"stage6boss_phase2",
 		"stage6boss_phase3",
 	NULL);
-	res_preload_multi(RES_TEXTURE, RESF_DEFAULT,
+	res_group_preload(rg, RES_TEXTURE, RESF_DEFAULT,
 		"stage6/sky",
 	NULL);
-	res_preload_multi(RES_SPRITE, RESF_DEFAULT,
+	res_group_preload(rg, RES_SPRITE, RESF_DEFAULT,
 		"part/blast_huge_halo",
 		"part/blast_huge_rays",
 		"part/myon",
@@ -117,7 +117,7 @@ static void stage6_preload(void) {
 		"stage6/toelagrangian/3",
 		"stage6/toelagrangian/4",
 	NULL);
-	res_preload_multi(RES_SHADER_PROGRAM, RESF_DEFAULT,
+	res_group_preload(rg, RES_SHADER_PROGRAM, RESF_DEFAULT,
 		"baryon_feedback",
 		"calabi-yau-quintic",
 		"envmap_reflect",
@@ -125,10 +125,10 @@ static void stage6_preload(void) {
 		"stage6_sky",
 		"zbuf_fog",
 	NULL);
-	res_preload_multi(RES_ANIM, RESF_DEFAULT,
+	res_group_preload(rg, RES_ANIM, RESF_DEFAULT,
 		"boss/elly",
 	NULL);
-	res_preload_multi(RES_MATERIAL, RESF_DEFAULT,
+	res_group_preload(rg, RES_MATERIAL, RESF_DEFAULT,
 		"stage6/floor",
 		"stage6/rim",
 		"stage6/spires",
@@ -136,7 +136,7 @@ static void stage6_preload(void) {
 		"stage6/tower",
 		"stage6/tower_bottom",
 	NULL);
-	res_preload_multi(RES_MODEL, RESF_DEFAULT,
+	res_group_preload(rg, RES_MODEL, RESF_DEFAULT,
 		"cube",
 		"stage6/calabi-yau-quintic",
 		"stage6/floor",
@@ -146,7 +146,7 @@ static void stage6_preload(void) {
 		"stage6/tower",
 		"stage6/tower_bottom",
 	NULL);
-	res_preload_multi(RES_SFX, RESF_DEFAULT | RESF_OPTIONAL,
+	res_group_preload(rg, RES_SFX, RESF_DEFAULT | RESF_OPTIONAL,
 		"warp",
 		"noise1",
 		"boom",

--- a/src/stages/stage6/stage6.c
+++ b/src/stages/stage6/stage6.c
@@ -88,16 +88,16 @@ static void stage6_preload(void) {
 	portrait_preload_face_sprite("elly", "normal", RESF_DEFAULT);
 	portrait_preload_base_sprite("elly", "beaten", RESF_DEFAULT);
 	portrait_preload_face_sprite("elly", "shouting", RESF_DEFAULT);
-	preload_resources(RES_BGM, RESF_OPTIONAL,
+	res_preload_multi(RES_BGM, RESF_OPTIONAL,
 		"stage6",
 		"stage6boss_phase1",
 		"stage6boss_phase2",
 		"stage6boss_phase3",
 	NULL);
-	preload_resources(RES_TEXTURE, RESF_DEFAULT,
+	res_preload_multi(RES_TEXTURE, RESF_DEFAULT,
 		"stage6/sky",
 	NULL);
-	preload_resources(RES_SPRITE, RESF_DEFAULT,
+	res_preload_multi(RES_SPRITE, RESF_DEFAULT,
 		"part/blast_huge_halo",
 		"part/blast_huge_rays",
 		"part/myon",
@@ -117,7 +117,7 @@ static void stage6_preload(void) {
 		"stage6/toelagrangian/3",
 		"stage6/toelagrangian/4",
 	NULL);
-	preload_resources(RES_SHADER_PROGRAM, RESF_DEFAULT,
+	res_preload_multi(RES_SHADER_PROGRAM, RESF_DEFAULT,
 		"baryon_feedback",
 		"calabi-yau-quintic",
 		"envmap_reflect",
@@ -125,10 +125,10 @@ static void stage6_preload(void) {
 		"stage6_sky",
 		"zbuf_fog",
 	NULL);
-	preload_resources(RES_ANIM, RESF_DEFAULT,
+	res_preload_multi(RES_ANIM, RESF_DEFAULT,
 		"boss/elly",
 	NULL);
-	preload_resources(RES_MATERIAL, RESF_DEFAULT,
+	res_preload_multi(RES_MATERIAL, RESF_DEFAULT,
 		"stage6/floor",
 		"stage6/rim",
 		"stage6/spires",
@@ -136,7 +136,7 @@ static void stage6_preload(void) {
 		"stage6/tower",
 		"stage6/tower_bottom",
 	NULL);
-	preload_resources(RES_MODEL, RESF_DEFAULT,
+	res_preload_multi(RES_MODEL, RESF_DEFAULT,
 		"cube",
 		"stage6/calabi-yau-quintic",
 		"stage6/floor",
@@ -146,7 +146,7 @@ static void stage6_preload(void) {
 		"stage6/tower",
 		"stage6/tower_bottom",
 	NULL);
-	preload_resources(RES_SFX, RESF_DEFAULT | RESF_OPTIONAL,
+	res_preload_multi(RES_SFX, RESF_DEFAULT | RESF_OPTIONAL,
 		"warp",
 		"noise1",
 		"boom",

--- a/src/video_postprocess.c
+++ b/src/video_postprocess.c
@@ -23,7 +23,7 @@ struct VideoPostProcess {
 };
 
 VideoPostProcess *video_postprocess_init(void) {
-	PostprocessShader *pps = get_resource_data(RES_POSTPROCESS, "global", RESF_OPTIONAL | RESF_PERMANENT | RESF_PRELOAD);
+	PostprocessShader *pps = res_get_data(RES_POSTPROCESS, "global", RESF_OPTIONAL | RESF_PERMANENT | RESF_PRELOAD);
 
 	if(!pps) {
 		return NULL;

--- a/src/video_postprocess.c
+++ b/src/video_postprocess.c
@@ -23,7 +23,9 @@ struct VideoPostProcess {
 };
 
 VideoPostProcess *video_postprocess_init(void) {
-	PostprocessShader *pps = res_get_data(RES_POSTPROCESS, "global", RESF_OPTIONAL | RESF_PERMANENT | RESF_PRELOAD);
+	// TODO separate group?
+	res_group_preload(NULL, RES_POSTPROCESS, RESF_OPTIONAL, "global", NULL);
+	PostprocessShader *pps = res_get_data(RES_POSTPROCESS, "global", RESF_OPTIONAL);
 
 	if(!pps) {
 		return NULL;


### PR DESCRIPTION
Renames some functions for consistency, but more importantly completely redesigns resource lifetime management.

`RESF_PERMANENT` is gone and resources are now reference-counted. Preload functions now require a `ResourceGroup` object that keeps references to the preloaded resources. `ResourceGroup`s must be eventually `res_group_release()`'d, which decrements the refcounts of previously preloaded resources and frees memory used to store the references. Resources with zero refcount are not unloaded immediately, but put in a "purgatory" list instead. `res_purge()` can be called to unload all resources currently in the purgatory. Currently a purge is done right after preloading resources for a stage. This lets us keep shared resources loaded across stages, while unloading the no longer needed ones.

Resources that weren't preloaded are put into an implicit global `ResourceGroup`, which is never released until exit. This still generates a warning at runtime. It is possible to put resources into this global group manually without triggering the warning by passing `NULL` for the group pointer to `res_group_preload()`, but it's recommended to manage a local `ResourceGroup` instead.