### PR TITLE
macOS: Update testing/release pipeline, enable ANGLE support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,6 +29,7 @@ on:
 env:
   MESON_VERSION: '0.63.3'
   EM_VERSION: '3.1.68'
+  PYTHON_VERSION: '3.11.8'
   EM_CACHE_FOLDER: 'emsdk'
   TAISEI_NOPRELOAD: 0
   TAISEI_PRELOAD_REQUIRED: 1
@@ -47,7 +48,7 @@ jobs:
     - name: Install Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
+        python-version: ${{ env.PYTHON_VERSION }}
 
     - name: Install Tools
       run: >
@@ -103,7 +104,7 @@ jobs:
   macos-test-build:
     name: macOS (x64)
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
-    runs-on: macos-13
+    runs-on: macos-14
     steps:
     - name: Checkout Code
       uses: actions/checkout@v4
@@ -113,7 +114,7 @@ jobs:
     - name: Install Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
+        python-version: ${{ env.PYTHON_VERSION }}
 
     - name: Install Tools
       run: >
@@ -135,6 +136,7 @@ jobs:
         ninja
         setuptools
         zstandard
+        --break-system-packages
 
     - name: Configure
       run: >
@@ -214,7 +216,7 @@ jobs:
     - name: Install Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
+        python-version: ${{ env.PYTHON_VERSION }}
 
     - name: Install Tools
       run: >

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -104,7 +104,7 @@ jobs:
   macos-test-build:
     name: macOS (x64)
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
-    runs-on: macos-14
+    runs-on: macos-13
     steps:
     - name: Checkout Code
       uses: actions/checkout@v4
@@ -119,11 +119,8 @@ jobs:
     - name: Install Tools
       run: >
         brew install
-        gcc
-        pkg-config
         docutils
         pygments
-        freetype2
         libzip
         opusfile
         libvorbis

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -103,7 +103,7 @@ jobs:
   macos-test-build:
     name: macOS (x64)
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
     - name: Checkout Code
       uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -104,7 +104,7 @@ jobs:
   macos-test-build:
     name: macOS (x64)
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
-    runs-on: macos-13
+    runs-on: macos-12
     steps:
     - name: Checkout Code
       uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -199,7 +199,7 @@ jobs:
   macos-release-build-universal:
     name: macOS (Universal)
     if: ${{ (github.event.inputs.macos-x64-arm64 || 'true') == 'true' }}
-    runs-on: macos-14
+    runs-on: macos-13
     steps:
     - name: Install Tools
       run: >

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -199,7 +199,7 @@ jobs:
   macos-release-build-universal:
     name: macOS (Universal)
     if: ${{ (github.event.inputs.macos-x64-arm64 || 'true') == 'true' }}
-    runs-on: macos-13
+    runs-on: macos-14
     steps:
     - name: Install Tools
       run: >
@@ -214,6 +214,8 @@ jobs:
         python-gnupg
         setuptools
         zstandard
+        --break-system-packages
+
       shell: bash
 
     - name: Import GPG Key
@@ -229,7 +231,7 @@ jobs:
         fetch-depth: 0
         ref: ${{ env.REF }}
 
-    - name: Checkout ANGLE DLLs
+    - name: Checkout Compiled ANGLE Libraries
       uses: actions/checkout@v4
       with:
         repository: taisei-project/angle-compiled
@@ -306,7 +308,7 @@ jobs:
         fetch-depth: 0
         ref: ${{ env.REF }}
 
-    - name: Checkout ANGLE DLLs
+    - name: Checkout Compiled ANGLE Libraries
       uses: actions/checkout@v4
       with:
         repository: taisei-project/angle-compiled
@@ -397,7 +399,7 @@ jobs:
         fetch-depth: 0
         ref: ${{ env.REF }}
 
-    - name: Checkout ANGLE DLLs
+    - name: Checkout Compiled ANGLE Libraries
       uses: actions/checkout@v4
       with:
         repository: taisei-project/angle-compiled

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -199,7 +199,7 @@ jobs:
   macos-release-build-universal:
     name: macOS (Universal)
     if: ${{ (github.event.inputs.macos-x64-arm64 || 'true') == 'true' }}
-    runs-on: macos-13
+    runs-on: macos-12
     steps:
     - name: Install Tools
       run: >

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -199,7 +199,7 @@ jobs:
   macos-release-build-universal:
     name: macOS (Universal)
     if: ${{ (github.event.inputs.macos-x64-arm64 || 'true') == 'true' }}
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
     - name: Install Tools
       run: >
@@ -228,6 +228,12 @@ jobs:
         submodules: 'recursive'
         fetch-depth: 0
         ref: ${{ env.REF }}
