### PR TITLE
Replaced `floor(log2(dim)` with `r_integer_log_2` 

### DIFF
--- a/src/renderer/api.c
+++ b/src/renderer/api.c
@@ -552,7 +552,7 @@ TextureType r_texture_type_from_pixmap_format(PixmapFormat fmt) {
 
 uint r_texture_util_max_num_miplevels(uint width, uint height) {
 	uint dim = max(width, height);
-	return dim > 0 ? 1 + floor(log2(dim)) : 0;  // TODO replace with integer log2
+	return dim > 0 ? 1 + r_integer_log_2(dim) : 0;
 }
 
 Framebuffer* r_framebuffer_create(void) {

--- a/src/renderer/api.h
+++ b/src/renderer/api.h
@@ -1012,3 +1012,10 @@ INLINE
 bool r_supports(RendererFeature feature) {
 	return r_features() & r_feature_bit(feature);
 }
+
+INLINE
+uint r_integer_log_2(uint x) {
+	uint log = 0;
+	while(x >>= 1) ++log;
+	return log;
+}


### PR DESCRIPTION
Just a little nitpick I had while browsing through the source code out of curiosity.