### PR TITLE
Numerical consistency improvements in pursuit of a desyncless world

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,3 +9,7 @@
 	path = external/basis_universal
 	url = https://github.com/taisei-project/basis_universal.git
 	branch = taisei
+[submodule "external/openlibm"]
+	path = external/openlibm
+	url = https://github.com/taisei-project/openlibm
+	branch = taisei-v1.5

--- a/meson.build
+++ b/meson.build
@@ -126,8 +126,11 @@ taisei_c_args = [
     '-Wunreachable-code-loop-increment',
 
     '-fexcess-precision=standard',
+    '-ffp-contract=off',
     '-fmerge-all-constants',
+    '-fno-fp-int-builtin-inexact',
     '-fno-math-errno',
+    '-fno-rounding-math',
     '-fno-signaling-nans',
     '-fno-trapping-math',
     '-fzero-init-padding-bits=all',

--- a/meson.build
+++ b/meson.build
@@ -125,14 +125,16 @@ taisei_c_args = [
     '-Wunreachable-code',
     '-Wunreachable-code-loop-increment',
 
+    # NOTE: These are important for replay consistency
     '-fexcess-precision=standard',
     '-ffp-contract=off',
-    '-fmerge-all-constants',
     '-fno-fp-int-builtin-inexact',
     '-fno-math-errno',
     '-fno-rounding-math',
     '-fno-signaling-nans',
     '-fno-trapping-math',
+
+    '-fmerge-all-constants',
     '-fzero-init-padding-bits=all',
 ]
 
@@ -205,9 +207,14 @@ dep_crypto      = dependency('libcrypto',                           required : g
 dep_gamemode    = dependency('gamemode',                            required : opt_gamemode)
 dep_libunibreak = dependency('libunibreak',                         required : true)
 
+# Vendoring our own, version-pinned openlibm is important for replay consistency.
+# Please don't patch this out. Otherwise some replays will not be portable across systems.
 use_openlibm = true
 
 if use_openlibm
+    # Our openlibm dependency links a static library as --whole-archive
+    # This is the only reliable way I've found to make it actually intercept the math calls
+    # It's important to only specify it once per target, otherwise you get duplicate symbol conflicts
     dep_m_linkwhole = subproject('openlibm').get_variable('openlibm_dep')
     dep_m = dep_m_linkwhole.partial_dependency(
         compile_args : true,

--- a/meson.build
+++ b/meson.build
@@ -202,7 +202,21 @@ dep_crypto      = dependency('libcrypto',                           required : g
 dep_gamemode    = dependency('gamemode',                            required : opt_gamemode)
 dep_libunibreak = dependency('libunibreak',                         required : true)
 
-dep_m           = cc.find_library('m', required : false)
+use_openlibm = true
+
+if use_openlibm
+    dep_m_linkwhole = subproject('openlibm').get_variable('openlibm_dep')
+    dep_m = dep_m_linkwhole.partial_dependency(
+        compile_args : true,
+        includes     : true,
+        link_args    : false,
+        links        : false,
+        sources      : false,
+    )
+else
+    dep_m = cc.find_library('m', required : false)
+    dep_m_linkwhole = declare_dependency()
+endif
 
 dep_basisu_transcoder = subproject('basis_universal').get_variable('basisu_transcoder_dep')
 dep_koishi      = subproject('koishi').get_variable('koishi_dep')
@@ -225,7 +239,11 @@ taisei_deps = [
     dep_webp,
     dep_zlib,
     dep_zstd,
-    # don't add glad here
+    # NOTE: don't add glad here
+]
+
+taisei_deps_linkwhole = [
+    dep_m_linkwhole
 ]
 
 if host_machine.system() == 'windows'
@@ -266,17 +284,20 @@ have_timespec =     cc.has_function('timespec_get')
 
 assert(have_vla and have_complex, 'Your C implementation needs to support complex numbers and variable-length arrays.')
 
+config.set('TAISEI_BUILDCONF_USE_OPENLIBM', use_openlibm)
 config.set('TAISEI_BUILDCONF_HAVE_TIMESPEC', have_timespec)
 config.set('TAISEI_BUILDCONF_HAVE_INT128', cc.sizeof('__int128') == 16)
 config.set('TAISEI_BUILDCONF_HAVE_LONG_DOUBLE', cc.sizeof('long double') > 8)
 config.set('TAISEI_BUILDCONF_HAVE_POSIX', have_posix)
-config.set('TAISEI_BUILDCONF_HAVE_SINCOS', cc.has_function('sincos', dependencies : dep_m))
 
-use_gnu_funcs = false
-gnu_funcs = ['sincos', 'strtok_r', 'memrchr', 'memmem']
+have_sincos = use_openlibm or cc.has_function('sincos', dependencies : dep_m)
+config.set('TAISEI_BUILDCONF_HAVE_SINCOS', have_sincos)
+
+use_gnu_funcs = have_sincos and not use_openlibm
+gnu_funcs = ['strtok_r', 'memrchr', 'memmem']
 
 foreach f : gnu_funcs
-    have = cc.has_function(f, dependencies : dep_m)
+    have = cc.has_function(f)
     config.set('TAISEI_BUILDCONF_HAVE_@0@'.format(f.to_upper()), have)
     use_gnu_funcs = have or use_gnu_funcs
 endforeach

--- a/misc/ci/common-options.ini
+++ b/misc/ci/common-options.ini
@@ -71,3 +71,6 @@ werror = false
 
 [zlib:built-in options]
 werror = false
+
+[openlibm:built-in options]
+werror = false

--- a/src/arch_switch.c
+++ b/src/arch_switch.c
@@ -6,6 +6,8 @@
  */
 
 #include "arch_switch.h"
+
+#include "global.h"
 #include "renderer/glcommon/debug.h"
 #include "util/env.h"
 #include "util/io.h"

--- a/src/meson.build
+++ b/src/meson.build
@@ -179,7 +179,7 @@ if stages_live_reload
     endif
 
     taisei_stages = shared_module('taisei-stages', stages_src, version_deps,
-        dependencies : taisei_deps,
+        dependencies : taisei_deps_linkwhole + taisei_deps,
         c_args : taisei_c_args,
         c_pch : 'pch/taisei_pch.h',
         build_by_default : true,
@@ -374,7 +374,7 @@ if host_machine.system() == 'emscripten'
     endif
 
     libtaisei = static_library(taisei_basename, taisei_src, taisei_main_src, version_deps,
-        dependencies : taisei_deps,
+        dependencies : taisei_deps_linkwhole + taisei_deps,
         c_pch : 'pch/taisei_pch.h',
         c_args : [em_common_args, taisei_c_args],
         install : meson_link_whole_is_broken,
@@ -420,7 +420,7 @@ if host_machine.system() == 'emscripten'
 elif host_machine.system() == 'nx'
     taisei_elf_name = '@0@.elf'.format(taisei_basename)
     taisei_elf = executable(taisei_elf_name, taisei_src, taisei_main_src, version_deps,
-        dependencies : taisei_deps,
+        dependencies : taisei_deps_linkwhole + taisei_deps,
         c_args : taisei_c_args,
         c_pch : 'pch/taisei_pch.h',
         install : is_debug_build,
@@ -471,7 +471,7 @@ else
 
     libtaisei_dep = declare_dependency(
         compile_args : taisei_c_args,
-        dependencies : taisei_deps,
+        dependencies : taisei_deps_linkwhole + taisei_deps,
         include_directories : include_directories('.'),
         link_with : libtaisei,
     )

--- a/src/util/compat.h
+++ b/src/util/compat.h
@@ -16,6 +16,9 @@
 	#include <openlibm_complex.h>
 	#include <openlibm_math.h>
 
+	typedef double double_t;
+	typedef float float_t;
+
 	// Defense against bad headers that pull in system math.h
 	#ifndef	_MATH_H			/* glibc, musl */
 	#define	_MATH_H		1

--- a/src/util/compat.h
+++ b/src/util/compat.h
@@ -9,13 +9,21 @@
 #pragma once
 #include "taisei.h"
 
+#ifdef TAISEI_BUILDCONF_USE_OPENLIBM
+	#undef __BSD_VISIBLE
+	#define __BSD_VISIBLE 1
+
+	#include <openlibm.h>
+#else
+	#include <complex.h>       // IWYU pragma: export
+	#include <math.h>          // IWYU pragma: export
+#endif
+
 // Common standard library headers
-#include <complex.h>       // IWYU pragma: export
 #include <ctype.h>         // IWYU pragma: export
 #include <float.h>         // IWYU pragma: export
 #include <inttypes.h>      // IWYU pragma: export
 #include <limits.h>        // IWYU pragma: export
-#include <math.h>          // IWYU pragma: export
 #include <stdalign.h>      // IWYU pragma: export
 #include <stdbool.h>       // IWYU pragma: export
 #include <stddef.h>        // IWYU pragma: export

--- a/src/util/compat.h
+++ b/src/util/compat.h
@@ -13,7 +13,33 @@
 	#undef __BSD_VISIBLE
 	#define __BSD_VISIBLE 1
 
-	#include <openlibm.h>
+	#include <openlibm_complex.h>
+	#include <openlibm_math.h>
+
+	// Defense against bad headers that pull in system math.h
+	#ifndef	_MATH_H			/* glibc, musl */
+	#define	_MATH_H		1
+	#endif
+
+	#ifndef	_MATH_H_		/* mingw, BSDs */
+	#define	_MATH_H_	1
+	#endif
+
+	#ifndef	__MATH_H__		/* macOS */
+	#define	__MATH_H__	1
+	#endif
+
+	#ifndef	__MATH_H		/* some obscure embedded crap  */
+	#define	__MATH_H	1
+	#endif
+
+	#ifndef _INC_MATH		/* msvc/ucrt apparently, not that we support that crap */
+	#define _INC_MATH	1
+	#endif
+
+	#ifndef	MATH_H			/* unknown/just in case */
+	#define	MATH_H		1
+	#endif
 #else
 	#include <complex.h>       // IWYU pragma: export
 	#include <math.h>          // IWYU pragma: export

--- a/src/util/glm.h
+++ b/src/util/glm.h
@@ -15,8 +15,12 @@
 
 // IWYU pragma: always_keep
 
+
 DIAGNOSTIC(push)
 DIAGNOSTIC(ignored "-Wdeprecated-declarations")
+#ifndef	_MATH_H
+#define	_MATH_H	1
+#endif
 #include <cglm/cglm.h>  // IWYU pragma: export
 DIAGNOSTIC(pop)
 

--- a/src/util/glm.h
+++ b/src/util/glm.h
@@ -18,9 +18,6 @@
 
 DIAGNOSTIC(push)
 DIAGNOSTIC(ignored "-Wdeprecated-declarations")
-#ifndef	_MATH_H
-#define	_MATH_H	1
-#endif
 #include <cglm/cglm.h>  // IWYU pragma: export
 DIAGNOSTIC(pop)
 

--- a/src/vfs/platform_paths/cache_apple.m
+++ b/src/vfs/platform_paths/cache_apple.m
@@ -6,20 +6,12 @@
  * Copyright (c) 2012-2019, Andrei Alexeyev <akari@taisei-project.org>.
 */
 
-// HACK: work around name clashes with macOS SDK
-#define Rect __apple_Rect
-#define thread_create __apple_thread_create
-#define ThreadID __apple_ThreadID
-
-#include <Foundation/Foundation.h>
-
-#undef Rect
-#undef thread_create
-#undef ThreadID
-
 #include "platform_paths.h"
 #include "util.h"
 #include "../syspath_public.h"
+
+#import <Foundation/NSArray.h>
+#import <Foundation/NSPathUtilities.h>
 
 const char *vfs_platformpath_cache(void) {
 	static char *cached;

--- a/subprojects/openlibm
+++ b/subprojects/openlibm
@@ -1,0 +1,1 @@
+../external/openlibm


### PR DESCRIPTION
* Replace the host math library with a vendored copy of `openlibm`. Ensures we have the same implementation of math routines on all platforms.
* Make floating point math codegen more predictable by nuking FMA contractions (`-ffp-contract=off`). 
* ~~On platforms where fp math can be influenced via global state (e.g. special registers), try to make DAMN SURE the environment is sane. This is a very **just in case some rogue driver fucks with us** thing.~~

I've managed to achieve bit-identical replays across Linux and Windows builds with this setup, though both were compiled by clang. I'll test gcc later. The third point is probably overkill, but the first two are definitely required.