+
+    - name: Checkout ANGLE DLLs
+      uses: actions/checkout@v4
+      with:
+        repository: taisei-project/angle-compiled
+        path: angle-compiled
 
     - name: Configure
       run: |

--- a/misc/ci/macos-aarch64-build-release.ini
+++ b/misc/ci/macos-aarch64-build-release.ini
@@ -1,7 +1,7 @@
 [constants]
 # apple silicon only supports macOS >=11.x, so just use that
 macos_min = '11.1'
-cflags = ['-mmacosx-version-min='+macos_min, '-arch', 'arm64', '-mcpu=apple-m1']
+cflags = ['-mmacosx-version-min='+macos_min, '-arch', 'arm64', '-mcpu=apple-m1', '-fno-integrated-as']
 ldflags = cflags
 
 [host_machine]

--- a/misc/ci/macos-aarch64-build-release.ini
+++ b/misc/ci/macos-aarch64-build-release.ini
@@ -1,7 +1,7 @@
 [constants]
 # apple silicon only supports macOS >=11.x, so just use that
 macos_min = '11.1'
-cflags = ['-Wl,-ld_classic', '-mmacosx-version-min='+macos_min, '-arch', 'arm64', '-mcpu=apple-m1', '-fno-integrated-as']
+cflags = ['-mmacosx-version-min='+macos_min, '-arch', 'arm64', '-mcpu=apple-m1', '-fno-integrated-as']
 ldflags = cflags
 
 [host_machine]

--- a/misc/ci/macos-aarch64-build-release.ini
+++ b/misc/ci/macos-aarch64-build-release.ini
@@ -1,7 +1,7 @@
 [constants]
 # apple silicon only supports macOS >=11.x, so just use that
 macos_min = '11.1'
-cflags = ['-mmacosx-version-min='+macos_min, '-arch', 'arm64', '-mcpu=apple-m1', '-fno-integrated-as']
+cflags = ['-Wl,-ld_classic', '-mmacosx-version-min='+macos_min, '-arch', 'arm64', '-mcpu=apple-m1', '-fno-integrated-as']
 ldflags = cflags
 
 [host_machine]

--- a/misc/ci/macos-aarch64-build-release.ini
+++ b/misc/ci/macos-aarch64-build-release.ini
@@ -1,12 +1,12 @@
 [constants]
 # apple silicon only supports macOS >=11.x, so just use that
 macos_min = '11.1'
-cflags = ['-mmacosx-version-min='+macos_min, '-arch', 'arm64', '-mcpu=apple-a14']
+cflags = ['-mmacosx-version-min='+macos_min, '-arch', 'arm64', '-mcpu=apple-m1']
 ldflags = cflags
 
 [host_machine]
 cpu_family = 'aarch64'
-cpu = 'apple-a14'
+cpu = 'apple-m1'
 system = 'darwin'
 endian = 'little'
 
@@ -21,6 +21,9 @@ pkgconfig = 'pkg-config'
 needs_exe_wrapper = true
 
 [project options]
+install_angle = true
+r_gles30 = 'enabled'
+shader_transpiler = 'enabled'
 install_macos_bundle = 'enabled'
 
 [built-in options]

--- a/misc/ci/macos-aarch64-build-release.ini
+++ b/misc/ci/macos-aarch64-build-release.ini
@@ -1,7 +1,7 @@
 [constants]
 # apple silicon only supports macOS >=11.x, so just use that
 macos_min = '11.1'
-cflags = ['-mmacosx-version-min='+macos_min, '-arch', 'arm64', '-mcpu=apple-m1', '-fno-integrated-as']
+cflags = ['-mmacosx-version-min='+macos_min, '-arch', 'arm64', '-mcpu=apple-m1']
 ldflags = cflags
 
 [host_machine]

--- a/misc/ci/macos-x86_64-build-release.ini
+++ b/misc/ci/macos-x86_64-build-release.ini
@@ -1,6 +1,6 @@
 [constants]
 macos_min = '10.15'
-cflags = ['-mmacosx-version-min='+macos_min, '-arch', 'x86_64', '-fno-integrated-as']
+cflags = ['-mmacosx-version-min='+macos_min, '-arch', 'x86_64']
 ldflags = cflags
 
 [host_machine]

--- a/misc/ci/macos-x86_64-build-release.ini
+++ b/misc/ci/macos-x86_64-build-release.ini
@@ -5,6 +5,12 @@ macos_min = '10.15'
 cflags = ['-mmacosx-version-min='+macos_min, '-march='+march, '-mtune='+mtune]
 ldflags = ['-mmacosx-version-min='+macos_min]
 
