### PR TITLE
switch: use native screen resolution and remove old workarounds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -335,7 +335,7 @@ jobs:
     name: Switch (ARM64)
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     runs-on: ubuntu-20.04
-    container: taiseiproject/switch-toolkit:20221226
+    container: taiseiproject/switch-toolkit:20231006
     steps:
     - name: Checkout Code
       uses: actions/checkout@v3

--- a/src/arch_switch.c
+++ b/src/arch_switch.c
@@ -22,8 +22,6 @@
 #define NX_LOG(str) NX_LOG_FMT("%s", str)
 #define NX_SETENV(name, val) NX_LOG_FMT("Setting env var %s to %s", name, val);env_set_string(name, val, true)
 
-uint32_t __nx_fs_num_sessions = 1;
-
 static nxAtExitFn g_nxAtExitFn = NULL;
 static char g_programDir[FS_MAX_PATH] = {0};
 static AppletHookCookie g_hookCookie;

--- a/src/arch_switch.c
+++ b/src/arch_switch.c
@@ -53,8 +53,6 @@ void userAppInit(void) {
 	NX_LOG("nxlink enabled");
 #endif
 
-	NX_SETENV("TAISEI_NOASYNC", "1");
-
 	appletInitializeGamePlayRecording();
 	appletSetGamePlayRecordingState(1);
 

--- a/src/arch_switch.c
+++ b/src/arch_switch.c
@@ -26,6 +26,9 @@ static nxAtExitFn g_nxAtExitFn = NULL;
 static char g_programDir[FS_MAX_PATH] = {0};
 static AppletHookCookie g_hookCookie;
 
+static s32 g_initialScreenWidth = 1920;
+static s32 g_initialScreenHeight = 1080;
+
 static void onAppletHook(AppletHookType hook, void *param) {
 	switch (hook) {
 		case AppletHookType_OnExitRequest:
@@ -51,6 +54,7 @@ void userAppInit(void) {
 	NX_LOG("nxlink enabled");
 #endif
 
+	appletGetDefaultDisplayResolution(&g_initialScreenWidth, &g_initialScreenHeight);
 	appletInitializeGamePlayRecording();
 	appletSetGamePlayRecordingState(1);
 
@@ -111,4 +115,12 @@ void noreturn nxAbort(void) {
 
 const char* nxGetProgramDir(void) {
 	return g_programDir;
+}
+
+int nxGetInitialScreenWidth(void) {
+	return g_initialScreenWidth;
+}
+
+int nxGetInitialScreenHeight(void) {
+	return g_initialScreenHeight;
 }

--- a/src/arch_switch.h
+++ b/src/arch_switch.h
@@ -16,3 +16,6 @@ int nxAtExit(nxAtExitFn fn);
 void noreturn nxExit(int rc);
 void noreturn nxAbort(void);
 const char* nxGetProgramDir(void);
+
+int nxGetInitialScreenWidth(void);
+int nxGetInitialScreenHeight(void);

--- a/src/config.c
+++ b/src/config.c
@@ -499,6 +499,9 @@ void config_load(void) {
 #ifdef __SWITCH__
 	config_set_int(CONFIG_GAMEPAD_ENABLED, true);
 	config_set_str(CONFIG_GAMEPAD_DEVICE, "any");
+	config_set_int(CONFIG_FULLSCREEN, 0);
+	config_set_int(CONFIG_VID_WIDTH, nxGetInitialScreenWidth());
+	config_set_int(CONFIG_VID_HEIGHT, nxGetInitialScreenHeight());
 #endif
 }
 

--- a/src/config.c
+++ b/src/config.c
@@ -499,7 +499,6 @@ void config_load(void) {
 #ifdef __SWITCH__
 	config_set_int(CONFIG_GAMEPAD_ENABLED, true);
 	config_set_str(CONFIG_GAMEPAD_DEVICE, "any");
-	config_set_int(CONFIG_FULLSCREEN, 0);
 	config_set_int(CONFIG_VID_WIDTH, nxGetInitialScreenWidth());
 	config_set_int(CONFIG_VID_HEIGHT, nxGetInitialScreenHeight());
 #endif

--- a/src/global.h
+++ b/src/global.h
@@ -48,13 +48,8 @@
 
 enum {
 	// defaults
-#ifdef __SWITCH__
-	RESX = 1280,
-	RESY = 720,
-#else
 	RESX = 800,
 	RESY = 600,
-#endif
 
 	VIEWPORT_X = 40,
 	VIEWPORT_Y = 20,

--- a/src/video.c
+++ b/src/video.c
@@ -142,6 +142,8 @@ static VideoCapabilityState video_query_capability_alwaysfullscreen(VideoCapabil
 
 static VideoCapabilityState video_query_capability_switch(VideoCapability cap) {
 	switch(cap) {
+		// We want the window to be resizable and resized internally by SDL
+		// when the Switch gets docked/undocked
 		case VIDEO_CAP_FULLSCREEN:
 			return VIDEO_NEVER_AVAILABLE;
 
@@ -777,6 +779,7 @@ static bool video_handle_window_event(SDL_Event *event, void *arg) {
 			log_debug("SDL_WINDOWEVENT_SIZE_CHANGED: %ix%i", event->window.data1, event->window.data2);
 
 			// Catch resizes by the SDL portlib itself, when the console is docked/undocked
+			// https://github.com/devkitPro/SDL/issues/31
 			if(video_get_backend() == VIDEO_BACKEND_SWITCH) {
 				video_handle_resize(event->window.data1, event->window.data2);
 			}


### PR DESCRIPTION
I had to apply the same kind of workaround needed for the meson bug encountered with libzstd. Most Mesa and libnx bugs we encountered have since been fixed, so I tried removing quirks and ifdef'd code in the switch code. 

Also, the SDL window size will now adjust to the native resolution of the screen you're playing on (tv, handheld). This is mostly handheld by the switch SDL port under the hood, which resizes the window if not flagged fullscreen.