### PR TITLE
i686 build fixes

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -179,7 +179,7 @@ taisei_c_args = cc.get_supported_arguments(taisei_c_args)
 
 foreach arglist : [
         taisei_conversion_c_args,
-        ['-msse', '-mfpmath=sse'],
+        ['-msse2', '-mfpmath=sse'],
     ]
     if cc.has_multi_arguments(arglist)
         taisei_c_args += arglist

--- a/scripts/pack.py
+++ b/scripts/pack.py
@@ -104,12 +104,12 @@ def log_file(path, arcname, comp_type=None):
 def pack(args):
     nocompress_file = args.directory / '.nocompress'
 
-    if 1:
+    if sys.maxsize > 2**32:
         comp_type = ZIP_ZSTANDARD
         comp_level = 20
     else:
-        comp_type = ZIP_DEFLATED
-        comp_level = 9
+        comp_type = ZIP_ZSTANDARD
+        comp_level = 19
 
     try:
         nocompress = list(map(re.compile, filter(None, nocompress_file.read_text().strip().split('\n'))))


### PR DESCRIPTION
cglm incorrectly assumes that SSE2 is also available when SSE1 
python3-zstandard runs out of memeory on i686 with comp_level=20

[related](https://github.com/void-linux/void-packages/pull/49348)