+[project options]
+install_angle = true
+r_gles30 = 'enabled'
+shader_transpiler = 'enabled'
+install_macos_bundle = 'enabled'
+
 [built-in options]
 c_args = cflags
 c_link_args = ldflags

--- a/misc/ci/macos-x86_64-build-release.ini
+++ b/misc/ci/macos-x86_64-build-release.ini
@@ -1,6 +1,6 @@
 [constants]
 macos_min = '10.15'
-cflags = ['-mmacosx-version-min='+macos_min, '-arch', 'x86_64', '-fno-integrated-as']
+cflags = ['-Wl,-ld_classic', '-mmacosx-version-min='+macos_min, '-arch', 'x86_64', '-fno-integrated-as']
 ldflags = cflags
 
 [host_machine]

--- a/misc/ci/macos-x86_64-build-release.ini
+++ b/misc/ci/macos-x86_64-build-release.ini
@@ -1,9 +1,18 @@
 [constants]
-march = 'core2'
-mtune = 'skylake'
 macos_min = '10.15'
-cflags = ['-mmacosx-version-min='+macos_min, '-march='+march, '-mtune='+mtune]
-ldflags = ['-mmacosx-version-min='+macos_min]
+cflags = ['-mmacosx-version-min='+macos_min, '-arch', 'x86_64']
+ldflags = cflags
+
+[host_machine]
+cpu_family = 'x86_64'
+system = 'darwin'
+
+[binaries]
+c = 'clang'
+cpp = 'clang++'
+objc = 'clang'
+strip = 'strip'
+pkgconfig = 'pkg-config'
 
 [project options]
 install_angle = true

--- a/misc/ci/macos-x86_64-build-release.ini
+++ b/misc/ci/macos-x86_64-build-release.ini
@@ -1,6 +1,6 @@
 [constants]
 macos_min = '10.15'
-cflags = ['-Wl,-ld_classic', '-mmacosx-version-min='+macos_min, '-arch', 'x86_64', '-fno-integrated-as']
+cflags = ['-mmacosx-version-min='+macos_min, '-arch', 'x86_64', '-fno-integrated-as']
 ldflags = cflags
 
 [host_machine]

--- a/misc/ci/macos-x86_64-build-release.ini
+++ b/misc/ci/macos-x86_64-build-release.ini
@@ -1,6 +1,6 @@
 [constants]
 macos_min = '10.15'
-cflags = ['-mmacosx-version-min='+macos_min, '-arch', 'x86_64']
+cflags = ['-mmacosx-version-min='+macos_min, '-arch', 'x86_64', '-fno-integrated-as']
 ldflags = cflags
 
 [host_machine]

--- a/misc/ci/macos-x86_64-build-test-ci.ini
+++ b/misc/ci/macos-x86_64-build-test-ci.ini
@@ -1,6 +1,6 @@
 [constants]
 macos_min = '10.15'
-cflags = ['-mmacosx-version-min='+macos_min, '-arch', 'x86_64']
+cflags = ['-mmacosx-version-min='+macos_min, '-arch', 'x86_64', '-fno-integrated-as']
 # NOTE: might need to pass -sdk_version to the linker as well, not sure how that works...
 ldflags = cflags
 

--- a/misc/ci/macos-x86_64-build-test-ci.ini
+++ b/misc/ci/macos-x86_64-build-test-ci.ini
@@ -1,6 +1,6 @@
 [constants]
 macos_min = '10.15'
-cflags = ['-mmacosx-version-min='+macos_min, '-arch', 'x86_64', '-fno-integrated-as']
+cflags = ['-mmacosx-version-min='+macos_min, '-arch', 'x86_64']
 # NOTE: might need to pass -sdk_version to the linker as well, not sure how that works...
 ldflags = cflags
 

--- a/misc/ci/macos-x86_64-build-test-ci.ini
+++ b/misc/ci/macos-x86_64-build-test-ci.ini
@@ -1,6 +1,6 @@
 [constants]
 macos_min = '10.15'
-cflags = ['-mmacosx-version-min='+macos_min, '-arch', 'x86_64', '-fno-integrated-as']
+cflags = ['-Wl,-ld_classic', '-mmacosx-version-min='+macos_min, '-arch', 'x86_64', '-fno-integrated-as']
 # NOTE: might need to pass -sdk_version to the linker as well, not sure how that works...
 ldflags = cflags
 

--- a/misc/ci/macos-x86_64-build-test-ci.ini
+++ b/misc/ci/macos-x86_64-build-test-ci.ini
@@ -1,11 +1,19 @@
 [constants]
-march = 'core2'
-mtune = 'skylake'
 macos_min = '10.15'
-
-cflags = ['-mmacosx-version-min='+macos_min, '-march='+march, '-mtune='+mtune]
+cflags = ['-mmacosx-version-min='+macos_min, '-arch', 'x86_64']
 # NOTE: might need to pass -sdk_version to the linker as well, not sure how that works...
-ldflags = ['-mmacosx-version-min='+macos_min]
+ldflags = cflags
+
+[host_machine]
+cpu_family = 'x86_64'
+system = 'darwin'
+
+[binaries]
+c = 'clang'
+cpp = 'clang++'
+objc = 'clang'
+strip = 'strip'
+pkgconfig = 'pkg-config'
 
 [built-in options]
 c_args = cflags

--- a/misc/ci/macos-x86_64-build-test-ci.ini
+++ b/misc/ci/macos-x86_64-build-test-ci.ini
@@ -1,6 +1,6 @@
 [constants]
 macos_min = '10.15'
-cflags = ['-Wl,-ld_classic', '-mmacosx-version-min='+macos_min, '-arch', 'x86_64', '-fno-integrated-as']
+cflags = ['-mmacosx-version-min='+macos_min, '-arch', 'x86_64', '-fno-integrated-as']
 # NOTE: might need to pass -sdk_version to the linker as well, not sure how that works...
 ldflags = cflags
 

--- a/scripts/macos_setup_universal.sh
+++ b/scripts/macos_setup_universal.sh
@@ -4,15 +4,25 @@ set -e
 
 source "$(pwd)/.mac_env"
 
-mkdir -p "$MAC_BUILD_DIR/compiled" "$MESON_BUILD_ROOT_MACOS_COMBINED"
+mkdir -p "$MAC_BUILD_DIR/compiled" "$TAISEI_ROOT/angle-compiled/lib/macOS-universal-dylib" "$MESON_BUILD_ROOT_MACOS_COMBINED"
+
+# combine dylibs
+lipo "$TAISEI_ROOT/angle-compiled/lib/macOS-arm64-dylib/libEGL.dylib" "$TAISEI_ROOT/angle-compiled/lib/macOS-x64-dylib/libEGL.dylib" -output "$TAISEI_ROOT/angle-compiled/lib/macOS-universal-dylib/libEGL.dylib" -create
+lipo "$TAISEI_ROOT/angle-compiled/lib/macOS-arm64-dylib/libGLESv2.dylib" "$TAISEI_ROOT/angle-compiled/lib/macOS-x64-dylib/libGLESv2.dylib" -output "$TAISEI_ROOT/angle-compiled/lib/macOS-universal-dylib/libGLESv2.dylib" -create
+
 meson setup \
+	-Dangle_libegl=$TAISEI_ROOT/angle-compiled/lib/macOS-universal-dylib/libEGL.dylib \
+	-Dangle_libgles=$TAISEI_ROOT/angle-compiled/lib/macOS-universal-dylib/libGLESv2.dylib \
 	--native-file "$TAISEI_ROOT/misc/ci/common-options.ini" \
 	--native-file "$TAISEI_ROOT/misc/ci/forcefallback.ini" \
 	--native-file "$TAISEI_ROOT/misc/ci/macos-x86_64-build-release.ini" \
 	--prefix "$MESON_BUILD_ROOT_MACOS_X64_COMPILED" \
 	"$MESON_BUILD_ROOT_MACOS_X64" \
 	"$TAISEI_ROOT" "$@"
+
 meson setup \
+	-Dangle_libegl=$TAISEI_ROOT/angle-compiled/lib/macOS-universal-dylib/libEGL.dylib \
+	-Dangle_libgles=$TAISEI_ROOT/angle-compiled/lib/macOS-universal-dylib/libGLESv2.dylib \
 	--cross-file "$TAISEI_ROOT/misc/ci/common-options.ini" \
 	--cross-file "$TAISEI_ROOT/misc/ci/forcefallback.ini" \
 	--cross-file "$TAISEI_ROOT/misc/ci/macos-aarch64-build-release.ini" \


### PR DESCRIPTION
This PR upgrades the macOS testing and release pipelines. 

Mostly this involves:

* ~~Bumping from `macos-12` to `macos-14`~~ 
* Changing the meson native/crossfiles to match the new syntax XCode `clang` expects. (i.e: using `arch` instead of `march`
* Importing the compiled ANGLE `dylibs` and `lipo`ing them together in the release pipeline so they're "universal" (x64 and ARM64)
* Other stuff to make this all work